### PR TITLE
add address arg for stagedTxIds

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -202,6 +202,31 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Null(result.Errors);
             Assert.Equal(expectedResult, result.Data);
+
+            var apvTx = StandaloneContextFx.BlockChain.MakeTransaction(
+                apvPrivateKey,
+                new PolymorphicAction<ActionBase>[] { }
+            );
+
+            var apvAddress = apvPrivateKey.ToAddress();
+            var query = $@"query {{
+                nodeStatus {{
+                    stagedTxIds(address: ""{apvAddress}"")
+                }}
+            }}";
+            result = await ExecuteQueryAsync(query);
+            expectedResult = new Dictionary<string, object>()
+            {
+                ["nodeStatus"] = new Dictionary<string, object>()
+                {
+                    ["stagedTxIds"] = new List<object>
+                    {
+                        apvTx.Id.ToString(),
+                    }
+                },
+            };
+            Assert.Null(result.Errors);
+            Assert.Equal(expectedResult, result.Data);
         }
 
         [Theory]

--- a/NineChronicles.Headless/GraphTypes/NodeStatus.cs
+++ b/NineChronicles.Headless/GraphTypes/NodeStatus.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
 using GraphQL;
@@ -8,6 +9,7 @@ using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Store;
+using Libplanet.Tx;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Headless.GraphTypes
@@ -81,17 +83,10 @@ namespace NineChronicles.Headless.GraphTypes
                     else
                     {
                         Address address = context.GetArgument<Address>("address");
-                        var stagedTransactionIds = context.Source.BlockChain.GetStagedTransactionIds();
+                        IImmutableSet<TxId> stagedTransactionIds = context.Source.BlockChain.GetStagedTransactionIds();
 
-                        foreach (var txId in stagedTransactionIds)
-                        {
-                            var tx = context.Source.BlockChain.GetTransaction(txId);
-                            if (tx.Signer != address)
-                            {
-                                stagedTransactionIds = stagedTransactionIds.Remove(txId);
-                            }
-                        }
-                        return stagedTransactionIds;
+                        return stagedTransactionIds.Where(txId =>
+                        context.Source.BlockChain.GetTransaction(txId).Signer.Equals(address));
                     }
                 }
             );


### PR DESCRIPTION
This PR enriches the original `stagedTxIds` query to take the address as an argument and return staged txids that are signed by that specific address. The original query is preserved so that you can still get all  staged txids.

**Original**
![Screen Shot 2021-02-08 at 10 49 40 PM](https://user-images.githubusercontent.com/42176649/107228926-91c5dc00-6a60-11eb-8921-59c4e6f64aae.png)

**Added feature**
![Screen Shot 2021-02-08 at 10 49 23 PM](https://user-images.githubusercontent.com/42176649/107228970-9e4a3480-6a60-11eb-8687-48b11037270a.png)