### PR TITLE
feat(cli): introduce `key` subcommand

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/KeyCommands.cs
+++ b/NineChronicles.Headless.Executable/Commands/KeyCommands.cs
@@ -1,0 +1,235 @@
+#nullable enable
+// Copied from https://git.io/Jqc0q
+namespace Libplanet.Extensions.Cocona.Commands
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using global::Cocona;
+    using Libplanet.Crypto;
+    using Libplanet.KeyStore;
+
+    public class KeyCommand
+    {
+        public KeyCommand()
+        {
+            KeyStore = Web3KeyStore.DefaultKeyStore;
+        }
+
+        public IKeyStore KeyStore { get; }
+
+        [PrimaryCommand]
+        [Command(Description = "List all private keys.")]
+        public void List() =>
+            PrintKeys(KeyStore.List().Select(t => t.ToValueTuple()));
+
+        [Command(Description = "Create a new private key.")]
+        public void Create(
+            [Option(
+                'p',
+                ValueName = "PASSPHRASE",
+                Description = "Take passphrase through this option instead of prompt."
+            )]
+            string? passphrase = null,
+            [Option(
+                Description = "Print the created private key as Web3 Secret Storage format."
+            )]
+            bool json = false,
+            [Option(Description = "Do not add to the key store, but only show the created key.")]
+            bool dryRun = false
+        ) =>
+            Add(new PrivateKey(), passphrase, json, dryRun);
+
+        [Command(Aliases = new[] { "rm" }, Description = "Remove a private key.")]
+        public void Remove(
+            [Argument(Name = "KEY-ID", Description = "A key UUID to remove.")] Guid keyId,
+            [Option(
+                'p',
+                ValueName = "PASSPHRASE",
+                Description = "Take passphrase through this option instead of prompt."
+            )]
+            string? passphrase = null
+        )
+        {
+            try
+            {
+                UnprotectKey(keyId, passphrase);
+                KeyStore.Remove(keyId);
+            }
+            catch (NoKeyException)
+            {
+                throw Utils.Error($"No such key ID: {keyId}");
+            }
+        }
+
+        [Command(Description = "Import a raw private key.")]
+        public void Import(
+            [Argument(
+                "PRIVATE-KEY",
+                Description = "A raw private key to import in hexadecimal string."
+            )]
+            string rawKeyHex,
+            [Option(
+                'p',
+                ValueName = "PASSPHRASE",
+                Description = "Take passphrase through this option instead of prompt."
+            )]
+            string? passphrase = null,
+            [Option(
+                Description = "Print the created private key as Web3 Secret Storage format."
+            )]
+            bool json = false,
+            [Option(Description = "Do not add to the key store, but only show the created key.")]
+            bool dryRun = false
+        )
+        {
+            PrivateKey key;
+            try
+            {
+                byte[] keyBytes = ByteUtil.ParseHex(rawKeyHex);
+                key = new PrivateKey(keyBytes);
+            }
+            catch (FormatException)
+            {
+                throw Utils.Error("A raw private key should be hexadecimal.");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                throw Utils.Error("Hexadecimal characters should be even (not odd).");
+            }
+            catch (Exception)
+            {
+                throw Utils.Error("Invalid private key.");
+            }
+
+            Add(key, passphrase, json, dryRun);
+        }
+
+        [Command(Description = "Export a raw private key (or public key).")]
+        public void Export(
+            [Argument("KEY-ID", Description = "A key UUID to export.")] Guid keyId,
+            [Option(
+                'p',
+                ValueName = "PASSPHRASE",
+                Description = "Take passphrase through this option instead of prompt."
+            )]
+            string? passphrase = null,
+            [Option('P', Description = "Export a public key instead of private key.")]
+            bool publicKey = false,
+            [Option(
+                'b',
+                Description = "Print raw bytes instead of hexadecimal.  No trailing LF appended."
+            )]
+            bool bytes = false
+        )
+        {
+            PrivateKey key = UnprotectKey(keyId, passphrase);
+            byte[] rawKey = publicKey ? key.PublicKey.Format(true) : key.ByteArray;
+            if (bytes)
+            {
+                using Stream stdout = Console.OpenStandardOutput();
+                stdout.Write(rawKey);
+            }
+            else
+            {
+                Console.WriteLine(ByteUtil.Hex(rawKey));
+            }
+        }
+
+        [Command(
+            Aliases = new[] { "gen" },
+            Description = "Generate a raw private key without storing it."
+        )]
+        public void Generate(
+            [Option('A', Description = "Do not show a derived address.")]
+            bool noAddress = false,
+            [Option('p', Description = "Show a public key as well.")]
+            bool publicKey = false
+        )
+        {
+            var key = new PrivateKey();
+            string priv = ByteUtil.Hex(key.ByteArray);
+            string addr = key.ToAddress().ToString();
+            string pub = ByteUtil.Hex(key.PublicKey.Format(compress: true));
+
+            if (!noAddress && publicKey)
+            {
+                Utils.PrintTable(
+                    ("Private key", "Address", "Public key"),
+                    new[] { (priv, addr, pub) }
+                );
+            }
+            else if (!noAddress)
+            {
+                Utils.PrintTable(("Private key", "Address"), new[] { (priv, addr) });
+            }
+            else if (publicKey)
+            {
+                Utils.PrintTable(("Private key", "Public key"), new[] { (priv, pub) });
+            }
+            else
+            {
+                Console.WriteLine(priv);
+            }
+        }
+
+        public PrivateKey UnprotectKey(Guid keyId, string? passphrase = null)
+        {
+            ProtectedPrivateKey ppk;
+            try
+            {
+                ppk = KeyStore.Get(keyId);
+            }
+            catch (NoKeyException)
+            {
+                throw Utils.Error($"No such key ID: {keyId}");
+            }
+
+            passphrase ??= ConsolePasswordReader.Read($"Passphrase (of {keyId}): ");
+
+            try
+            {
+                return ppk.Unprotect(passphrase);
+            }
+            catch (IncorrectPassphraseException)
+            {
+                throw Utils.Error("The passphrase is wrong.");
+            }
+        }
+
+        private void Add(PrivateKey key, string? passphrase, bool json, bool dryRun)
+        {
+            if (passphrase is null)
+            {
+                passphrase = ConsolePasswordReader.Read("Passphrase: ");
+                string second = ConsolePasswordReader.Read("Retype passphrase: ");
+                if (!passphrase.Equals(second))
+                {
+                    throw Utils.Error("Passphrases do not match.");
+                }
+            }
+
+            ProtectedPrivateKey ppk = ProtectedPrivateKey.Protect(key, passphrase);
+            Guid keyId = dryRun ? Guid.NewGuid() : KeyStore.Add(ppk);
+            if (json)
+            {
+                using Stream stdout = System.Console.OpenStandardOutput();
+                ppk.WriteJson(stdout, keyId);
+                stdout.WriteByte(0x0a);  // line ending
+            }
+            else
+            {
+                PrintKeys(new[] { (keyId, ppk) });
+            }
+        }
+
+        private void PrintKeys(IEnumerable<(Guid KeyId, ProtectedPrivateKey Key)> keys)
+        {
+            Utils.PrintTable(
+                ("Key ID", "Address"),
+                keys.Select(t => (t.KeyId.ToString(), t.Key.Address.ToString()))
+            );
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -12,6 +12,7 @@ using Cocona;
 using Cocona.Lite;
 using Libplanet;
 using Libplanet.Crypto;
+using Libplanet.Extensions.Cocona.Commands;
 using Libplanet.KeyStore;
 using Microsoft.Extensions.Hosting;
 using NineChronicles.Headless.Executable.Commands;
@@ -27,6 +28,7 @@ namespace NineChronicles.Headless.Executable
 {
     [HasSubCommands(typeof(ValidationCommand), "validation")]
     [HasSubCommands(typeof(ChainCommand), "chain")]
+    [HasSubCommands(typeof(KeyCommand), "key")]
     public class Program : CoconaLiteConsoleAppBase
     {
         const string SentryDsn = "https://ceac97d4a7d34e7b95e4c445b9b5669e@o195672.ingest.sentry.io/5287621";

--- a/NineChronicles.Headless.Executable/Utils/ConsolePasswordReader.cs
+++ b/NineChronicles.Headless.Executable/Utils/ConsolePasswordReader.cs
@@ -1,0 +1,47 @@
+#nullable enable
+// Copied from https://git.io/Jqc0L
+namespace Libplanet.Extensions.Cocona
+{
+    using System;
+    using System.Text;
+
+    public static class ConsolePasswordReader
+    {
+        public static string Read(string prompt)
+        {
+            var password = new StringBuilder();
+
+            Console.Write(prompt);
+            do
+            {
+                var key = Console.ReadKey(true).KeyChar;
+
+                if (key == '\b')
+                {
+                    if (password.Length <= 0)
+                    {
+                        continue;
+                    }
+
+                    password.Remove(password.Length - 1, 1);
+                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                    Console.Write(' ');
+                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                }
+                else if (key == '\r')
+                {
+                    Console.WriteLine();
+                    break;
+                }
+                else if (!char.IsControl(key))
+                {
+                    password.Append(key);
+                    Console.Write('*');
+                }
+            }
+            while (true);
+
+            return password.ToString();
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable/Utils/Utils.cs
+++ b/NineChronicles.Headless.Executable/Utils/Utils.cs
@@ -1,0 +1,75 @@
+#nullable enable
+// Copied from https://git.io/Jqc0O
+namespace Libplanet.Extensions.Cocona
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using global::Cocona;
+
+    public static class Utils
+    {
+        public static CommandExitedException Error(string message, int exitCode = 128)
+        {
+            Console.Error.WriteLine("Error: {0}", message);
+            Console.Error.Flush();
+            return new CommandExitedException(exitCode);
+        }
+
+        public static void PrintTable<T>(T header, IEnumerable<T> rows)
+            where T : ITuple
+        {
+            IEnumerable<(int, string)> RowToStrings(T tuple)
+            {
+                return Enumerable.Range(0, tuple.Length)
+                    .Select(i => (i, tuple[i]?.ToString()?.Normalize() ?? string.Empty));
+            }
+
+            // Calculates the column lengths:
+            T[] rowsArray = rows.ToArray();
+            int[] columnLengths = RowToStrings(header).Select(pair => pair.Item2.Length).ToArray();
+            foreach (T row in rowsArray)
+            {
+                foreach ((int i, string col) in RowToStrings(row))
+                {
+                    int length = col.Length;
+                    if (columnLengths[i] < length)
+                    {
+                        columnLengths[i] = length;
+                    }
+                }
+            }
+
+            // Prints column names (into /dev/stderr):
+            foreach ((int i, string col) in RowToStrings(header))
+            {
+                int length = columnLengths[i];
+                Console.Error.Write(i > 0 ? $" {{0,-{length}}}" : $"{{0,-{length}}}", col);
+            }
+
+            Console.Error.WriteLine();
+
+            // Prints horizontal lines (into /dev/stderr):
+            foreach ((int i, string col) in RowToStrings(header))
+            {
+                Console.Error.Write(i > 0 ? " {0}" : "{0}", new string('-', columnLengths[i]));
+            }
+
+            Console.Error.WriteLine();
+            Console.Error.Flush();
+
+            // Print rows:
+            foreach (T row in rowsArray)
+            {
+                foreach ((int i, string col) in RowToStrings(row))
+                {
+                    int length = columnLengths[i];
+                    Console.Write(i > 0 ? $" {{0,-{length}}}" : $"{{0,-{length}}}", col);
+                }
+
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ NineChronicles.Headless.Executable
 Commands:
   validation
   chain
+  key
 
 Options:
   --no-miner


### PR DESCRIPTION
This pull request introduces `key` subcommand to handle `IKeyStore` in command line. This uses the copy of `Libplanet.Tools`' `key` subcommand. They should be replaced if https://github.com/planetarium/libplanet/pull/1210 accepted.