### PR TITLE
Introduce --log-action-renders option

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -43,6 +43,8 @@ namespace Libplanet.Headless.Hosting
 
         public bool Render { get; set; }
 
+        public bool LogActionRenders { get; set; }
+
         public int Workers { get; set; } = 5;
 
         public int Confirmations { get; set; } = 0;

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -114,6 +114,8 @@ namespace NineChronicles.Headless.Executable
                 Description =
                     "The size of reorg interval. Works only when dev mode is on.  0 by default.")]
             int reorgInterval = 0,
+            [Option(Description = "Log action renders besides block renders.  --rpc-server implies this.")]
+            bool logActionRenders = false,
             [Option(Description = "The log minimum level during headless execution.  debug by default.")]
             string logMinimumLevel = "debug",
             [Option(Description = "The Cognito identity for AWS CloudWatch logging.")]
@@ -268,6 +270,12 @@ namespace NineChronicles.Headless.Executable
                     rpcProperties = NineChroniclesNodeServiceProperties
                         .GenerateRpcNodeServiceProperties(rpcListenHost, rpcListenPort);
                     properties.Render = true;
+                    properties.LogActionRenders = true;
+                }
+
+                if (logActionRenders)
+                {
+                    properties.LogActionRenders = true;
                 }
 
                 var nineChroniclesProperties = new NineChroniclesNodeServiceProperties()

--- a/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
+++ b/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
@@ -38,6 +38,7 @@ namespace NineChronicles.Headless.Tests.Common
                 MinimumDifficulty = MinimumDifficulty,
                 NoMiner = true,
                 Render = false,
+                LogActionRenders = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
                 MaximumTransactions = MaximumTransactions,

--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -87,7 +87,8 @@ namespace NineChronicles.Headless
                 Log.Error("Secp256K1CryptoBackend initialize failed. Use default backend. {e}", e);
             }
 
-            var blockPolicySource = new BlockPolicySource(Log.Logger, LogEventLevel.Debug);
+            LogEventLevel logLevel = LogEventLevel.Debug;
+            var blockPolicySource = new BlockPolicySource(Log.Logger, logLevel);
             // BlockPolicy shared through Lib9c.
             IBlockPolicy<PolymorphicAction<ActionBase>> blockPolicy = null;
             // Policies for dev mode.
@@ -122,6 +123,21 @@ namespace NineChronicles.Headless
             {
                 renderers.Add(blockPolicySource.BlockRenderer);
                 renderers.Add(blockPolicySource.LoggedActionRenderer);
+            }
+            else if (Properties.LogActionRenders)
+            {
+                renderers.Add(blockPolicySource.BlockRenderer);
+                // The following "nullRenderer" does nothing.  It's just for filling
+                // the LoggedActionRenderer<T>() constructor's parameter:
+                IActionRenderer<NineChroniclesActionType> nullRenderer =
+                    new AnonymousActionRenderer<NineChroniclesActionType>();
+                renderers.Add(
+                    new LoggedActionRenderer<NineChroniclesActionType>(
+                        nullRenderer,
+                        Log.Logger,
+                        logLevel
+                    )
+                );
             }
             else
             {

--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@
 
 ```
 $ dotnet run --project ./NineChronicles.Headless.Executable/ -- --help
-
-Usage: NineChronicles.Headless.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-pro
-tocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval
-<Int32>] [--dev.reorg-interval <Int32>] [--log-minimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--authorized-miner] [--help] [--version]
+Usage: NineChronicles.Headless.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--graphql-secret-token-path <String>] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-action-renders] [--log-minimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--authorized-miner] [--tx-life-time <Int32>] [--help] [--version]
 
 Run headless application with options.
 
@@ -30,6 +27,7 @@ Options:
   --graphql-server
   --graphql-host <String>                                   (Default: 0.0.0.0)
   --graphql-port <Nullable`1>                               (Default: )
+  --graphql-secret-token-path <String>                     The path to write GraphQL secret token. If you want to protect this headless application, you should use this option and take it into headers. (Default: )
   --libplanet-node
   --workers <Int32>                                        Number of workers to use in Swarm (Default: 5)
   --confirmations <Int32>                                  The number of required confirmations to recognize a block.  0 by default. (Default: 0)
@@ -38,13 +36,14 @@ Options:
   --dev                                                    Flag to turn on the dev mode.  false by default.
   --dev.block-interval <Int32>                             The time interval between blocks. It's unit is milliseconds. Works only when dev mode is on.  10000 (ms) by default. (Default: 10000)
   --dev.reorg-interval <Int32>                             The size of reorg interval. Works only when dev mode is on.  0 by default. (Default: 0)
+  --log-action-renders                                     Log action renders besides block renders.  --rpc-server implies this.
   --log-minimum-level <String>                             The log minimum level during headless execution.  debug by default. (Default: debug)
   --aws-cognito-identity <String>                          The Cognito identity for AWS CloudWatch logging. (Default: )
   --aws-access-key <String>                                The access key for AWS CloudWatch logging. (Default: )
   --aws-secret-key <String>                                The secret key for AWS CloudWatch logging. (Default: )
   --aws-region <String>                                    The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2). (Default: )
   --authorized-miner                                       Run as an authorized miner, which mines only blocks that should be authorized.
-  --tx-life-time                                           The lifetime of each transaction, which uses minute as its unit.  60 (m) by default. (Default: 60)
+  --tx-life-time <Int32>                                   The lifetime of each transaction, which uses minute as its unit.  60 (m) by default. (Default: 60)
   -h, --help                                               Show help message
   --version                                                Show version
 ```


### PR DESCRIPTION
The introduced `--log-action-renders` option enforces action renderings to be logged whether `--rpc-server` is turned on or off.  However, this can cause the significant performance impact (see also: <https://github.com/planetarium/libplanet/pull/970> & <https://github.com/planetarium/libplanet/pull/883>), so this is turned off by default.