### PR TITLE
Fix NullReferenceException with empty authorized miner state

### DIFF
--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -264,6 +264,12 @@ namespace NineChronicles.Headless
             {
                 bp.AuthorizedMinersState = new AuthorizedMinersState(ams);
             }
+
+            if (authorizedMiner && blockPolicy is BlockPolicy {AuthorizedMinersState: null})
+            {
+                throw new Exception(
+                    "--authorized-miner was set but there are no AuthorizedMinerState.");
+            }
         }
 
         internal static IBlockPolicy<PolymorphicAction<ActionBase>> GetBlockPolicy(int minimumDifficulty, int maximumTransactions) =>


### PR DESCRIPTION
Prevent `NullReferenceException` with empty authorized miner state in block policy.