### PR TITLE
Hide development versions

### DIFF
--- a/.github/workflows/deploy_ghpackages_docker.yml
+++ b/.github/workflows/deploy_ghpackages_docker.yml
@@ -14,10 +14,8 @@ jobs:
         with:
           submodules: recursive
       - name: Build the Docker image
-        run: docker build . -t docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:git-${{ github.sha }} -t docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:latest --build-arg COMMIT=git-${{ github.sha }}
+        run: docker build . -t docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:git-${{ github.sha }} --build-arg COMMIT=git-${{ github.sha }}
       - name: login
         run: docker login docker.pkg.github.com -u '${{ secrets.GH_USERNAME }}' -p '${{ secrets.GH_ACCESS_TOKEN }}'
       - name: push git version
         run: docker push docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:git-${{ github.sha }}
-      - name: push latest version
-        run: docker push docker.pkg.github.com/planetarium/ninechronicles.headless/ninechronicles-headless:latest

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -17,8 +17,7 @@ jobs:
       - name: login
         run: docker login --username '${{ secrets.DOCKER_USERNAME }}' --password '${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}'
       - name: build
-        run: docker build . -t planetariumhq/ninechronicles-headless:git-${{ github.sha }} --build-arg COMMIT=git-${{ github.sha }} -t planetariumhq/ninechronicles-headless:latest --build-arg COMMIT=git-${{ github.sha }}
+        run: docker build . -t planetariumhq/ninechronicles-headless:git-${{ github.sha }} --build-arg COMMIT=git-${{ github.sha }} --build-arg COMMIT=git-${{ github.sha }}
       - name: push git-version
         run: docker push planetariumhq/ninechronicles-headless:git-${{ github.sha }}
-      - name: push latest
-        run: docker push planetariumhq/ninechronicles-headless:latest
+


### PR DESCRIPTION
This PR removes automated push to `planetariumhq/ninechronicles-headless:latest` to hide pre-release versions.