### PR TITLE
support-monorocksdb

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -269,6 +269,23 @@ namespace Libplanet.Headless.Hosting
                     Log.Error("RocksDB is not available. DefaultStore will be used. {0}", e);
                 }
             }
+            else if (type == "monorocksdb")
+            {
+                 try
+                {
+                    store = new RocksDBStore.MonoRocksDBStore(
+                        path,
+                        maxTotalWalSize: 16 * 1024 * 1024,
+                        maxLogFileSize: 16 * 1024 * 1024,
+                        keepLogFileNum: 1
+                    );
+                    Log.Debug("MonoRocksDB is initialized.");
+                }
+                catch (TypeInitializationException e)
+                {
+                    Log.Error("MonoRocksDB is not available. DefaultStore will be used. {0}", e);
+                }
+            }
             else
             {
                 var message = type is null

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -271,7 +271,7 @@ namespace Libplanet.Headless.Hosting
             }
             else if (type == "monorocksdb")
             {
-                 try
+                try
                 {
                     store = new RocksDBStore.MonoRocksDBStore(
                         path,


### PR DESCRIPTION
This PR takes `monorocksdb` as an option for `--store-type`.
After this PR, `monorocksdb` will take the [original rocksdb(MonoRocksDBStore)](https://github.com/planetarium/libplanet/blob/main/Libplanet.RocksDBStore/MonoRocksDBStore.cs) and `rocksdb` will take the [new rocksdb](https://github.com/planetarium/libplanet/blob/main/Libplanet.RocksDBStore/RocksDBStore.cs).