### PR TITLE
feat: provide authorized miner mode

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -127,7 +127,7 @@ namespace NineChronicles.Headless.Executable
             [Option(Description =
                 "Flag to use as authorized miner. " +
                 "If true, it will mine only blocks that authorized miners should mine.")]
-            bool isAuthorizedMiner = false
+            bool authorizedMiner = false
         )
         {
 #if SENTRY || ! DEBUG
@@ -280,7 +280,7 @@ namespace NineChronicles.Headless.Executable
                         isDev: isDev,
                         blockInterval: blockInterval,
                         reorgInterval: reorgInterval,
-                        isAuthorizedMiner: isAuthorizedMiner);
+                        authorizedMiner: authorizedMiner);
                 standaloneContext.NineChroniclesNodeService = nineChroniclesNodeService;
 
                 if (libplanetNode)

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -123,7 +123,11 @@ namespace NineChronicles.Headless.Executable
             [Option(Description = "The secret key for AWS CloudWatch logging.")]
             string awsSecretKey = null,
             [Option(Description = "The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2).")]
-            string awsRegion = null
+            string awsRegion = null,
+            [Option(Description =
+                "Flag to use as authorized miner. " +
+                "If true, it will mine only blocks that authorized miners should mine.")]
+            bool isAuthorizedMiner = false
         )
         {
 #if SENTRY || ! DEBUG
@@ -275,7 +279,8 @@ namespace NineChronicles.Headless.Executable
                         strictRendering: strictRendering,
                         isDev: isDev,
                         blockInterval: blockInterval,
-                        reorgInterval: reorgInterval);
+                        reorgInterval: reorgInterval,
+                        isAuthorizedMiner: isAuthorizedMiner);
                 standaloneContext.NineChroniclesNodeService = nineChroniclesNodeService;
 
                 if (libplanetNode)

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -124,9 +124,7 @@ namespace NineChronicles.Headless.Executable
             string awsSecretKey = null,
             [Option(Description = "The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2).")]
             string awsRegion = null,
-            [Option(Description =
-                "Flag to use as authorized miner. " +
-                "If true, it will mine only blocks that authorized miners should mine.")]
+            [Option(Description = "Run as an authorized miner, which mines only blocks that should be authorized.")]
             bool authorizedMiner = false
         )
         {

--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -66,7 +66,7 @@ namespace NineChronicles.Headless
             Progress<PreloadState> preloadProgress = null,
             bool ignoreBootstrapFailure = false,
             bool strictRendering = false,
-            bool isAuthorizedMiner = false,
+            bool authorizedMiner = false,
             bool isDev = false,
             int blockInterval = 10000,
             int reorgInterval = 0
@@ -147,7 +147,7 @@ namespace NineChronicles.Headless
                                              && nextBlockIndex > 0
                                              && nextBlockIndex <= bp.AuthorizedMinersState.ValidUntil
                                              && nextBlockIndex % bp.AuthorizedMinersState.Interval == 0;
-                        if (swarm.Running && (!isAuthorizedMiner || isTargetBlock))
+                        if (swarm.Running && (!authorizedMiner || isTargetBlock))
                         {
                             Log.Debug("Start mining.");
                             await miner.MineBlockAsync(properties.MaximumTransactions, cancellationToken);

--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -66,6 +66,7 @@ namespace NineChronicles.Headless
             Progress<PreloadState> preloadProgress = null,
             bool ignoreBootstrapFailure = false,
             bool strictRendering = false,
+            bool isAuthorizedMiner = false,
             bool isDev = false,
             int blockInterval = 10000,
             int reorgInterval = 0
@@ -140,7 +141,13 @@ namespace NineChronicles.Headless
                 {
                     try
                     {
-                        if (swarm.Running)
+                        long nextBlockIndex = chain.Tip.Index;
+                        bool isTargetBlock = blockPolicy is BlockPolicy bp
+                                             // Copied from https://git.io/JLxNd
+                                             && nextBlockIndex > 0
+                                             && nextBlockIndex <= bp.AuthorizedMinersState.ValidUntil
+                                             && nextBlockIndex % bp.AuthorizedMinersState.Interval == 0;
+                        if (swarm.Running && (!isAuthorizedMiner || isTargetBlock))
                         {
                             Log.Debug("Start mining.");
                             await miner.MineBlockAsync(properties.MaximumTransactions, cancellationToken);

--- a/NineChronicles.Headless/StandaloneServices.cs
+++ b/NineChronicles.Headless/StandaloneServices.cs
@@ -12,6 +12,7 @@ namespace NineChronicles.Headless
             StandaloneContext standaloneContext = null,
             bool ignoreBootstrapFailure = true,
             bool strictRendering = false,
+            bool isAuthorizedMiner = false,
             bool isDev = false,
             int blockInterval = 10000,
             int reorgInterval = 0
@@ -58,7 +59,8 @@ namespace NineChronicles.Headless
                 strictRendering: strictRendering,
                 isDev: isDev,
                 blockInterval: blockInterval,
-                reorgInterval: reorgInterval);
+                reorgInterval: reorgInterval,
+                isAuthorizedMiner: isAuthorizedMiner);
             service.ConfigureStandaloneContext(standaloneContext);
 
             return service;

--- a/NineChronicles.Headless/StandaloneServices.cs
+++ b/NineChronicles.Headless/StandaloneServices.cs
@@ -12,7 +12,7 @@ namespace NineChronicles.Headless
             StandaloneContext standaloneContext = null,
             bool ignoreBootstrapFailure = true,
             bool strictRendering = false,
-            bool isAuthorizedMiner = false,
+            bool authorizedMiner = false,
             bool isDev = false,
             int blockInterval = 10000,
             int reorgInterval = 0
@@ -60,7 +60,7 @@ namespace NineChronicles.Headless
                 isDev: isDev,
                 blockInterval: blockInterval,
                 reorgInterval: reorgInterval,
-                isAuthorizedMiner: isAuthorizedMiner);
+                authorizedMiner: authorizedMiner);
             service.ConfigureStandaloneContext(standaloneContext);
 
             return service;

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@
 ```
 $ dotnet run --project ./NineChronicles.Headless.Executable/ -- --help
 
-Usage: NineChronicles.Headless.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--st
-ore-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [
---graphql-host <String>] [--graphql-port <Nullable`1>] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-m
-inimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--help] [--version]
+Usage: NineChronicles.Headless.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-pro
+tocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval
+<Int32>] [--dev.reorg-interval <Int32>] [--log-minimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--is-authorized-miner] [--help] [--version]
 
