### PR TITLE
Represent block hashes using `BlockHash` instead of `HashDigest<SHA256>`

### DIFF
--- a/NineChronicles.Headless.Executable/Store/IStoreExtensions.cs
+++ b/NineChronicles.Headless.Executable/Store/IStoreExtensions.cs
@@ -1,8 +1,6 @@
 #nullable enable
 using System;
 using System.Linq;
-using System.Security.Cryptography;
-using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Store;
@@ -20,7 +18,7 @@ namespace NineChronicles.Headless.Executable.Store
                 throw new InvalidOperationException("The store doesn't have genesis block.");
             }
 
-            HashDigest<SHA256> genesisBlockHash = store.IterateIndexes(chainId.Value).First();
+            BlockHash genesisBlockHash = store.IterateIndexes(chainId.Value).First();
             Block<T> genesisBlock = store.GetBlock<T>(genesisBlockHash);
             return genesisBlock;
         }

--- a/NineChronicles.Headless.Executable/Store/NoOpStateStore.cs
+++ b/NineChronicles.Headless.Executable/Store/NoOpStateStore.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Immutable;
-using System.Security.Cryptography;
 using Bencodex.Types;
-using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Store;
@@ -15,15 +13,11 @@ namespace NineChronicles.Headless.Executable.Store
         {
         }
 
-        public IValue? GetState(string stateKey, HashDigest<SHA256>? blockHash = null, Guid? chainId = null)
-        {
-            return null;
-        }
+        public IValue? GetState(string stateKey, BlockHash? blockHash = null, Guid? chainId = null) =>
+            null;
 
