### PR TITLE
fix(graphql): correct query authorization conditionally

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -152,7 +152,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             public TestServiceProvider(StandaloneContext standaloneContext, IConfiguration configuration)
             {
-                Query = new StandaloneQuery(standaloneContext);
+                Query = new StandaloneQuery(standaloneContext, configuration);
                 Mutation = new StandaloneMutation(standaloneContext, configuration);
                 Subscription = new StandaloneSubscription(standaloneContext);
                 StandaloneContext = standaloneContext;

--- a/NineChronicles.Headless/GraphTypes/GraphTypeAuthorizationExtensions.cs
+++ b/NineChronicles.Headless/GraphTypes/GraphTypeAuthorizationExtensions.cs
@@ -1,0 +1,11 @@
+using GraphQL.Server.Authorization.AspNetCore;
+using GraphQL.Types;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public static class GraphTypeAuthorizationExtensions
+    {
+        public static FieldType AuthorizeWithLocalPolicyIf(this FieldType fieldType, bool condition) =>
+            condition ? fieldType.AuthorizeWith(GraphQLService.LocalPolicyKey) : fieldType;
+    }
+}


### PR DESCRIPTION
It fixes a bug where some fields of `StandaloneQuery` doesn't work conditionally.