### PR TITLE
fix(logging): cover situation that guid is broken

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -352,7 +352,7 @@ namespace NineChronicles.Headless.Executable
             string path = AWSSinkGuidPath();
             if (!File.Exists(path))
             {
-                Console.Error.WriteLine($"AWSSink id doesn't exist.");
+                Console.Error.WriteLine($"AWSSink id doesn't exist. (path: {path})");
                 return null;
             }
 

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -162,8 +162,12 @@ namespace NineChronicles.Headless.Executable
                     ? (AWSCredentials)new CognitoAWSCredentials(awsCognitoIdentity, regionEndpoint)
                     : (AWSCredentials)new BasicAWSCredentials(awsAccessKey, awsSecretKey);
 
-                var guid = LoadAWSSinkGuid() ?? Guid.NewGuid();
-                StoreAWSSinkGuid(guid);
+                var guid = LoadAWSSinkGuid();
+                if (guid is null)
+                {
+                    guid = Guid.NewGuid();
+                    StoreAWSSinkGuid(guid.Value);   
+                }
 
                 var awsSink = new AWSSink(
                     credentials,

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -350,7 +350,20 @@ namespace NineChronicles.Headless.Executable
         private Guid? LoadAWSSinkGuid()
         {
             string path = AWSSinkGuidPath();
-            return File.Exists(path) ? Guid.Parse(File.ReadAllText(AWSSinkGuidPath())) : (Guid?)null;
+            if (!File.Exists(path))
+            {
+                Console.Error.WriteLine($"AWSSink id doesn't exist.");
+                return null;
+            }
+
+            string guidString = File.ReadAllText(AWSSinkGuidPath());
+            if (Guid.TryParse(guidString, out Guid guid))
+            {
+                return guid;
+            }
+
+            Console.Error.WriteLine($"AWSSink id seems broken. (id: {guidString}");
+            return null;
         }
 
         private void StoreAWSSinkGuid(Guid guid)


### PR DESCRIPTION
Currently, it loads the `Guid` used in `AWSSink` and store it every run. Maybe it may make the `Guid` if `NineChronicles.Headless` killed after short time. Also it hasn't covered the situtation. I believe This pull request resolves them.