### PR TITLE
feat: send cloudwatch logs periodically

### DIFF
--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.5.1.2" />
     <PackageReference Include="Cocona.Lite" Version="1.3.*" />
     <PackageReference Include="Sentry.Serilog" Version="2.1.*" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.*" />
   </ItemGroup>
   
   <ItemGroup>

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -16,6 +16,7 @@ using NineChronicles.Headless.Properties;
 using Org.BouncyCastle.Security;
 using Sentry;
 using Serilog;
+using Serilog.Sinks.PeriodicBatching;
 using NineChroniclesActionType = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Headless.Executable
@@ -178,7 +179,12 @@ namespace NineChronicles.Headless.Executable
                     regionEndpoint,
                     "9c-standalone-logs",
                     guid.ToString());
-                loggerConf.WriteTo.Sink(awsSink);
+                var periodicBatchingSink = new PeriodicBatchingSink(awsSink, new PeriodicBatchingSinkOptions
+                {
+                    Period = TimeSpan.FromSeconds(2),
+                    BatchSizeLimit = 1000,
+                });
+                loggerConf.WriteTo.Sink(periodicBatchingSink);
             }
 
             Log.Logger = loggerConf.CreateLogger();


### PR DESCRIPTION
Currently, there is a problem with memory leaks because of `AWSSink._queue`. There was a time which couldn't handle `LogEvent`s well so the capacity of the `Queue<T>` used by _queue, became more and more, up to 4GB in my case.

This pull request tries to resolve the problem by handling the events at the correct time well with `PeriodicBatchSink`. You can see the sink's more information in [serilog/serilog-sinks-periodicbatching](https://github.com/serilog/serilog-sinks-periodicbatching). I opened this because the test in local was better than now when monitoring with memory profiler. I believe it will make the memory leak problem better but I'm not sure that it can fix all memory leaks well 🤔 .

If you want to test this in your local, make sure you must run with `--aws-*` options.