### PR TITLE
feat(gql): add avatar state query

### DIFF
--- a/NineChronicles.Headless.Tests/GraphQLTestUtils.cs
+++ b/NineChronicles.Headless.Tests/GraphQLTestUtils.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Types;
+
+namespace NineChronicles.Headless.Tests
+{
+    public static class GraphQLTestUtils
+    {
+        public static Task<ExecutionResult> ExecuteQueryAsync<TObjectGraphType>(
+            string query,
+            IDictionary<string, object> userContext = null,
+            object source = null)
+            where TObjectGraphType : IObjectGraphType, new()
+        {
+            var documentExecutor = new DocumentExecuter();
+            return documentExecutor.ExecuteAsync(new ExecutionOptions
+            {
+                Query = query,
+                Schema = new Schema
+                {
+                    Query = new TObjectGraphType(),
+                },
+                UserContext = userContext,
+                Root = source,
+            });
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CollectionMapTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CollectionMapTypeTest.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nekoyume.Model;
+using NineChronicles.Headless.GraphTypes.States.Models;
+using Xunit;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
+
+namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
+{
+    public class CollectionMapTypeTest
+    {
+        [Theory]
+        [MemberData(nameof(QueryPairs))]
+        public async Task Query(int[][] pairs)
+        {
+            var collectionMap = new CollectionMap();
+            foreach (int[] pair in pairs)
+            {
+                collectionMap.Add(
+                    pair[0],
+                    pair[1]);
+            }
+            var result = await ExecuteQueryAsync<CollectionMapType>(
+                "{ count pairs }",
+                source: collectionMap);
+            var resultData = (Dictionary<string, object>)result.Data;
+            Assert.Equal(pairs.Length, resultData["count"]);
+            Assert.Equal(pairs, resultData["pairs"]);
+        }
+
+        public static IEnumerable<object[]> QueryPairs => new[]
+        {
+            new[]
+            {
+               new int[][] {}, 
+            },
+            new[]
+            {
+                new[]
+                {
+                    new[] { 1, 2, },
+                    new[] { 3, 4, },
+                },
+            },
+        };
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -9,6 +9,7 @@ using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Nekoyume.Action;
 using Nekoyume.Model.State;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>; 
 
 namespace NineChronicles.Headless.GraphTypes
 {
@@ -16,6 +17,7 @@ namespace NineChronicles.Headless.GraphTypes
     {
         public StandaloneQuery(StandaloneContext standaloneContext)
         {
+            Field<NonNullGraphType<StateQuery<NCAction>>>(name: "stateQuery", resolve: _ => standaloneContext.BlockChain);
             Field<ByteStringType>(
                 name: "state",
                 arguments: new QueryArguments(

--- a/NineChronicles.Headless/GraphTypes/StateQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StateQuery.cs
@@ -1,0 +1,30 @@
+using Bencodex.Types;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet;
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Nekoyume.Model.State;
+using NineChronicles.Headless.GraphTypes.States;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public class StateQuery<T> : ObjectGraphType<BlockChain<T>>
+        where T : IAction, new()
+    {
+        public StateQuery()
+        {
+            Field<AvatarStateType>(
+                name: "avatar",
+                arguments: new QueryArguments(new QueryArgument<AddressType>
+                {
+                    Name = "address",
+                }),
+                resolve: context =>
+                {
+                    var address = context.GetArgument<Address>("address");
+                    return new AvatarState((Dictionary)context.Source.GetState(address));
+                });
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
@@ -1,0 +1,93 @@
+using GraphQL.Types;
+using Nekoyume.Model.State;
+using NineChronicles.Headless.GraphTypes.States.Models;
+using NineChronicles.Headless.GraphTypes.States.Models.World;
+using NineChronicles.Headless.GraphTypes.States.Models.Item;
+using NineChronicles.Headless.GraphTypes.States.Models.Mail;
+using NineChronicles.Headless.GraphTypes.States.Models.Quest;
+
+namespace NineChronicles.Headless.GraphTypes.States
+{
+    public class AvatarStateType : ObjectGraphType<AvatarState>
+    {
+        public AvatarStateType()
+        {
+            Field<NonNullGraphType<AddressType>>(
+                nameof(AvatarState.address),
+                resolve: context => context.Source.address);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.blockIndex),
+                resolve: context => context.Source.blockIndex);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.characterId),
+                resolve: context => context.Source.characterId);
+            Field<NonNullGraphType<LongGraphType>>(
+                nameof(AvatarState.dailyRewardReceivedIndex),
+                resolve: context => context.Source.dailyRewardReceivedIndex);
+            Field<NonNullGraphType<AddressType>>(
+                nameof(AvatarState.agentAddress),
+                resolve: context => context.Source.agentAddress);
+            Field<NonNullGraphType<AddressType>>(
+                nameof(AvatarState.RankingMapAddress),
+                resolve: context => context.Source.RankingMapAddress);
+            Field<NonNullGraphType<LongGraphType>>(
+                nameof(AvatarState.updatedAt),
+                resolve: context => context.Source.updatedAt);
+
+            Field<NonNullGraphType<StringGraphType>>(
+                nameof(AvatarState.name),
+                resolve: context => context.Source.name);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.exp),
+                resolve: context => context.Source.exp);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.level),
+                resolve: context => context.Source.level);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.actionPoint),
+                resolve: context => context.Source.actionPoint);
+
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.ear),
+                resolve: context => context.Source.ear);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.hair),
+                resolve: context => context.Source.hair);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.lens),
+                resolve: context => context.Source.lens);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(AvatarState.tail),
+                resolve: context => context.Source.tail);
+
+            Field<NonNullGraphType<InventoryType>>(
+                nameof(AvatarState.inventory),
+                resolve: context => context.Source.inventory);
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<AddressType>>>>(
+                nameof(AvatarState.combinationSlotAddresses),
+                resolve: context => context.Source.combinationSlotAddresses);
+            Field<NonNullGraphType<CollectionMapType>>(
+                nameof(AvatarState.itemMap),
+                resolve: context => context.Source.itemMap);
+            Field<NonNullGraphType<CollectionMapType>>(
+                nameof(AvatarState.eventMap),
+                resolve: context => context.Source.eventMap);
+            Field<NonNullGraphType<CollectionMapType>>(
+                nameof(AvatarState.monsterMap),
+                resolve: context => context.Source.monsterMap);
+            Field<NonNullGraphType<CollectionMapType>>(
+                nameof(AvatarState.stageMap),
+                resolve: context => context.Source.stageMap);
+
+            Field<NonNullGraphType<QuestListType>>(
+                nameof(AvatarState.questList),
+                resolve: context => context.Source.questList);
+            Field<NonNullGraphType<MailBoxType>>(
+                nameof(AvatarState.mailBox),
+                resolve: context => context.Source.mailBox);
+            Field<NonNullGraphType<WorldInformationType>>(
+                nameof(AvatarState.worldInformation),
+                resolve: context => context.Source.worldInformation);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/CollectionMapType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/CollectionMapType.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using GraphQL.Types;
+using Nekoyume.Model;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models
+{
+    public class CollectionMapType : ObjectGraphType<CollectionMap>
+    {
+        public CollectionMapType()
+        {
+            Field<NonNullGraphType<IntGraphType>>(nameof(CollectionMap.Count));
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<ListGraphType<IntGraphType>>>>>(
+                "pairs",
+                resolve: context => context.Source.Keys.Select(k => new[] { k, context.Source[k], }));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/ConsumableType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/ConsumableType.cs
@@ -1,0 +1,15 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+using NineChronicles.Headless.GraphTypes.States.Models.Item.Enum;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public class ConsumableType : ItemBaseType<Consumable>
+    {
+        public ConsumableType()
+        {
+            Field<NonNullGraphType<GuidGraphType>>(nameof(Consumable.ItemId));
+            Field<NonNullGraphType<StatTypeEnumType>>(nameof(Consumable.MainStat));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/CostumeType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/CostumeType.cs
@@ -1,0 +1,14 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public class CostumeType : ItemBaseType<Costume>
+    {
+        public CostumeType()
+        {
+            Field<NonNullGraphType<GuidGraphType>>(nameof(Costume.ItemId));
+            Field<NonNullGraphType<BooleanGraphType>>(nameof(Costume.Equipped));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/DecimalStatType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/DecimalStatType.cs
@@ -1,0 +1,15 @@
+using GraphQL.Types;
+using Nekoyume.Model.Stat;
+using NineChronicles.Headless.GraphTypes.States.Models.Item.Enum;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public class DecimalStatType : ObjectGraphType<DecimalStat>
+    {
+        public DecimalStatType()
+        {
+            Field<NonNullGraphType<StatTypeEnumType>>(nameof(DecimalStat.Type));
+            Field<NonNullGraphType<DecimalGraphType>>(nameof(DecimalStat.Value));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/Enum/ElementalTypeEnumType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/Enum/ElementalTypeEnumType.cs
@@ -1,0 +1,9 @@
+using GraphQL.Types;
+using Nekoyume.Model.Elemental;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item.Enum
+{
+    public class ElementalTypeEnumType : EnumerationGraphType<ElementalType>
+    {
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/Enum/ItemSubTypeEnumType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/Enum/ItemSubTypeEnumType.cs
@@ -1,0 +1,9 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item.Enum
+{
+    public class ItemSubTypeEnumType : EnumerationGraphType<ItemSubType>
+    {
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/Enum/ItemTypeEnumType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/Enum/ItemTypeEnumType.cs
@@ -1,0 +1,9 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item.Enum
+{
+    public class ItemTypeEnumType : EnumerationGraphType<ItemType>
+    {
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/Enum/StatTypeEnumType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/Enum/StatTypeEnumType.cs
@@ -1,0 +1,9 @@
+using GraphQL.Types;
+using Nekoyume.Model.Stat;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item.Enum
+{
+    public class StatTypeEnumType : EnumerationGraphType<StatType>
+    {
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/EquipmentType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/EquipmentType.cs
@@ -1,0 +1,15 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public class EquipmentType : ItemBaseType<Equipment>
+    {
+        public EquipmentType()
+        {
+            Field<NonNullGraphType<IntGraphType>>(nameof(Equipment.SetId));
+            Field<NonNullGraphType<DecimalStatType>>(nameof(Equipment.Stat));
+            Field<NonNullGraphType<BooleanGraphType>>(nameof(Equipment.Equipped));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/InventoryType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/InventoryType.cs
@@ -1,0 +1,16 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public class InventoryType : ObjectGraphType<Inventory>
+    {
+        public InventoryType()
+        {
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<ConsumableType>>>>(nameof(Inventory.Consumables));
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<MaterialType>>>>(nameof(Inventory.Materials));
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<EquipmentType>>>>(nameof(Inventory.Equipments));
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<CostumeType>>>>(nameof(Inventory.Costumes));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/ItemBaseType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/ItemBaseType.cs
@@ -1,0 +1,20 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+using NineChronicles.Headless.GraphTypes.States.Models.Item.Enum;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public abstract class ItemBaseType<T> : ObjectGraphType<T>
+        where T : ItemBase
+    {
+        protected ItemBaseType()
+        {
+            Field<NonNullGraphType<IntGraphType>>(nameof(ItemBase.Grade));
+            Field<NonNullGraphType<IntGraphType>>(nameof(ItemBase.Id));
+            
+            Field<NonNullGraphType<ItemTypeEnumType>>(nameof(ItemBase.ItemType), resolve: context => context.Source.ItemType);
+            Field<NonNullGraphType<ItemSubTypeEnumType>>(nameof(ItemBase.ItemSubType));
+            Field<NonNullGraphType<ElementalTypeEnumType>>(nameof(ItemBase.ElementalType));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/MaterialType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/MaterialType.cs
@@ -1,0 +1,15 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public class MaterialType : ItemBaseType<Material>
+    {
+        public MaterialType()
+        {
+            Field<NonNullGraphType<ByteStringType>>(
+                nameof(Material.ItemId),
+                resolve: context => context.Source.ItemId.ToByteArray());
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Mail/MailBoxType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Mail/MailBoxType.cs
@@ -1,0 +1,14 @@
+using GraphQL.Types;
+using Nekoyume.Model.Mail;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Mail
+{
+    public class MailBoxType : ObjectGraphType<MailBox>
+    {
+        public MailBoxType()
+        {
+            Field<NonNullGraphType<IntGraphType>>(nameof(MailBox.Count));
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<MailType>>>>("mails", resolve: context => context.Source);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Mail/MailType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Mail/MailType.cs
@@ -1,0 +1,20 @@
+using GraphQL.Types;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Mail
+{
+    public class MailType : ObjectGraphType<Nekoyume.Model.Mail.Mail>
+    {
+        public MailType()
+        {
+            Field<NonNullGraphType<GuidGraphType>>(
+                nameof(Nekoyume.Model.Mail.Mail.id),
+                resolve: context => context.Source.id);
+            Field<NonNullGraphType<LongGraphType>>(
+                nameof(Nekoyume.Model.Mail.Mail.requiredBlockIndex),
+                resolve: context => context.Source.requiredBlockIndex);
+            Field<NonNullGraphType<LongGraphType>>(
+                nameof(Nekoyume.Model.Mail.Mail.blockIndex),
+                resolve: context => context.Source.blockIndex);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Quest/QuestListType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Quest/QuestListType.cs
@@ -1,0 +1,15 @@
+using GraphQL.Types;
+using Nekoyume.Model.Quest;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Quest
+{
+    public class QuestListType : ObjectGraphType<QuestList>
+    {
+        public QuestListType()
+        {
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>>(
+                nameof(QuestList.completedQuestIds),
+                resolve: context => context.Source.completedQuestIds);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Quest/QuestRewardType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Quest/QuestRewardType.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using GraphQL.Types;
+using Nekoyume.Model.Quest;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Quest
+{
+    public class QuestRewardType : ObjectGraphType<QuestReward>
+    {
+        public QuestRewardType()
+        {
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>>>>(
+                nameof(QuestReward.ItemMap),
+                resolve: context => context.Source.ItemMap.Select(pair => new[] { pair.Key, pair.Value }));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Quest/QuestType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Quest/QuestType.cs
@@ -1,0 +1,16 @@
+using GraphQL.Types;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Quest
+{
+    public class QuestType : ObjectGraphType<Nekoyume.Model.Quest.Quest>
+    {
+        public QuestType()
+        {
+            Field<NonNullGraphType<IntGraphType>>(nameof(Nekoyume.Model.Quest.Quest.Id));
+            Field<NonNullGraphType<IntGraphType>>(nameof(Nekoyume.Model.Quest.Quest.Goal));
+            Field<NonNullGraphType<QuestRewardType>>(nameof(Nekoyume.Model.Quest.Quest.Reward));
+            Field<NonNullGraphType<BooleanGraphType>>(nameof(Nekoyume.Model.Quest.Quest.Complete));
+            Field<NonNullGraphType<BooleanGraphType>>(nameof(Nekoyume.Model.Quest.Quest.IsPaidInAction));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/World/WorldInformationType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/World/WorldInformationType.cs
@@ -1,0 +1,45 @@
+using GraphQL;
+using GraphQL.Types;
+using Nekoyume.Model;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.World
+{
+    public class WorldInformationType : ObjectGraphType<WorldInformation>
+    {
+        public WorldInformationType()
+        {
+            Field<NonNullGraphType<BooleanGraphType>>(
+                nameof(WorldInformation.IsStageCleared),
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
+                    {
+                        Name = "stageId",
+                    }),
+                resolve: context => context.Source.IsStageCleared(context.GetArgument<int>("stageId")));
+            Field<NonNullGraphType<BooleanGraphType>>(
+                nameof(WorldInformation.IsWorldUnlocked),
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
+                    {
+                        Name = "worldId",
+                    }),
+                resolve: context => context.Source.IsStageCleared(context.GetArgument<int>("worldId")));
+            Field<NonNullGraphType<WorldType>>(
+                "world",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
+                    {
+                        Name = "worldId",
+                    }),
+                resolve: context =>
+                {
+                    int worldId = context.GetArgument<int>("worldId");
+                    return context.Source.TryGetWorld(
+                        context.GetArgument<int>("worldId"),
+                        out WorldInformation.World world)
+                        ? world
+                        : throw new ExecutionError($"Failed to fetch world {worldId}.");
+                });
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/World/WorldType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/World/WorldType.cs
@@ -1,0 +1,21 @@
+using GraphQL.Types;
+using Nekoyume.Model;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.World
+{
+    public class WorldType : ObjectGraphType<WorldInformation.World>
+    {
+        public WorldType()
+        {
+            Field<NonNullGraphType<IntGraphType>>(nameof(WorldInformation.World.Id), resolve: context => context.Source.Id);
+            Field<NonNullGraphType<StringGraphType>>(nameof(WorldInformation.World.Name), resolve: context => context.Source.Name);
+            Field<NonNullGraphType<BooleanGraphType>>(nameof(WorldInformation.World.IsUnlocked), resolve: context => context.Source.IsUnlocked);
+            Field<NonNullGraphType<BooleanGraphType>>(nameof(WorldInformation.World.IsStageCleared), resolve: context => context.Source.IsStageCleared);
+            Field<NonNullGraphType<LongGraphType>>(nameof(WorldInformation.World.UnlockedBlockIndex), resolve: context => context.Source.UnlockedBlockIndex);
+            Field<NonNullGraphType<LongGraphType>>(nameof(WorldInformation.World.StageClearedBlockIndex), resolve: context => context.Source.StageClearedBlockIndex);
+            Field<NonNullGraphType<IntGraphType>>(nameof(WorldInformation.World.StageBegin), resolve: context => context.Source.StageBegin);
+            Field<NonNullGraphType<IntGraphType>>(nameof(WorldInformation.World.StageEnd), resolve: context => context.Source.StageEnd);
+            Field<NonNullGraphType<IntGraphType>>(nameof(WorldInformation.World.StageClearedId), resolve: context => context.Source.StageClearedId);
+        }
+    }
+}


### PR DESCRIPTION
## Overview

It provides [`Lib9c.Model.State.AvatarState`][lib9c-avatar-state] as GraphQL API.

## Comment about a test

I added a test for only `CollectionMapType` because I thought other types are covered from tests of graphql-dotnet/graphql-dotnet. For instance, `StatTypeEnumType` is actually the alias of `EnumerationGraphType<StatType>` and if I wrote its test code, it will just check that `new StatTypeEnumType().Serialize(StatType.*)` evaluate as the capital of the enum. I thought there is no duty to test them because they should be tested in `GraphQL.Tests` and guaranteed. If it seems that I am thinking in an incorrect way or you feel like to want discussion for this, please leave a comment.

[lib9c-avatar-state]: https://github.com/planetarium/lib9c/blob/main/Lib9c/Model/State/AvatarState.cs