-Run standalone application with options.
+Run headless application with options.
 
 Options:
   --no-miner
@@ -39,11 +38,12 @@ Options:
   --dev                                                    Flag to turn on the dev mode.  false by default.
   --dev.block-interval <Int32>                             The time interval between blocks. It's unit is milliseconds. Works only when dev mode is on.  10000 (ms) by default. (Default: 10000)
   --dev.reorg-interval <Int32>                             The size of reorg interval. Works only when dev mode is on.  0 by default. (Default: 0)
-  --log-minimum-level <String>                             The log minimum level during standalone execution. (Default: debug)
+  --log-minimum-level <String>                             The log minimum level during headless execution.  debug by default. (Default: debug)
   --aws-cognito-identity <String>                          The Cognito identity for AWS CloudWatch logging. (Default: )
   --aws-access-key <String>                                The access key for AWS CloudWatch logging. (Default: )
   --aws-secret-key <String>                                The secret key for AWS CloudWatch logging. (Default: )
   --aws-region <String>                                    The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2). (Default: )
+  --is-authorized-miner                                    Flag to use as authorized miner. If true, it will mine only blocks that authorized miners should mine.
   -h, --help                                               Show help message
   --version                                                Show version
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ $ dotnet run --project ./NineChronicles.Headless.Executable/ -- --help
 
 Usage: NineChronicles.Headless.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-pro
 tocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval
-<Int32>] [--dev.reorg-interval <Int32>] [--log-minimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--is-authorized-miner] [--help] [--version]
+<Int32>] [--dev.reorg-interval <Int32>] [--log-minimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--authorized-miner] [--help] [--version]
 
 Run headless application with options.
 
@@ -43,7 +43,7 @@ Options:
   --aws-access-key <String>                                The access key for AWS CloudWatch logging. (Default: )
   --aws-secret-key <String>                                The secret key for AWS CloudWatch logging. (Default: )
   --aws-region <String>                                    The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2). (Default: )
-  --is-authorized-miner                                    Flag to use as authorized miner. If true, it will mine only blocks that authorized miners should mine.
+  --authorized-miner                                       Run as an authorized miner, which mines only blocks that should be authorized.
   -h, --help                                               Show help message
   --version                                                Show version
 ```


### PR DESCRIPTION
It provides `--is-authorized-miner` flag for *authorized miner* mode. The mode makes miner mine only blocks that authorized miner should mine.