### PR TITLE
fix: correct index to mine by authorized miner

### DIFF
--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -141,7 +141,7 @@ namespace NineChronicles.Headless
                 {
                     try
                     {
-                        long nextBlockIndex = chain.Tip.Index;
+                        long nextBlockIndex = chain.Tip.Index + 1;
                         bool isTargetBlock = blockPolicy is BlockPolicy bp
                                              // Copied from https://git.io/JLxNd
                                              && nextBlockIndex > 0


### PR DESCRIPTION
It fixes a bug that it didn't detect the index of the block to mine correctly. It was appeared since #234.