### PR TITLE
fix(graphql): resolve manually for field

### DIFF
--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/DecimalStatType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/DecimalStatType.cs
@@ -8,7 +8,9 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
     {
         public DecimalStatType()
         {
-            Field<NonNullGraphType<StatTypeEnumType>>(nameof(DecimalStat.Type));
+            Field<NonNullGraphType<StatTypeEnumType>>(
+                nameof(DecimalStat.Type),
+                resolve: context => context.Source.Type);
             Field<NonNullGraphType<DecimalGraphType>>(nameof(DecimalStat.Value));
         }
     }


### PR DESCRIPTION
It fixes #358 by resolving `DecimalStat.Type` manually because `DecimalStat.Type` is field, not property.