### PR TITLE
feat(cli): implement `validation'  subcommand

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
@@ -1,39 +1,44 @@
 using NineChronicles.Headless.Executable.Commands;
+using NineChronicles.Headless.Executable.Tests.IO;
 using Xunit;
 
 namespace NineChronicles.Headless.Executable.Tests.Commands
 {
     public class ValidationCommandTest
     {
+        private readonly StringIOConsole _console;
         private readonly ValidationCommand _command;
 
         public ValidationCommandTest()
         {
-            _command = new ValidationCommand();
+            _console = new StringIOConsole();
+            _command = new ValidationCommand(_console);
         }
 
         [Theory]
-        [InlineData("", -1)]
-        [InlineData("invalid hexadecimal", -1)]
-        [InlineData("0000000000000000000000000000000000000000000000000000000000000000", -1)]
-        [InlineData("ab8d591ccdcce263c39eb1f353e44b64869f0afea2df643bf6839ebde650d244", 0)]
-        [InlineData("d6c3e0d525dac340a132ae05aaa9f3e278d61b70d2b71326570e64aee249e566", 0)]
-        [InlineData("761f68d68426549df5904395b5ca5bce64a3da759085d8565242db42a5a1b0b9", 0)]
-        public void PrivateKey(string privateKeyHex, int exitCode)
+        [InlineData("", -1, "The given private key, '', had an issue during parsing.\n")]
+        [InlineData("invalid hexadecimal", -1, "The given private key, 'invalid hexadecimal', had an issue during parsing.\n")]
+        [InlineData("000000000000000000000000000000000000000000000000000000000000000000", -1, "The given private key, '000000000000000000000000000000000000000000000000000000000000000000', had an issue during parsing.\n")]
+        [InlineData("ab8d591ccdcce263c39eb1f353e44b64869f0afea2df643bf6839ebde650d244", 0, "")]
+        [InlineData("d6c3e0d525dac340a132ae05aaa9f3e278d61b70d2b71326570e64aee249e566", 0, "")]
+        [InlineData("761f68d68426549df5904395b5ca5bce64a3da759085d8565242db42a5a1b0b9", 0, "")]
+        public void PrivateKey(string privateKeyHex, int exitCode, string errorOutput)
         {
             Assert.Equal(exitCode, _command.PrivateKey(privateKeyHex));
+            Assert.Equal(errorOutput, _console.Error.ToString());
         }
         
         [Theory]
-        [InlineData("", -1)]
-        [InlineData("invalid hexadecimal", -1)]
-        [InlineData("000000000000000000000000000000000000000000000000000000000000000000", -1)]
-        [InlineData("03b0868d9301b30c512d307ea67af4c8bef637ef099e39d32b808a43e6b41469c5", 0)]
-        [InlineData("03308c1618a75e85a5fb57f7e453a642c307dc6310e90a7418b1aec565d963534a", 0)]
-        [InlineData("028a6190bf643175b20e4a2d1d86fe6c4b8f7d5fe3d163632be4e59f83335824b8", 0)]
-        public void PublicKey(string publicKeyHex, int exitCode)
+        [InlineData("", -1, "The given public key, '', had an issue during parsing.\n")]
+        [InlineData("invalid hexadecimal", -1, "The given public key, 'invalid hexadecimal', had an issue during parsing.\n")]
+        [InlineData("000000000000000000000000000000000000000000000000000000000000000000", -1, "The given public key, '000000000000000000000000000000000000000000000000000000000000000000', had an issue during parsing.\n")]
+        [InlineData("03b0868d9301b30c512d307ea67af4c8bef637ef099e39d32b808a43e6b41469c5", 0, "")]
+        [InlineData("03308c1618a75e85a5fb57f7e453a642c307dc6310e90a7418b1aec565d963534a", 0, "")]
+        [InlineData("028a6190bf643175b20e4a2d1d86fe6c4b8f7d5fe3d163632be4e59f83335824b8", 0, "")]
+        public void PublicKey(string publicKeyHex, int exitCode, string errorOutput)
         {
             Assert.Equal(exitCode, _command.PublicKey(publicKeyHex));
+            Assert.Equal(errorOutput, _console.Error.ToString());
         }
     }
 }

--- a/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
@@ -1,0 +1,27 @@
+using NineChronicles.Headless.Executable.Commands;
+using Xunit;
+
+namespace NineChronicles.Headless.Executable.Tests.Commands
+{
+    public class ValidationCommandTest
+    {
+        private readonly ValidationCommand _command;
+
+        public ValidationCommandTest()
+        {
+            _command = new ValidationCommand();
+        }
+
+        [Theory]
+        [InlineData("", -1)]
+        [InlineData("invalid hexadecimal", -1)]
+        [InlineData("0000000000000000000000000000000000000000000000000000000000000000", -1)]
+        [InlineData("ab8d591ccdcce263c39eb1f353e44b64869f0afea2df643bf6839ebde650d244", 0)]
+        [InlineData("d6c3e0d525dac340a132ae05aaa9f3e278d61b70d2b71326570e64aee249e566", 0)]
+        [InlineData("761f68d68426549df5904395b5ca5bce64a3da759085d8565242db42a5a1b0b9", 0)]
+        public void PrivateKey(string privateKeyHex, int exitCode)
+        {
+            Assert.Equal(exitCode, _command.PrivateKey(privateKeyHex));
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
@@ -23,5 +23,17 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         {
             Assert.Equal(exitCode, _command.PrivateKey(privateKeyHex));
         }
+        
+        [Theory]
+        [InlineData("", -1)]
+        [InlineData("invalid hexadecimal", -1)]
+        [InlineData("000000000000000000000000000000000000000000000000000000000000000000", -1)]
+        [InlineData("03b0868d9301b30c512d307ea67af4c8bef637ef099e39d32b808a43e6b41469c5", 0)]
+        [InlineData("03308c1618a75e85a5fb57f7e453a642c307dc6310e90a7418b1aec565d963534a", 0)]
+        [InlineData("028a6190bf643175b20e4a2d1d86fe6c4b8f7d5fe3d163632be4e59f83335824b8", 0)]
+        public void PublicKey(string publicKeyHex, int exitCode)
+        {
+            Assert.Equal(exitCode, _command.PublicKey(publicKeyHex));
+        }
     }
 }

--- a/NineChronicles.Headless.Executable.Tests/IO/StringIOConsole.cs
+++ b/NineChronicles.Headless.Executable.Tests/IO/StringIOConsole.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using NineChronicles.Headless.Executable.IO;
+
+namespace NineChronicles.Headless.Executable.Tests.IO
+{
+    public sealed class StringIOConsole : IConsole
+    {
+        public StringIOConsole(StringReader @in, StringWriter @out, StringWriter error)
+        {
+            In = @in;
+            Out = @out;
+            Error = error;
+        }
+
+        public StringIOConsole(string input = "")
+            : this(new StringReader(input), new StringWriter(), new StringWriter())
+        {
+        }
+
+        public StringReader In { get; }
+
+        public StringWriter Out { get; }
+
+        public StringWriter Error { get; }
+
+        TextReader IConsole.In => In;
+
+        TextWriter IConsole.Out => Out;
+
+        TextWriter IConsole.Error => Error;
+    }
+}

--- a/NineChronicles.Headless.Executable.Tests/NineChronicles.Headless.Executable.Tests.csproj
+++ b/NineChronicles.Headless.Executable.Tests/NineChronicles.Headless.Executable.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>8</LangVersion>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference
+            Include="..\NineChronicles.Headless.Executable\NineChronicles.Headless.Executable.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.RocksDBStore", "L
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Stun", "Lib9c\.Libplanet\Libplanet.Stun\Libplanet.Stun.csproj", "{3B2875B4-B6C6-4929-B885-18A922110ED2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NineChronicles.Headless.Executable.Tests", "NineChronicles.Headless.Executable.Tests\NineChronicles.Headless.Executable.Tests.csproj", "{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,18 @@ Global
 		{3B2875B4-B6C6-4929-B885-18A922110ED2}.Release|x64.Build.0 = Release|Any CPU
 		{3B2875B4-B6C6-4929-B885-18A922110ED2}.Release|x86.ActiveCfg = Release|Any CPU
 		{3B2875B4-B6C6-4929-B885-18A922110ED2}.Release|x86.Build.0 = Release|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Debug|x64.Build.0 = Debug|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Debug|x86.Build.0 = Debug|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Release|x64.ActiveCfg = Release|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Release|x64.Build.0 = Release|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Release|x86.ActiveCfg = Release|Any CPU
+		{6E38A2CF-B93F-4CD5-9CAC-DE121998FF18}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NineChronicles.Headless.Executable/Commands/ValidationCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ValidationCommand.cs
@@ -1,11 +1,19 @@
 using Cocona;
 using Libplanet;
 using Libplanet.Crypto;
+using NineChronicles.Headless.Executable.IO;
 
 namespace NineChronicles.Headless.Executable.Commands
 {
     public class ValidationCommand : CoconaLiteConsoleAppBase
     {
+        private readonly IConsole _console;
+
+        public ValidationCommand(IConsole console)
+        {
+            _console = console;
+        }
+
         [Command(Description = "Validate private key")]
         public int PrivateKey(
             [Argument(
@@ -20,6 +28,7 @@ namespace NineChronicles.Headless.Executable.Commands
             }
             catch
             {
+                _console.Error.WriteLine($"The given private key, '{privateKeyHex}', had an issue during parsing.");
                 return -1;
             }
         }
@@ -38,6 +47,7 @@ namespace NineChronicles.Headless.Executable.Commands
             }
             catch
             {
+                _console.Error.WriteLine($"The given public key, '{publicKeyHex}', had an issue during parsing.");
                 return -1;
             }
         }

--- a/NineChronicles.Headless.Executable/Commands/ValidationCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ValidationCommand.cs
@@ -23,5 +23,23 @@ namespace NineChronicles.Headless.Executable.Commands
                 return -1;
             }
         }
+        
+        [Command(Description = "Validate public key")]
+        public int PublicKey(
+            [Argument(
+                Name = "PUBLIC-KEY",
+                Description = "A hexadecimal representation of public key to validate.")]
+            string publicKeyHex)
+        {
+            try
+            {
+                _ = new PublicKey(ByteUtil.ParseHex(publicKeyHex));
+                return 0;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
     }
 }

--- a/NineChronicles.Headless.Executable/Commands/ValidationCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ValidationCommand.cs
@@ -1,0 +1,27 @@
+using Cocona;
+using Libplanet;
+using Libplanet.Crypto;
+
+namespace NineChronicles.Headless.Executable.Commands
+{
+    public class ValidationCommand : CoconaLiteConsoleAppBase
+    {
+        [Command(Description = "Validate private key")]
+        public int PrivateKey(
+            [Argument(
+                Name = "PRIVATE-KEY",
+                Description = "A hexadecimal representation of private key to validate.")]
+            string privateKeyHex)
+        {
+            try
+            {
+                _ = new PrivateKey(ByteUtil.ParseHex(privateKeyHex));
+                return 0;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable/IO/IConsole.cs
+++ b/NineChronicles.Headless.Executable/IO/IConsole.cs
@@ -1,0 +1,11 @@
+using System.IO;
+
+namespace NineChronicles.Headless.Executable.IO
+{
+    public interface IConsole
+    {
+        TextReader In { get; }
+        TextWriter Out { get; }
+        TextWriter Error { get; }
+    }
+}

--- a/NineChronicles.Headless.Executable/IO/StandardConsole.cs
+++ b/NineChronicles.Headless.Executable/IO/StandardConsole.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+
+namespace NineChronicles.Headless.Executable.IO
+{
+    public class StandardConsole : IConsole
+    {
+        public StandardConsole()
+        {
+            In = Console.In;
+            Out = Console.Out;
+            Error = Console.Error;
+        }
+
+        public TextReader In { get; }
+
+        public TextWriter Out { get; }
+
+        public TextWriter Error { get; }
+    }
+}

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -47,7 +47,7 @@ namespace NineChronicles.Headless.Executable
 #endif
         }
 
-        [Command(Description = "Run headless application with options.")]
+        [PrimaryCommand]
         public async Task Run(
             bool noMiner = false,
             [Option("app-protocol-version", new[] { 'V' }, Description = "App protocol version token")]

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -13,6 +13,7 @@ using Libplanet;
 using Libplanet.KeyStore;
 using Microsoft.Extensions.Hosting;
 using NineChronicles.Headless.Executable.Commands;
+using NineChronicles.Headless.Executable.IO;
 using NineChronicles.Headless.Properties;
 using Org.BouncyCastle.Security;
 using Sentry;
@@ -35,7 +36,9 @@ namespace NineChronicles.Headless.Executable
 #if SENTRY || ! DEBUG
             using var _ = SentrySdk.Init(ConfigureSentryOptions);
 #endif
-            await CoconaLiteApp.RunAsync<Program>(args);
+            await CoconaLiteApp.Create()
+                .ConfigureServices(services => services.AddSingleton<IConsole, StandardConsole>())
+                .RunAsync<Program>(args);
         }
 
         static void ConfigureSentryOptions(SentryOptions o)

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -12,6 +12,7 @@ using Cocona;
 using Libplanet;
 using Libplanet.KeyStore;
 using Microsoft.Extensions.Hosting;
+using NineChronicles.Headless.Executable.Commands;
 using NineChronicles.Headless.Properties;
 using Org.BouncyCastle.Security;
 using Sentry;
@@ -21,6 +22,7 @@ using NineChroniclesActionType = Libplanet.Action.PolymorphicAction<Nekoyume.Act
 
 namespace NineChronicles.Headless.Executable
 {
+    [HasSubCommands(typeof(ValidationCommand), "validation")]
     public class Program : CoconaLiteConsoleAppBase
     {
         const string SentryDsn = "https://ceac97d4a7d34e7b95e4c445b9b5669e@o195672.ingest.sentry.io/5287621";


### PR DESCRIPTION
This pull request introduces new sub-command, `validation`, a command group of commands to validate _Libplanet_'s types (e.g. `PrivateKey`, `PublicKey`).

New commands:

- `NineChronicles.Headless.Executable validation private-key <PRIVATE-KEY>`
- `NineChronicles.Headless.Executable validation public-key <PUBLIC-KEY>`

These commands are introduced to replace GraphQL API `validationQuery`.