### PR TITLE
update ghpackages repo name

### DIFF
--- a/.github/workflows/deploy_ghpackages_docker.yml
+++ b/.github/workflows/deploy_ghpackages_docker.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           submodules: recursive
       - name: Build the Docker image
-        run: docker build . -t docker.pkg.github.com/planetarium/ninechronicles.standalone/ninechronicles-headless:git-${{ github.sha }} -t docker.pkg.github.com/planetarium/ninechronicles.standalone/ninechronicles-headless:latest --build-arg COMMIT=git-${{ github.sha }}
+        run: docker build . -t docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:git-${{ github.sha }} -t docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:latest --build-arg COMMIT=git-${{ github.sha }}
       - name: login
         run: docker login docker.pkg.github.com -u '${{ secrets.GH_USERNAME }}' -p '${{ secrets.GH_ACCESS_TOKEN }}'
       - name: push git version
-        run: docker push docker.pkg.github.com/planetarium/ninechronicles.standalone/ninechronicles-headless:git-${{ github.sha }}
+        run: docker push docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:git-${{ github.sha }}
       - name: push latest version
-        run: docker push docker.pkg.github.com/planetarium/ninechronicles.standalone/ninechronicles-headless:latest
+        run: docker push docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:latest


### PR DESCRIPTION
This PR updates the repository name in github packages workflow from "standalone" to "headless"