### PR TITLE
feat(graphql): use private key in session

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
@@ -13,6 +13,8 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         {
             _console = new StringIOConsole();
             _command = new ValidationCommand(_console);
+
+            _console.SetNewLine("\n");
         }
 
         [Theory]

--- a/NineChronicles.Headless.Executable.Tests/IO/StringIOConsole.cs
+++ b/NineChronicles.Headless.Executable.Tests/IO/StringIOConsole.cs
@@ -17,6 +17,12 @@ namespace NineChronicles.Headless.Executable.Tests.IO
         {
         }
 
+        public void SetNewLine(string newLine)
+        {
+            Out.NewLine = newLine;
+            Error.NewLine = newLine;
+        }
+
         public StringReader In { get; }
 
         public StringWriter Out { get; }

--- a/NineChronicles.Headless.Tests/Controllers/GraphQLControllerTest.cs
+++ b/NineChronicles.Headless.Tests/Controllers/GraphQLControllerTest.cs
@@ -13,6 +13,7 @@ using Libplanet.Store.Trie;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Nekoyume.Action;
 using NineChronicles.Headless.Controllers;
 using NineChronicles.Headless.Requests;
@@ -49,7 +50,11 @@ namespace NineChronicles.Headless.Tests.Controllers
             _configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
             _httpContextAccessor = new HttpContextAccessor();
             _httpContextAccessor.HttpContext = new DefaultHttpContext();
-            
+            _httpContextAccessor.HttpContext.Session = new InMemorySession(string.Empty, true);
+            var services = new ServiceCollection();
+            services.AddAuthentication();
+            _httpContextAccessor.HttpContext.RequestServices = services.BuildServiceProvider();
+
             _controller = new GraphQLController(_standaloneContext, _httpContextAccessor, _configuration);
         }
 

--- a/NineChronicles.Headless.Tests/GraphQLTestUtils.cs
+++ b/NineChronicles.Headless.Tests/GraphQLTestUtils.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
+using Libplanet.KeyStore;
 using Microsoft.Extensions.DependencyInjection;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
@@ -23,6 +25,8 @@ namespace NineChronicles.Headless.Tests
             {
                 services.AddSingleton(standaloneContext);
             }
+
+            services.AddSingleton(standaloneContext?.KeyStore ?? CreateRandomWeb3KeyStore());
 
             services.AddLibplanetExplorer<NCAction>();
 
@@ -53,6 +57,11 @@ namespace NineChronicles.Headless.Tests
                 UserContext = userContext,
                 Root = source,
             });
+        }
+
+        public static Web3KeyStore CreateRandomWeb3KeyStore()
+        {
+            return new Web3KeyStore(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
         }
     }
 }

