### PR TITLE
Disable action notifications to avoid spamming on reorg

### DIFF
--- a/NineChronicles.Headless/Controllers/GraphQLController.cs
+++ b/NineChronicles.Headless/Controllers/GraphQLController.cs
@@ -73,8 +73,10 @@ namespace NineChronicles.Headless.Controllers
                     StandaloneContext.NineChroniclesNodeService.Swarm.BlockChain;
                 StandaloneContext.NineChroniclesNodeService.BlockRenderer.EveryBlock()
                     .Subscribe(pair => NotifyRefillActionPoint(pair.NewTip.Index));
-                StandaloneContext.NineChroniclesNodeService.ActionRenderer.EveryRender<ActionBase>()
-                    .Subscribe(NotifyAction);
+
+                // FIXME We disabled notifications due to an issue where the action is repeatedly executed during reorg
+                // StandaloneContext.NineChroniclesNodeService.ActionRenderer.EveryRender<ActionBase>()
+                //    .Subscribe(NotifyAction);
                 nineChroniclesNodeHostBuilder
                     .RunConsoleAsync()
                     .ContinueWith(task =>


### PR DESCRIPTION
This PR disables notifications due to spamming on reorg. we should add filters for reorg before uncomment them.