### PR TITLE
feat(gql): add ranking state query

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StateQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StateQuery.cs
@@ -14,6 +14,7 @@ namespace NineChronicles.Headless.GraphTypes
     {
         public StateQuery()
         {
+            Name = "StateQuery";
             Field<AvatarStateType>(
                 name: "avatar",
                 arguments: new QueryArguments(new QueryArgument<AddressType>

--- a/NineChronicles.Headless/GraphTypes/StateQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StateQuery.cs
@@ -25,6 +25,18 @@ namespace NineChronicles.Headless.GraphTypes
                     var address = context.GetArgument<Address>("address");
                     return new AvatarState((Dictionary)context.Source.GetState(address));
                 });
+            Field<RankingMapStateType>(
+                name: "rankingMap",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
+                    {
+                        Name = "index",
+                    }),
+                resolve: context =>
+                {
+                    var index = context.GetArgument<int>("index");
+                    return new RankingMapState((Dictionary)context.Source.GetState(RankingState.Derive(index)));
+                });
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/States/RankingInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/RankingInfoType.cs
@@ -1,0 +1,36 @@
+using GraphQL.Types;
+using Nekoyume.Model.State;
+
+namespace NineChronicles.Headless.GraphTypes.States
+{
+    public class RankingInfoType : ObjectGraphType<RankingInfo>
+    {
+        public RankingInfoType()
+        {
+            Field<NonNullGraphType<LongGraphType>>(
+                nameof(RankingInfo.Exp),
+                resolve: context => context.Source.Exp);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(RankingInfo.Level),
+                resolve: context => context.Source.Level);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(RankingInfo.ArmorId),
+                resolve: context => context.Source.ArmorId);
+            Field<NonNullGraphType<LongGraphType>>(
+                nameof(RankingInfo.UpdatedAt),
+                resolve: context => context.Source.UpdatedAt);
+            Field<NonNullGraphType<LongGraphType>>(
+                nameof(RankingInfo.StageClearedBlockIndex),
+                resolve: context => context.Source.StageClearedBlockIndex);
+            Field<NonNullGraphType<AddressType>>(
+                nameof(RankingInfo.AgentAddress),
+                resolve: context => context.Source.AgentAddress);
+            Field<NonNullGraphType<AddressType>>(
+                nameof(RankingInfo.AvatarAddress),
+                resolve: context => context.Source.AvatarAddress);
+            Field<NonNullGraphType<StringGraphType>>(
+                nameof(RankingInfo.AvatarName),
+                resolve: context => context.Source.AvatarName);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/RankingMapStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/RankingMapStateType.cs
@@ -1,0 +1,22 @@
+using GraphQL.Types;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+
+namespace NineChronicles.Headless.GraphTypes.States
+{
+    public class RankingMapStateType : ObjectGraphType<RankingMapState>
+    {
+        public RankingMapStateType()
+        {
+            Field<NonNullGraphType<AddressType>>(
+                nameof(RankingMapState.address),
+                resolve: context => context.Source.address);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(RankingMapState.Capacity),
+                resolve: context => RankingMapState.Capacity);
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<RankingInfoType>>>>(
+                "rankingInfos",
+                resolve: context => context.Source.GetRankingInfos(null));
+        }
+    }
+}


### PR DESCRIPTION
It should be mereed after #216 merged.

It provides GraphQL API for `RankingState`, `RankingMapState`.

![image](https://user-images.githubusercontent.com/26626194/102330531-00d90400-3fcd-11eb-86bc-32362e8746b8.png)