--- a/NineChronicles.Headless.Tests/GraphQLTestUtils.cs
+++ b/NineChronicles.Headless.Tests/GraphQLTestUtils.cs
@@ -6,27 +6,54 @@ using GraphQL;
 using GraphQL.Types;
 using Libplanet.KeyStore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Headless.Tests
 {
     public static class GraphQLTestUtils
     {
+        public enum ExecutionMode
+        {
+            Query,
+            Mutation,
+            Subscription,
+        }
+
         public static Task<ExecutionResult> ExecuteQueryAsync<TObjectGraphType>(
             string query,
             IDictionary<string, object>? userContext = null,
             object? source = null,
-            StandaloneContext? standaloneContext = null)
+            StandaloneContext? standaloneContext = null,
+            ExecutionMode executionMode = ExecutionMode.Query)
             where TObjectGraphType : class, IObjectGraphType
         {
             var services = new ServiceCollection();
-            services.AddSingleton(typeof(TObjectGraphType));
+            return ExecuteQueryAsync<TObjectGraphType>(
+                services,
+                query,
+                userContext,
+                source,
+                standaloneContext,
+                executionMode);
+        }
+        
+        public static Task<ExecutionResult> ExecuteQueryAsync<TObjectGraphType>(
+            ServiceCollection services,
+            string query,
+            IDictionary<string, object>? userContext = null,
+            object? source = null,
+            StandaloneContext? standaloneContext = null,
+            ExecutionMode executionMode = ExecutionMode.Query)
+            where TObjectGraphType : class, IObjectGraphType
+        {
+            services.TryAddSingleton(typeof(TObjectGraphType));
             if (!(standaloneContext is null))
             {
-                services.AddSingleton(standaloneContext);
+                services.TryAddSingleton(standaloneContext);
             }
 
-            services.AddSingleton(standaloneContext?.KeyStore ?? CreateRandomWeb3KeyStore());
+            services.TryAddSingleton(standaloneContext?.KeyStore ?? CreateRandomWeb3KeyStore());
 
             services.AddLibplanetExplorer<NCAction>();
 
@@ -35,25 +62,39 @@ namespace NineChronicles.Headless.Tests
                 serviceProvider,
                 query,
                 userContext,
-                source);
+                source,
+                executionMode);
         }
         
         public static Task<ExecutionResult> ExecuteQueryAsync<TObjectGraphType>(
             IServiceProvider serviceProvider,
             string query,
             IDictionary<string, object>? userContext = null,
-            object? source = null)
+            object? source = null,
+            ExecutionMode executionMode = ExecutionMode.Query)
             where TObjectGraphType : IObjectGraphType
         {
             var graphType = (IObjectGraphType)serviceProvider.GetService(typeof(TObjectGraphType));
             var documentExecutor = new DocumentExecuter();
+            var schema = new Schema();
+
+            switch (executionMode)
+            {
+                case ExecutionMode.Query:
+                    schema.Query = graphType;
+                    break;
+                case ExecutionMode.Mutation:
+                    schema.Mutation = graphType;
+                    break;
+                case ExecutionMode.Subscription:
+                    schema.Subscription = graphType;
+                    break;
+            }
+
             return documentExecutor.ExecuteAsync(new ExecutionOptions
             {
                 Query = query,
-                Schema = new Schema
-                {
-                    Query = graphType,
-                },
+                Schema = schema,
                 UserContext = userContext,
                 Root = source,
             });

--- a/NineChronicles.Headless.Tests/GraphTypes/AuthenticationMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/AuthenticationMutationTest.cs
@@ -36,7 +36,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var authServiceMock = new Mock<IAuthenticationService>();
             authServiceMock
                 .Setup(_ => _.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(), It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
-                .Returns(Task.FromResult((object)null));
+                .Returns(Task.FromResult((object?)null));
             var serviceProviderMock = new Mock<IServiceProvider>();
             serviceProviderMock
                 .Setup(_ => _.GetService(typeof(IAuthenticationService)))

--- a/NineChronicles.Headless.Tests/GraphTypes/AuthenticationMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/AuthenticationMutationTest.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using GraphQL;
+using Libplanet;
+using Libplanet.Crypto;
+using Libplanet.KeyStore;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NineChronicles.Headless.GraphTypes;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests.GraphTypes
+{
+    public class AuthenticationMutationTest : IDisposable
+    {
+        private readonly Web3KeyStore _keyStore;
+        private readonly PrivateKey _privateKey;
+        private readonly string _passphrase;
+        private readonly ServiceCollection _services;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public AuthenticationMutationTest()
+        {
+            _keyStore = GraphQLTestUtils.CreateRandomWeb3KeyStore();
+            _httpContextAccessor = new HttpContextAccessor();
+            _httpContextAccessor.HttpContext = new DefaultHttpContext
+            {
+                Session = new InMemorySession(string.Empty, true),
+            };
+            _privateKey = new PrivateKey();
+            _passphrase = Guid.NewGuid().ToString();
+            _keyStore.Add(ProtectedPrivateKey.Protect(_privateKey, _passphrase));
+            _services = new ServiceCollection();
+            _services.AddSingleton<IKeyStore>(_keyStore);
+            _services.AddSingleton(_httpContextAccessor);
+        }
+
+        [Fact]
+        public async Task Login_Success()
+        {
+            var result = await ExecuteAsync(LoginQuery(_privateKey.ToAddress(), _passphrase));
+            Assert.Equal(true, result.Data.As<Dictionary<string, object>>()["login"]);
+            Assert.Null(result.Errors);
+        }
+
+        [Fact]
+        public async Task Login_ShouldFailWithNotExistedKey()
+        {
+            var result = await ExecuteAsync(LoginQuery(new PrivateKey().ToAddress(), _passphrase));
+            Assert.Null(result.Data);
+            Assert.NotNull(result.Errors);
+        }
+
+        [Fact]
+        public async Task Login_ShouldFailWithIncorrectPassphrase()
+        {
+            var result = await ExecuteAsync(LoginQuery(_privateKey.ToAddress(), Guid.NewGuid().ToString()));
+            Assert.Null(result.Data);
+            Assert.NotNull(result.Errors);
+        }
+
+        [Fact]
+        public async Task Logout()
+        {
+            var result = await ExecuteAsync(LogoutQuery());
+            Assert.Equal(false, result.Data.As<Dictionary<string, object>>()["logout"]);
+            Assert.NotNull(result.Errors);
+        }
+
+        private string LoginQuery(Address address, string passphrase) =>
+            @$"mutation {{ login(address: ""{address}"", passphrase: ""{passphrase}"") }}";
+
+        private string LogoutQuery() =>
+            "mutation { logout }";
+
+        private Task<ExecutionResult> ExecuteAsync(string query)
+        {
+            return GraphQLTestUtils.ExecuteQueryAsync<AuthenticationMutation>(_services, query, executionMode: GraphQLTestUtils.ExecutionMode.Mutation, source: new object());
+        }
+        
+
+        public void Dispose()
+        {
+            Directory.Delete(_keyStore.Path, true);
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -24,6 +24,7 @@ using Serilog;
 using Xunit.Abstractions;
 using RewardGold = NineChronicles.Headless.Tests.Common.Actions.RewardGold;
 using Libplanet.Store.Trie;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
@@ -35,11 +36,14 @@ namespace NineChronicles.Headless.Tests.GraphTypes
     {
         protected ITestOutputHelper _output;
 
+        protected readonly IHttpContextAccessor _httpContextAccessor;
+
         public GraphQLTestBase(ITestOutputHelper output)
         {
             Log.Logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.Console().CreateLogger();
 
             _output = output;
+            _httpContextAccessor = new HttpContextAccessor();
 
             var store = new DefaultStore(null);
             var stateStore = new TrieStateStore(
@@ -95,6 +99,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             var services = new ServiceCollection();
             services.AddSingleton(StandaloneContextFx);
+            services.AddSingleton(StandaloneContextFx.KeyStore ?? GraphQLTestUtils.CreateRandomWeb3KeyStore());
+            services.AddSingleton(_httpContextAccessor);
             services.AddSingleton<IConfiguration>(configuration);
             services.AddGraphTypes();
             services.AddLibplanetExplorer<NCAction>();

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Bencodex.Types;
+using Microsoft.AspNetCore.Http;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,11 +31,19 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
         private readonly TableSheets? _tableSheets = null;
 
+        private readonly PrivateKey _privateKey;
+
         public StandaloneMutationTest(ITestOutputHelper output) : base(output)
         {
             var fixturePath = Path.Combine("..", "..", "..", "..", "Lib9c", ".Lib9c.Tests", "Data", "TableCSV");
             _sheets = TableSheetsImporter.ImportSheets(fixturePath);
             _tableSheets = new TableSheets(_sheets);
+            _privateKey = new PrivateKey();
+            _httpContextAccessor.HttpContext = new DefaultHttpContext
+            {
+                Session = new InMemorySession(string.Empty, true)
+            };
+            _httpContextAccessor.HttpContext.Session.SetPrivateKey(_privateKey);
         }
 
         [Fact]
@@ -132,7 +141,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var state = (Bencodex.Types.Dictionary)blockChain.GetState(
                 ActivatedAccountsState.Address);
             var activatedAccountsState = new ActivatedAccountsState(state);
-            Address userAddress = service.MinerPrivateKey!.ToAddress();
+            Address userAddress = _privateKey.ToAddress();
             Assert.True(activatedAccountsState.Accounts.Contains(userAddress));
         }
 

--- a/NineChronicles.Headless.Tests/ISessionExtensionsTest.cs
+++ b/NineChronicles.Headless.Tests/ISessionExtensionsTest.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Libplanet.Crypto;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests
+{
+    public class ISessionExtensionsTest
+    {
+        [Fact]
+        public void GetPrivateKey()
+        {
+            var privateKey = new PrivateKey();
+            var session = new InMemorySession(string.Empty, true, new Dictionary<string, byte[]>
+            {
+                [ISessionExtensions.SessionPrivateKeyKey] = privateKey.ByteArray, 
+            });
+
+            Assert.Equal(privateKey, session.GetPrivateKey());
+        }
+
+        [Fact]
+        public void SetPrivateKey()
+        {
+            var session = new InMemorySession(string.Empty, true);
+            var privateKey = new PrivateKey();
+
+            Assert.False(session.TryGetValue(ISessionExtensions.SessionPrivateKeyKey, out byte[] _));
+            session.SetPrivateKey(privateKey);
+            Assert.True(session.TryGetValue(ISessionExtensions.SessionPrivateKeyKey, out byte[] bytes));
+            Assert.Equal(privateKey.ByteArray, bytes);
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/ISessionExtensionsTest.cs
+++ b/NineChronicles.Headless.Tests/ISessionExtensionsTest.cs
@@ -26,7 +26,7 @@ namespace NineChronicles.Headless.Tests
 
             Assert.False(session.TryGetValue(ISessionExtensions.SessionPrivateKeyKey, out byte[] _));
             session.SetPrivateKey(privateKey);
-            Assert.True(session.TryGetValue(ISessionExtensions.SessionPrivateKeyKey, out byte[] bytes));
+            Assert.True(session.TryGetValue(ISessionExtensions.SessionPrivateKeyKey, out byte[]? bytes));
             Assert.Equal(privateKey.ByteArray, bytes);
         }
     }

--- a/NineChronicles.Headless.Tests/InMemorySession.cs
+++ b/NineChronicles.Headless.Tests/InMemorySession.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace NineChronicles.Headless.Tests
+{
+    public class InMemorySession : ISession
+    {
+        private readonly Dictionary<string, byte[]> _value;
+
+        public InMemorySession(string id, bool isAvailable, Dictionary<string, byte[]> value = null)
+        {
+            Id = id;
+            IsAvailable = isAvailable;
+            _value = value ?? new Dictionary<string, byte[]>();
+        }
+
+        /// <inheritdoc/>
+        public void Clear()
+        {
+            _value.Clear();
+        }
+
+        /// <summary>
+        /// It doesn't do anything because it stores data in memory.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to broadcast the cancellation.</param>
+        /// <returns>An awaitable task.</returns>
+        public Task CommitAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// It doesn't do anything because it stores data in memory.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to broadcast the cancellation.</param>
+        /// <returns>An awaitable task.</returns>
+        public Task LoadAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public void Remove(string key)
+        {
+            _value.Remove(key);
+        }
+
+        /// <inheritdoc/>
+        public void Set(string key, byte[] value)
+        {
+            _value[key] = value;
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetValue(string key, out byte[] value)
+        {
+            return _value.TryGetValue(key, out value);
+        }
+
+        /// <inheritdoc/>
+        public string Id { get; }
+
+        /// <inheritdoc/>
+        public bool IsAvailable { get; }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> Keys => Value.Keys;
+
+        /// <summary>
+        /// The storage to store data of the session in memory.
+        /// </summary>
+        public IReadOnlyDictionary<string, byte[]> Value => _value;
+    }
+}

--- a/NineChronicles.Headless.Tests/InMemorySession.cs
+++ b/NineChronicles.Headless.Tests/InMemorySession.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace NineChronicles.Headless.Tests
     {
         private readonly Dictionary<string, byte[]> _value;
 
-        public InMemorySession(string id, bool isAvailable, Dictionary<string, byte[]> value = null)
+        public InMemorySession(string id, bool isAvailable, Dictionary<string, byte[]>? value = null)
         {
             Id = id;
             IsAvailable = isAvailable;
@@ -55,7 +56,7 @@ namespace NineChronicles.Headless.Tests
         }
 
         /// <inheritdoc/>
-        public bool TryGetValue(string key, out byte[] value)
+        public bool TryGetValue(string key, out byte[]? value)
         {
             return _value.TryGetValue(key, out value);
         }

--- a/NineChronicles.Headless.Tests/InMemorySessionTest.cs
+++ b/NineChronicles.Headless.Tests/InMemorySessionTest.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests
+{
+    public class InMemorySessionTest : SessionTest
+    {
+        public InMemorySessionTest()
+            : base(new InMemorySession(string.Empty, true))
+        {
+        }
+
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        [InlineData("baz")]
+        public override void Id(string id)
+        {
+            var session = new InMemorySession(id, true);
+            Assert.Equal(id, session.Id);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public override void IsAvailable(bool isAvailable)
+        {
+            var session = new InMemorySession(string.Empty, isAvailable);
+            Assert.Equal(isAvailable, session.IsAvailable);
+        }
+
+        [Fact]
+        public override Task CommitAsync()
+        {   
+            var session = new InMemorySession(string.Empty, true);
+            Assert.Equal(Task.CompletedTask, session.CommitAsync());
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public override Task LoadAsync()
+        {
+            var session = new InMemorySession(string.Empty, true);
+            Assert.Equal(Task.CompletedTask, session.LoadAsync());
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/Middleware/AuthenticationValidationMiddlewareTest.cs
+++ b/NineChronicles.Headless.Tests/Middleware/AuthenticationValidationMiddlewareTest.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using NineChronicles.Headless.Middleware;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests.Middleware
+{
+    public class AuthenticationValidationMiddlewareTest
+    {
+        private readonly IMiddleware _middleware;
+        private readonly HttpContext _httpContext;
+        private readonly RequestDelegate _requestDelegate;
+
+        public AuthenticationValidationMiddlewareTest()
+        {
+            var services = new ServiceCollection();
+            _httpContext = new DefaultHttpContext();
+            services.AddSingleton(_httpContext);
+            services.AddLogging().AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie();
+            _httpContext.RequestServices = services.BuildServiceProvider();
+            _httpContext.Session = new InMemorySession(string.Empty, true);
+            _requestDelegate = hc => Task.CompletedTask;
+            _middleware = new AuthenticationValidationMiddleware();
+        }
+
+        [Fact]
+        public async Task InvokeAsync_SignOut_IfPrivateKeyDoesNotExist()
+        {
+            var userRoleClaim = new Claim(ClaimTypes.Role, "User");
+            bool IsSignedIn() => _httpContext.User.HasClaim(userRoleClaim.Type, userRoleClaim.Value);
+            var identity = new ClaimsIdentity(new List<Claim> {userRoleClaim}, "Login");
+            await _httpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(new List<ClaimsIdentity>
+            {
+                identity
+            }));
+            _httpContext.User.AddIdentity(identity);
+            Assert.True(IsSignedIn());
+            Assert.Null(_httpContext.Session.GetPrivateKey());
+
+            await _middleware.InvokeAsync(
+                _httpContext,
+                _requestDelegate);
+
+            Assert.True(_httpContext.Response.Headers.Contains(new KeyValuePair<string, StringValues>(
+                "Set-Cookie",
+                ".AspNetCore.Cookies=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly")));
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
+++ b/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NineChronicles.Headless.Tests/SessionTest.cs
+++ b/NineChronicles.Headless.Tests/SessionTest.cs
@@ -1,0 +1,95 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests
+{
+    public abstract class SessionTest
+    {
+        private readonly ISession _session;
+
+        protected SessionTest(ISession session)
+        {
+            _session = session;
+        }
+
+        [Fact]
+        public void Clear()
+        {
+            _session.Set("foo", new byte[] { 0xbe, 0xef });
+            Assert.NotEmpty(_session.Keys);
+            _session.Clear();
+            Assert.Empty(_session.Keys);
+        }
+
+        [Fact]
+        public void Remove()
+        {
+            const string foo = "foo", bar = "bar", session = "session";
+            _session.Set(foo, new byte[] { 0xbe, 0xef });
+            _session.Set(bar, new byte[] { 0xbe, 0xef });
+            _session.Set(session, new byte[] { 0xab, 0xcd });
+            Assert.Contains(foo, _session.Keys);
+            Assert.Contains(bar, _session.Keys);
+            Assert.Contains(session, _session.Keys);
+            _session.Remove(foo);
+            Assert.DoesNotContain(foo, _session.Keys);
+            Assert.Contains(bar, _session.Keys);
+            Assert.Contains(session, _session.Keys);
+            _session.Remove(bar);
+            Assert.DoesNotContain(foo, _session.Keys);
+            Assert.DoesNotContain(bar, _session.Keys);
+            Assert.Contains(session, _session.Keys);
+            _session.Remove(session);
+            Assert.DoesNotContain(foo, _session.Keys);
+            Assert.DoesNotContain(bar, _session.Keys);
+            Assert.DoesNotContain(session, _session.Keys);
+        }
+
+        [Theory]
+        [InlineData("foo", new byte[] { 0x00 })]
+        [InlineData("bar", new byte[] { 0x01 })]
+        public void Set(string key, byte[] value)
+        {
+            _session.Set(key, value);
+            Assert.True(_session.TryGetValue(key, out byte[] storedValue));
+            Assert.Equal(value, storedValue);
+        }
+
+        [Fact]
+        public void TryGetValue()
+        {
+            const string foo = "foo";
+            Assert.False(_session.TryGetValue(foo, out byte[] _));
+
+            var value = new byte[] { 0xbe, 0xef };
+            _session.Set(foo, value);
+            Assert.True(_session.TryGetValue(foo, out byte[] storedValue));
+            Assert.Equal(value, storedValue);
+        }
+
+        [Fact]
+        public void Keys()
+        {
+            const string foo = "foo", bar = "bar", baz = "baz";
+            byte[] GenerateEmptyBytes() => new byte[0]; 
+            _session.Set(foo, GenerateEmptyBytes());
+            Assert.Equal(new[] { foo, }, _session.Keys);
+            _session.Set(bar, GenerateEmptyBytes());
+            Assert.Equal(new[] { foo, bar, }, _session.Keys);
+            _session.Set(baz, GenerateEmptyBytes());
+            Assert.Equal(new[] { foo, bar, baz, }, _session.Keys);
+        }
+
+        [Fact]
+        public abstract Task CommitAsync();
+
+        [Fact]
+        public abstract Task LoadAsync();
+
+        public abstract void Id(string id);
+
+        public abstract void IsAvailable(bool isAvailable);
+    }
+}

--- a/NineChronicles.Headless/Controllers/GraphQLController.cs
+++ b/NineChronicles.Headless/Controllers/GraphQLController.cs
@@ -120,15 +120,6 @@ namespace NineChronicles.Headless.Controllers
 
             var privateKey = new PrivateKey(ByteUtil.ParseHex(request.PrivateKeyString));
             StandaloneContext.NineChroniclesNodeService.MinerPrivateKey = privateKey;
-            // FIXME: move sign in into login query. 
-            var claims = new List<Claim>
-            {
-                new Claim(ClaimTypes.Name, privateKey.ToAddress().ToHex()),
-                new Claim(ClaimTypes.Role, "User"),
-            };
-            var claimsIdentity = new ClaimsIdentity(claims, "Login");
-            _httpContextAccessor.HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(claimsIdentity));
-            _httpContextAccessor.HttpContext.Session.SetPrivateKey(privateKey);
             var msg = $"Private key set ({StandaloneContext.NineChroniclesNodeService.MinerPrivateKey.PublicKey.ToAddress()}).";
             Log.Information("SetPrivateKey: {Msg}", msg);
             return Ok(msg);
@@ -254,66 +245,61 @@ namespace NineChronicles.Headless.Controllers
                 .Where(NeedsRefillNotification)
                 .ToList();
 
-            if (avatarStatesToSendNotification.Any())
-            {
-                var notification = new Notification(NotificationEnum.Refill);
-                StandaloneContext.NotificationSubject.OnNext(notification);
-            }
-
             foreach (var avatarState in avatarStatesToSendNotification)
             {
                 Log.Debug(
                     "Record notification for {AvatarAddress}",
                     avatarState.address.ToHex());
+                var notification = new Notification(NotificationEnum.Refill, avatarState.address);
+                StandaloneContext.NotificationSubject.OnNext(notification);
                 NotificationRecords[avatarState.address] = avatarState.dailyRewardReceivedIndex;
             }
         }
 
         private void NotifyAction(ActionBase.ActionEvaluation<ActionBase> eval)
         {
-            if (StandaloneContext.NineChroniclesNodeService is null)
+            List<Tuple<Guid, ProtectedPrivateKey>>? tuples =
+                StandaloneContext.KeyStore?.List().ToList();
+            if (tuples is null || !tuples.Any())
             {
-                throw new InvalidOperationException(
-                    $"{nameof(StandaloneContext.NineChroniclesNodeService)} is null.");
-            }
-
-            if (StandaloneContext.NineChroniclesNodeService.MinerPrivateKey is null)
-            {
-                Log.Information("PrivateKey is not set. please call SetPrivateKey() first.");
                 return;
             }
-            Address address = StandaloneContext.NineChroniclesNodeService.MinerPrivateKey.PublicKey.ToAddress();
-            if (eval.OutputStates.UpdatedAddresses.Contains(address) || eval.Signer == address)
+
+            var playerAddresses = tuples.Select(tuple => tuple.Item2.Address).ToHashSet();
+
+            if (playerAddresses.Contains(eval.Signer))
             {
-                if (eval.Signer == address)
+                var type = NotificationEnum.Refill;
+                var msg = string.Empty;
+                switch (eval.Action)
                 {
-                    var type = NotificationEnum.Refill;
-                    var msg = string.Empty;
-                    switch (eval.Action)
-                    {
-                        case HackAndSlash4 has:
-                            type = NotificationEnum.HAS;
-                            msg = has.stageId.ToString(CultureInfo.InvariantCulture);
-                            break;
-                        case CombinationConsumable3 _:
-                            type = NotificationEnum.CombinationConsumable;
-                            break;
-                        case CombinationEquipment4 _:
-                            type = NotificationEnum.CombinationEquipment;
-                            break;
-                        case Buy4 _:
-                            type = NotificationEnum.Buyer;
-                            break;
-                    }
-                    Log.Information("NotifyAction: Type: {Type} MSG: {Msg}", type, msg);
-                    var notification = new Notification(type, msg);
-                    StandaloneContext.NotificationSubject.OnNext(notification);
+                    case HackAndSlash4 has:
+                        type = NotificationEnum.HAS;
+                        msg = has.stageId.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case CombinationConsumable3 _:
+                        type = NotificationEnum.CombinationConsumable;
+                        break;
+                    case CombinationEquipment4 _:
+                        type = NotificationEnum.CombinationEquipment;
+                        break;
+                    case Buy4 _:
+                        type = NotificationEnum.Buyer;
+                        break;
                 }
-                else
+                Log.Information("NotifyAction: Type: {Type} MSG: {Msg}", type, msg);
+                var notification = new Notification(type, eval.Signer, msg);
+                StandaloneContext.NotificationSubject.OnNext(notification);
+            }
+
+            playerAddresses.IntersectWith(eval.OutputStates.UpdatedAddresses);
+            if (playerAddresses.Any() && eval.Action is Buy4 buy)
+            {
+                foreach (Address address in playerAddresses)
                 {
-                    if (eval.Action is Buy4 buy && buy.sellerAgentAddress == address)
+                    if (buy.sellerAgentAddress == address)
                     {
-                        var notification = new Notification(NotificationEnum.Seller);
+                        var notification = new Notification(NotificationEnum.Seller, address);
                         StandaloneContext.NotificationSubject.OnNext(notification);
                     }
                 }

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -88,6 +88,14 @@ namespace NineChronicles.Headless
                 services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                     .AddCookie();
 
+                services.AddSession(options =>
+                {
+                    options.Cookie.Name = ".NineChronicles.Session";
+                    options.Cookie.IsEssential = true;
+                });
+
+                services.AddDistributedMemoryCache();
+
                 services.AddHealthChecks();
 
                 services.AddControllers();
@@ -134,6 +142,7 @@ namespace NineChronicles.Headless
                     app.UseCors("AllowAllOrigins");
                 }
 
+                app.UseSession();
                 app.UseRouting();
                 app.UseAuthentication();
                 app.UseAuthorization();

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using GraphQL.Server;
-using GraphQL.Utilities;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -85,6 +85,9 @@ namespace NineChronicles.Headless
 
                 services.AddTransient<LocalAuthenticationMiddleware>();
 
+                services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+                    .AddCookie();
+
                 services.AddHealthChecks();
 
                 services.AddControllers();
@@ -132,7 +135,9 @@ namespace NineChronicles.Headless
                 }
 
                 app.UseRouting();
+                app.UseAuthentication();
                 app.UseAuthorization();
+                app.UseCookiePolicy();
                 app.UseEndpoints(endpoints =>
                 {
                     endpoints.MapControllers();

--- a/NineChronicles.Headless/GraphTypes/ActionMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionMutation.cs
@@ -11,16 +11,23 @@ using Nekoyume.Model.State;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using GraphQL.Server.Authorization.AspNetCore;
 using Libplanet.Explorer.GraphTypes;
 using Libplanet.Tx;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using NineChroniclesActionType = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Headless.GraphTypes
 {
     public class ActionMutation : ObjectGraphType<NineChroniclesNodeService>
     {
-        public ActionMutation()
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public ActionMutation(IHttpContextAccessor httpContextAccessor)
         {
+            _httpContextAccessor = httpContextAccessor;
+
             Field<NonNullGraphType<TxIdType>>("createAvatar",
                 description: "Create new avatar.",
                 arguments: new QueryArguments(
@@ -60,9 +67,9 @@ namespace NineChronicles.Headless.GraphTypes
                     try
                     {
                         NineChroniclesNodeService service = context.Source;
-                        if (!(service.MinerPrivateKey is { } privateKey))
+                        if (!(_httpContextAccessor.HttpContext.Session.GetPrivateKey() is { } privateKey))
                         {
-                            throw new InvalidOperationException($"{nameof(service.MinerPrivateKey)} is null.");
+                            throw new InvalidOperationException("The session private key is null.");
                         }
 
                         if (!(service.Swarm?.BlockChain is { } blockChain))
@@ -278,12 +285,12 @@ namespace NineChronicles.Headless.GraphTypes
                     try
                     {
                         NineChroniclesNodeService service = context.Source;
-                        if (!(service.MinerPrivateKey is { } privatekey))
+                        if (!(_httpContextAccessor.HttpContext.Session.GetPrivateKey() is { } privatekey))
                         {
-                            throw new InvalidOperationException($"{nameof(service.MinerPrivateKey)} is null.");
+                            throw new InvalidOperationException("The session private key is null.");
                         }
 
-                        if (!(service.Swarm?.BlockChain is { } blockChain))
+                        if (!(service.Swarm.BlockChain is { } blockChain))
                         {
                             throw new InvalidOperationException($"{nameof(service.Swarm.BlockChain)} is null.");
                         }
@@ -342,12 +349,12 @@ namespace NineChronicles.Headless.GraphTypes
                     try
                     {
                         NineChroniclesNodeService service = context.Source;
-                        if (!(service.MinerPrivateKey is { } privateKey))
+                        if (!(_httpContextAccessor.HttpContext.Session.GetPrivateKey() is { } privateKey))
                         {
-                            throw new InvalidOperationException($"{nameof(service.MinerPrivateKey)} is null.");
+                            throw new InvalidOperationException("The session private key is null.");
                         }
 
-                        if (!(service.Swarm?.BlockChain is { } blockChain))
+                        if (!(service.Swarm.BlockChain is { } blockChain))
                         {
                             throw new InvalidOperationException($"{nameof(service.Swarm.BlockChain)} is null.");
                         }
@@ -400,16 +407,15 @@ namespace NineChronicles.Headless.GraphTypes
                     try
                     {
                         NineChroniclesNodeService service = context.Source;
-                        if (!(service.MinerPrivateKey is { } privateKey))
+                        if (!(_httpContextAccessor.HttpContext.Session.GetPrivateKey() is { } privateKey))
                         {
-                            throw new InvalidOperationException($"{nameof(service.MinerPrivateKey)} is null.");
+                            throw new InvalidOperationException("The session private key is null.");
                         }
 
-                        if (!(service.Swarm?.BlockChain is { } blockChain))
+                        if (!(service.Swarm.BlockChain is { } blockChain))
                         {
                             throw new InvalidOperationException($"{nameof(service.Swarm.BlockChain)} is null.");
                         }
-
 
                         Address sellerAvatarAddress = context.GetArgument<Address>("sellerAvatarAddress");
                         Guid itemId = context.GetArgument<Guid>("itemId");
@@ -451,12 +457,12 @@ namespace NineChronicles.Headless.GraphTypes
                     try
                     {
                         NineChroniclesNodeService service = context.Source;
-                        if (!(service.MinerPrivateKey is { } privateKey))
+                        if (!(_httpContextAccessor.HttpContext.Session.GetPrivateKey() is { } privateKey))
                         {
-                            throw new InvalidOperationException($"{nameof(service.MinerPrivateKey)} is null.");
+                            throw new InvalidOperationException("The session private key is null.");
                         }
 
-                        if (!(service.Swarm?.BlockChain is { } blockChain))
+                        if (!(service.Swarm.BlockChain is { } blockChain))
                         {
                             throw new InvalidOperationException($"{nameof(service.Swarm.BlockChain)} is null.");
                         }

--- a/NineChronicles.Headless/GraphTypes/ActivationStatusMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/ActivationStatusMutation.cs
@@ -5,6 +5,7 @@ using GraphQL.Types;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Crypto;
+using Microsoft.AspNetCore.Http;
 using Nekoyume.Action;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
@@ -15,8 +16,12 @@ namespace NineChronicles.Headless.GraphTypes
 {
     public class ActivationStatusMutation : ObjectGraphType<NineChroniclesNodeService>
     {
-        public ActivationStatusMutation()
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public ActivationStatusMutation(IHttpContextAccessor httpContextAccessor)
         {
+            _httpContextAccessor = httpContextAccessor;
+
             Field<NonNullGraphType<BooleanGraphType>>("activateAccount",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<StringGraphType>>
@@ -31,7 +36,7 @@ namespace NineChronicles.Headless.GraphTypes
                             context.GetArgument<string>("encodedActivationKey");
                         NineChroniclesNodeService service = context.Source;
                         // FIXME: Private key may not exists at this moment.
-                        if (!(service.MinerPrivateKey is { } privateKey))
+                        if (!(_httpContextAccessor.HttpContext.Session.GetPrivateKey() is { } privateKey))
                         {
                             throw new InvalidOperationException($"{nameof(privateKey)} is null.");
                         }

--- a/NineChronicles.Headless/GraphTypes/AuthenticationMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/AuthenticationMutation.cs
@@ -25,7 +25,8 @@ namespace NineChronicles.Headless.GraphTypes
 
             FieldAsync<NonNullGraphType<BooleanGraphType>>(
                 "login",
-                "",
+                "Log in with the the given address and the given passphrase. " +
+                    "If the address doesn't exist in the key store, it will fail.",
                 new QueryArguments(
                     new QueryArgument<NonNullGraphType<AddressType>>
                     {
@@ -61,7 +62,7 @@ namespace NineChronicles.Headless.GraphTypes
                     return true;
                 });
 
-            FieldAsync<NonNullGraphType<BooleanGraphType>>("logout", "", resolve: async context =>
+            FieldAsync<NonNullGraphType<BooleanGraphType>>("logout", "Logout the session.", resolve: async context =>
             {
                 if (!_httpContextAccessor.HttpContext.User.HasClaim(ClaimTypes.Role, "User"))
                 {

--- a/NineChronicles.Headless/GraphTypes/AuthenticationMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/AuthenticationMutation.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet;
+using Libplanet.Crypto;
+using Libplanet.Explorer.GraphTypes;
+using Libplanet.KeyStore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public class AuthenticationMutation : ObjectGraphType
+    {
+        private readonly IKeyStore _keyStore;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public AuthenticationMutation(IKeyStore keyStore, IHttpContextAccessor httpContextAccessor)
+        {
+            _keyStore = keyStore;
+            _httpContextAccessor = httpContextAccessor;
+
+            FieldAsync<NonNullGraphType<BooleanGraphType>>(
+                "login",
+                "",
+                new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "address",
+                        Description = "The address of the private key to use in this session.",
+                    },
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Name = "passphrase",
+                        Description = "The passphrase to unlock the protected private key.",
+                    }
+                ), resolve: async context =>
+                {
+                    Address address = context.GetArgument<Address>("address");
+                    string passphrase = context.GetArgument<string>("passphrase");
+                    if (!(_keyStore.List().First(t => t.Item2.Address == address)?.Item2 is { } protectedPrivateKey))
+                    {
+                        context.Errors.Add(
+                            new ExecutionError(
+                                $"The given address '{address}' didn't exist in protected private keys."));
+                        return false;
+                    }
+
+                    PrivateKey privateKey = protectedPrivateKey.Unprotect(passphrase);
+                    var claims = new List<Claim>
+                    {
+                        new Claim(ClaimTypes.Name, privateKey.ToAddress().ToHex()),
+                        new Claim(ClaimTypes.Role, "User"),
+                    };
+                    var claimsIdentity = new ClaimsIdentity(claims, "Login");
+                    await _httpContextAccessor.HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(claimsIdentity));
+                    _httpContextAccessor.HttpContext.Session.SetPrivateKey(privateKey);
+                    return true;
+                });
+
+            FieldAsync<NonNullGraphType<BooleanGraphType>>("logout", "", resolve: async context =>
+            {
+                if (!_httpContextAccessor.HttpContext.User.HasClaim(ClaimTypes.Role, "User"))
+                {
+                    context.Errors.Add(new ExecutionError("You seem not logged in."));
+                    return false;
+                }
+
+                await _httpContextAccessor.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                return true;
+            });
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/KeyStoreMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/KeyStoreMutation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using GraphQL;
+using GraphQL.Server.Authorization.AspNetCore;
 using GraphQL.Types;
 using Libplanet;
 using Libplanet.Crypto;

--- a/NineChronicles.Headless/GraphTypes/Notification.cs
+++ b/NineChronicles.Headless/GraphTypes/Notification.cs
@@ -1,13 +1,18 @@
+using Libplanet;
+
 namespace NineChronicles.Headless.GraphTypes
 {
     public class Notification
     {
         public NotificationEnum Type { get; set; }
         public string Message { get; set; }
+        
+        public Address Receiver { get; }
 
-        public Notification(NotificationEnum type, string msg = "")
+        public Notification(NotificationEnum type, Address receiver, string msg = "")
         {
-            Type = type;   
+            Type = type;
+            Receiver = receiver;
             Message = msg;
         }
     }

--- a/NineChronicles.Headless/GraphTypes/NotificationType.cs
+++ b/NineChronicles.Headless/GraphTypes/NotificationType.cs
@@ -1,4 +1,5 @@
 using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
 
 namespace NineChronicles.Headless.GraphTypes
 {
@@ -15,6 +16,11 @@ namespace NineChronicles.Headless.GraphTypes
                 name: "message",
                 description: "The message of Notification.",
                 resolve: context => context.Source.Message);
+            
+            Field<NonNullGraphType<AddressType>>(
+                name: "receiver",
+                description: "The receiver of Notification.",
+                resolve: context => context.Source.Receiver);
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -27,17 +27,24 @@ namespace NineChronicles.Headless.GraphTypes
                 this.AuthorizeWith(GraphQLService.LocalPolicyKey);   
             }
 
+            Field<AuthenticationMutation>(
+                "auth",
+                resolve: context => new { });
+
             Field<KeyStoreMutation>(
-                name: "keyStore",
-                resolve: context => standaloneContext.KeyStore);
+                    name: "keyStore",
+                    resolve: context => standaloneContext.KeyStore)
+                .AuthorizeWith(GraphQLService.UserPolicyKey);
 
             Field<ActivationStatusMutation>(
-                name: "activationStatus",
-                resolve: context => standaloneContext.NineChroniclesNodeService);
+                    name: "activationStatus",
+                    resolve: context => standaloneContext.NineChroniclesNodeService)
+                .AuthorizeWith(GraphQLService.UserPolicyKey);
 
             Field<ActionMutation>(
-                name: "action",
-                resolve: context => standaloneContext.NineChroniclesNodeService);
+                    name: "action",
+                    resolve: context => standaloneContext.NineChroniclesNodeService)
+                .AuthorizeWith(GraphQLService.UserPolicyKey);
 
             Field<NonNullGraphType<BooleanGraphType>>(
                 name: "stageTx",
@@ -80,7 +87,7 @@ namespace NineChronicles.Headless.GraphTypes
                         return false;
                     }
                 }
-            );
+            ).AuthorizeWith(GraphQLService.UserPolicyKey);
 
             Field<TxIdType>(
                 name: "transferGold",
@@ -113,10 +120,10 @@ namespace NineChronicles.Headless.GraphTypes
 
                     BlockChain<NCAction> blockChain = service.BlockChain;
                     var currency = new GoldCurrencyState(
-                        (Dictionary)blockChain.GetState(GoldCurrencyState.Address)
+                        (Dictionary) blockChain.GetState(GoldCurrencyState.Address)
                     ).Currency;
                     FungibleAssetValue amount =
-                    FungibleAssetValue.Parse(currency, context.GetArgument<string>("amount"));
+                        FungibleAssetValue.Parse(currency, context.GetArgument<string>("amount"));
 
                     Address recipient = context.GetArgument<Address>("recipient");
 
@@ -133,7 +140,7 @@ namespace NineChronicles.Headless.GraphTypes
                     );
                     return tx.Id;
                 }
-            );
+            ).AuthorizeWith(GraphQLService.UserPolicyKey);
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
 using GraphQL;
+using GraphQL.Server.Authorization.AspNetCore;
 using GraphQL.Types;
 using Libplanet;
 using Libplanet.Action;

--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -137,9 +137,8 @@ namespace NineChronicles.Headless.GraphTypes
                 Type = typeof(NonNullGraphType<NotificationType>),
                 Resolver = new FuncFieldResolver<Notification>(context => (context.Source as Notification)!),
                 Subscriber = new EventStreamResolver<Notification>(context =>
-                    StandaloneContext.NotificationSubject.AsObservable()
-                        .Where(notification => notification.Receiver == context.UserContext[GraphQLService.UserContextPrivateKeyKey].As<PrivateKey>()?.ToAddress())),
-            }).AuthorizeWith(GraphQLService.UserPolicyKey);
+                    StandaloneContext.NotificationSubject.AsObservable()),
+            });
             AddField(new EventStreamFieldType
             {
                 Name = "nodeException",

--- a/NineChronicles.Headless/ISessionExtensions.cs
+++ b/NineChronicles.Headless/ISessionExtensions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Libplanet.Crypto;
 using Microsoft.AspNetCore.Http;
 using ISession = Microsoft.AspNetCore.Http.ISession;
@@ -8,8 +10,10 @@ namespace NineChronicles.Headless
     {
         internal const string SessionPrivateKeyKey = "private-key";
 
-        internal static PrivateKey GetPrivateKey(this ISession session) =>
-            new PrivateKey(session.Get(SessionPrivateKeyKey));
+        internal static PrivateKey? GetPrivateKey(this ISession session) =>
+            session.Get(SessionPrivateKeyKey) is { } bytes
+                ? new PrivateKey(bytes)
+                : null;
         
         internal static void SetPrivateKey(this ISession session, PrivateKey privateKey) =>
             session.Set(SessionPrivateKeyKey, privateKey.ByteArray);

--- a/NineChronicles.Headless/ISessionExtensions.cs
+++ b/NineChronicles.Headless/ISessionExtensions.cs
@@ -1,0 +1,17 @@
+using Libplanet.Crypto;
+using Microsoft.AspNetCore.Http;
+using ISession = Microsoft.AspNetCore.Http.ISession;
+
+namespace NineChronicles.Headless
+{
+    internal static class ISessionExtensions
+    {
+        internal const string SessionPrivateKeyKey = "private-key";
+
+        internal static PrivateKey GetPrivateKey(this ISession session) =>
+            new PrivateKey(session.Get(SessionPrivateKeyKey));
+        
+        internal static void SetPrivateKey(this ISession session, PrivateKey privateKey) =>
+            session.Set(SessionPrivateKeyKey, privateKey.ByteArray);
+    }
+}

--- a/NineChronicles.Headless/Middleware/AuthenticationValidationMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/AuthenticationValidationMiddleware.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace NineChronicles.Headless.Middleware
+{
+    public class AuthenticationValidationMiddleware : IMiddleware
+    {
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            if (context.Session.GetPrivateKey() is null)
+            {
+                await context.SignOutAsync();
+            }
+
+            await next(context);
+        }
+    }
+}

--- a/NineChronicles.Headless/UserContextBuilder.cs
+++ b/NineChronicles.Headless/UserContextBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Server.Transports.AspNetCore;
+using Libplanet.Crypto;
 using Libplanet.Explorer.Interfaces;
 using Microsoft.AspNetCore.Http;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
@@ -21,6 +22,7 @@ namespace NineChronicles.Headless
             return new ValueTask<IDictionary<string, object?>>(new Dictionary<string, object?>
             {
                 [nameof(IBlockChainContext<NCAction>.Store)] = _standaloneContext.Store,
+                [GraphQLService.UserContextPrivateKeyKey] = httpContext.Session.GetPrivateKey(),
             }).AsTask();
         }
     }


### PR DESCRIPTION
It resolves #316.

This pull request makes it manage private key by session (i.e. user), with key store as account backend.

Since this pull request, it will have [Moq](https://github.com/moq/moq4) to mock services, as a dependency.