### PR TITLE
build: use static code analysis tool

### DIFF
--- a/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
+++ b/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
@@ -6,10 +6,20 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Libplanet.Headless.Tests</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />

--- a/Libplanet.Headless/Libplanet.Headless.csproj
+++ b/Libplanet.Headless/Libplanet.Headless.csproj
@@ -3,10 +3,20 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/NineChronicles.Headless.Common.ruleset
+++ b/NineChronicles.Headless.Common.ruleset
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet
+    Name="Rules for all projects in NineChronicles.Headless"
+    Description="Code analysis rules for all projects in NineChroncles.Headless."
+    ToolsVersion="10.0">
+
+    <Rules
+        AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis"
+        RuleNamespace="Microsoft.Rules.Managed">
+
+        <Rule Id="SA0001" Action="None"/>
+        <Rule Id="SA1000" Action="None"/>
+        <Rule Id="SA1003" Action="None"/>
+        <Rule Id="SA1005" Action="None"/>
+        <Rule Id="SA1008" Action="None"/>
+        <Rule Id="SA1009" Action="None"/>
+        <Rule Id="SA1011" Action="None"/>
+        <Rule Id="SA1012" Action="None"/>
+        <Rule Id="SA1013" Action="None"/>
+        <Rule Id="SA1024" Action="None"/>
+        <Rule Id="SA1025" Action="None"/>
+        <Rule Id="SA1026" Action="None"/>
+        <Rule Id="SA1028" Action="None"/>
+        <Rule Id="SA1101" Action="None"/>
+        <Rule Id="SA1111" Action="None"/>
+        <Rule Id="SA1116" Action="None"/>
+        <Rule Id="SA1117" Action="None"/>
+        <Rule Id="SA1118" Action="None"/>
+        <Rule Id="SA1122" Action="None"/>
+        <Rule Id="SA1127" Action="None"/>
+        <Rule Id="SA1128" Action="None"/>
+        <Rule Id="SA1129" Action="None"/>
+        <Rule Id="SA1131" Action="None"/>
+        <Rule Id="SA1200" Action="None"/>
+        <Rule Id="SA1201" Action="None"/>
+        <Rule Id="SA1202" Action="None"/>
+        <Rule Id="SA1208" Action="None"/>
+        <Rule Id="SA1209" Action="None"/>
+        <Rule Id="SA1210" Action="None"/>
+        <Rule Id="SA1211" Action="None"/>
+        <Rule Id="SA1214" Action="None"/>
+        <Rule Id="SA1300" Action="None"/>
+        <Rule Id="SA1306" Action="None"/>
+        <Rule Id="SA1309" Action="None"/>
+        <Rule Id="SA1312" Action="None"/>
+        <Rule Id="SA1400" Action="None"/>
+        <Rule Id="SA1401" Action="None"/>
+        <Rule Id="SA1413" Action="None"/>
+        <Rule Id="SA1500" Action="None"/>
+        <Rule Id="SA1505" Action="None"/>
+        <Rule Id="SA1507" Action="None"/>
+        <Rule Id="SA1508" Action="None"/>
+        <Rule Id="SA1513" Action="None"/>
+        <Rule Id="SA1515" Action="None"/>
+        <Rule Id="SA1516" Action="None"/>
+        <Rule Id="SA1518" Action="None"/>
+        <Rule Id="SA1633" Action="None"/>
+        <Rule Id="SA1649" Action="None"/>
+    </Rules>
+
+    <Rules AnalyzerId="SonarAnalyzer" RuleNamespace="SonarAnalyzer">
+        <Rule Id="S101" Action="None"/>
+        <Rule Id="S112" Action="None"/>
+        <Rule Id="S125" Action="None"/>
+        <Rule Id="S927" Action="None"/>
+        <Rule Id="S1104" Action="None"/>
+        <Rule Id="S1134" Action="None"/>
+        <Rule Id="S1135" Action="None"/>
+        <Rule Id="S1186" Action="None"/>
+        <Rule Id="S1481" Action="None"/>
+        <Rule Id="S1854" Action="None"/>
+        <Rule Id="S2259" Action="None"/>
+        <Rule Id="S2344" Action="None"/>
+        <Rule Id="S2699" Action="None"/>
+        <Rule Id="S2743" Action="None"/>
+        <Rule Id="S2933" Action="None"/>
+        <Rule Id="S2971" Action="None"/>
+        <Rule Id="S3881" Action="None"/>
+        <Rule Id="S3925" Action="None"/>
+    </Rules>
+</RuleSet>

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   
   <ItemGroup>
@@ -12,6 +14,14 @@
     <PackageReference Include="Cocona.Lite" Version="1.3.*" />
     <PackageReference Include="Sentry.Serilog" Version="2.1.*" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.*" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>

--- a/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
+++ b/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
@@ -5,10 +5,20 @@
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\Lib9c\Lib9c.csproj" />
@@ -20,6 +22,14 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0-dev-00839" />
     <PackageReference Include="GraphQL" Version="3.2.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
This pull request makes the below projects to use static code analysis to achieve #302.

- `Libplanet.Headless`
- `Libplanet.Headless.Tests`
- `NIneChronicles.Headless`
- `NIneChronicles.Headless.Tests`
- `NIneChronicles.Headless.Executable`

But this pull request doesn't update codes by the all rules and they have been ignored. It expects they should be removed from `NineChronicles.Headless.Common.ruleset` and resolved step by step.