### PR TITLE
feat: introduce `--no-cors` option

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -84,6 +84,8 @@ namespace NineChronicles.Headless.Executable
                                                                "If you want to protect this headless application, " +
                                                                "you should use this option and take it into headers.")]
             string graphQLSecretTokenPath = null,
+            [Option(Description = "Run without CORS policy.")]
+            bool noCors = false,
             [Option("libplanet-node")]
             bool libplanetNode = false,
             [Option("workers", Description = "Number of workers to use in Swarm")]
@@ -231,6 +233,7 @@ namespace NineChronicles.Headless.Executable
                         GraphQLListenHost = graphQLHost,
                         GraphQLListenPort = graphQLPort,
                         SecretToken = secretToken,
+                        NoCors = noCors,
                     };
 
                     var graphQLService = new GraphQLService(graphQLNodeServiceProperties);

--- a/NineChronicles.Headless.Tests/GraphQLStartupTest.cs
+++ b/NineChronicles.Headless.Tests/GraphQLStartupTest.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests
+{
+    public class GraphQLStartupTest
+    {
+        private readonly GraphQLService.GraphQLStartup _startup;
+        private readonly IConfiguration _configuration;
+
+        public GraphQLStartupTest()
+        {
+            _configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            _startup = new GraphQLService.GraphQLStartup(_configuration);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Configure(bool noCors)
+        {
+            if (noCors)
+            {
+                _configuration[GraphQLService.NoCorsKey] = string.Empty;
+            }
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            _startup.ConfigureServices(services);
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            var options = serviceProvider.GetService<IOptions<CorsOptions>>();
+            Assert.Equal(noCors, !(options.Value.GetPolicy(GraphQLService.NoCorsPolicyName) is null));
+        }
+    }
+}

--- a/NineChronicles.Headless/Properties/GraphQLNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/GraphQLNodeServiceProperties.cs
@@ -9,5 +9,7 @@ namespace NineChronicles.Headless.Properties
         public int? GraphQLListenPort { get; set; }
         
         public string SecretToken { get; set; }
+
+        public bool NoCors { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 ```
 $ dotnet run --project ./NineChronicles.Headless.Executable/ -- --help
-Usage: NineChronicles.Headless.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--graphql-secret-token-path <String>] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-action-renders] [--log-minimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--authorized-miner] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--help] [--version]
+Usage: NineChronicles.Headless.Executable [--no-miner] [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <Nullable`1>] [--minimum-difficulty <Int32>] [--private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-pro
+tocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--graphql-secret-token-path <String>] [--no-cors] [--libplanet-node] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>]
+[--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-action-renders] [--log-minimum-level <String>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--authorized-miner] [--tx-life-time <Int32>] [--message-timeout <Int32>
+] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--help] [--version]
 
 Run headless application with options.
 
@@ -28,6 +31,7 @@ Options:
   --graphql-host <String>                                   (Default: 0.0.0.0)
   --graphql-port <Nullable`1>                               (Default: )
   --graphql-secret-token-path <String>                     The path to write GraphQL secret token. If you want to protect this headless application, you should use this option and take it into headers. (Default: )
+  --no-cors                                                Run without CORS policy.
   --libplanet-node
   --workers <Int32>                                        Number of workers to use in Swarm (Default: 5)
   --confirmations <Int32>                                  The number of required confirmations to recognize a block.  0 by default. (Default: 0)


### PR DESCRIPTION
It introduces `--no-cors` option for users to want to run with *Access-Control-Allow-Origin* header (i.e., without being restricted with CORS policy).