-        public bool ContainsBlockStates(HashDigest<SHA256> blockHash)
-        {
-            return false;
-        }
+        public bool ContainsBlockStates(BlockHash blockHash) =>
+            false;
 
         public void ForkStates<T>(Guid sourceChainId, Guid destinationChainId, Block<T> branchpoint) where T : IAction, new()
         {

--- a/NineChronicles.Headless/BlockChainExtensions.cs
+++ b/NineChronicles.Headless/BlockChainExtensions.cs
@@ -1,17 +1,16 @@
-using System.Security.Cryptography;
-using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blockchain;
+using Libplanet.Blocks;
 
 namespace NineChronicles.Headless
 {
     public static class BlockChainExtensions
     {
-        public static AccountStateGetter ToAccountStateGetter<T>(this BlockChain<T> chain, HashDigest<SHA256>? blockHash = null)
+        public static AccountStateGetter ToAccountStateGetter<T>(this BlockChain<T> chain, BlockHash? blockHash = null)
             where T : IAction, new() =>
             address => chain.GetState(address, blockHash ?? chain.Tip.Hash);
         
-        public static AccountBalanceGetter ToAccountBalanceGetter<T>(this BlockChain<T> chain, HashDigest<SHA256>? blockHash = null)
+        public static AccountBalanceGetter ToAccountBalanceGetter<T>(this BlockChain<T> chain, BlockHash? blockHash = null)
             where T : IAction, new() =>
             (address, currency) => chain.GetBalance(address, currency, blockHash ?? chain.Tip.Hash);
     }

--- a/NineChronicles.Headless/GraphTypes/BlockHeaderType.cs
+++ b/NineChronicles.Headless/GraphTypes/BlockHeaderType.cs
@@ -11,7 +11,7 @@ namespace NineChronicles.Headless.GraphTypes
     {
         public long Index { get; set; }
 
-        public HashDigest<SHA256> Hash { get; set; }
+        public BlockHash Hash { get; set; }
 
         public Address? Miner { get; set; }
 

--- a/NineChronicles.Headless/GraphTypes/NodeStatus.cs
+++ b/NineChronicles.Headless/GraphTypes/NodeStatus.cs
@@ -137,7 +137,7 @@ namespace NineChronicles.Headless.GraphTypes
             while (true)
             {
                 yield return block;
-                if (block.PreviousHash is HashDigest<SHA256> prev)
+                if (block.PreviousHash is { } prev)
                 {
                     block = blockChain[prev];
                 }

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -1,6 +1,4 @@
 #nullable enable
-using System;
-using System.Security.Cryptography;
 using Bencodex;
 using Bencodex.Types;
 using GraphQL;
@@ -9,9 +7,8 @@ using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Blockchain;
+using Libplanet.Blocks;
 using Libplanet.Explorer.GraphTypes;
-using Libplanet.Explorer.Interfaces;
-using Libplanet.Store;
 using Microsoft.Extensions.Configuration;
 using Libplanet.Tx;
 using Nekoyume.Action;
@@ -34,9 +31,9 @@ namespace NineChronicles.Headless.GraphTypes
                 }),
                 resolve: context =>
                 {
-                    HashDigest<SHA256>? blockHash = context.GetArgument<byte[]>("hash") switch
+                    BlockHash? blockHash = context.GetArgument<byte[]>("hash") switch
                     {
-                        byte[] bytes => new HashDigest<SHA256>(bytes),
+                        byte[] bytes => new BlockHash(bytes),
                         null => null,
                     };
 
@@ -63,7 +60,7 @@ namespace NineChronicles.Headless.GraphTypes
                     var blockHashByteArray = context.GetArgument<byte[]>("hash");
                     var blockHash = blockHashByteArray is null
                         ? blockChain.Tip.Hash
-                        : new HashDigest<SHA256>(blockHashByteArray);
+                        : new BlockHash(blockHashByteArray);
 
                     var state = blockChain.GetState(address, blockHash);
 
@@ -127,7 +124,7 @@ namespace NineChronicles.Headless.GraphTypes
                     byte[] blockHashByteArray = context.GetArgument<byte[]>("hash");
                     var blockHash = blockHashByteArray is null
                         ? blockChain.Tip.Hash
-                        : new HashDigest<SHA256>(blockHashByteArray);
+                        : new BlockHash(blockHashByteArray);
                     Currency currency = new GoldCurrencyState(
                         (Dictionary)blockChain.GetState(GoldCurrencyState.Address)
                     ).Currency;

--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -2,21 +2,15 @@ using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Security.Cryptography;
-using System.Threading.Tasks;
-using BTAI;
 using GraphQL;
 using GraphQL.Resolvers;
 using GraphQL.Subscription;
 using GraphQL.Types;
 using Lib9c.Renderer;
-using Libplanet;
-using Libplanet.Blockchain;
+using Libplanet.Blocks;
 using Libplanet.Explorer.GraphTypes;
 using Libplanet.Net;
 using Libplanet.Headless;
-using Nekoyume.Action;
-using Log = Serilog.Log;
 
 namespace NineChronicles.Headless.GraphTypes
 {
@@ -26,7 +20,7 @@ namespace NineChronicles.Headless.GraphTypes
         {
             public long Index { get; set; }
 
-            public HashDigest<SHA256> Hash { get; set; }
+            public BlockHash Hash { get; set; }
 
             public TipChanged()
             {


### PR DESCRIPTION
The submodule *Lib9c* should be bumped to the merge commit after <https://github.com/planetarium/lib9c/pull/328> is merged.

~The build currently fails because *Libplanet.Exploerer*, which is one of its dependencies, depends on *Libplanet* on the NuGet Gallery instead of *Lib9c/.Libplanet/Libplanet* project.  This should be rebased after <https://github.com/planetarium/libplanet/pull/1197> is merged and the version of *Libplanet.Explorer*'s dependency to *Libplanet* is upgraded.~ This was addressed by <https://github.com/planetarium/libplanet/pull/1244> & #445, and now it's no problem.

---

Follow up Libplanet's recent change: block hashes are now represented using `BlockHash` (instead of `BlockHash<SHA256>`).

See also:

https://github.com/planetarium/libplanet/issues/1192
https://github.com/planetarium/libplanet/pull/1197
https://github.com/planetarium/lib9c/pull/328