### PR TITLE
feat(cli): add `--no-passphrase` option into `key` command

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/KeyCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/KeyCommandTest.cs
@@ -1,0 +1,34 @@
+using System;
+using Libplanet.Crypto;
+using Libplanet.Extensions.Cocona.Commands;
+using Libplanet.KeyStore;
+using NineChronicles.Headless.Executable.Tests.KeyStore;
+using Xunit;
+
+namespace NineChronicles.Headless.Executable.Tests.Commands
+{
+    public class KeyCommandTest
+    {
+        private readonly IKeyStore _keyStore;
+        private readonly KeyCommand _keyCommand;
+
+        public KeyCommandTest()
+        {
+            _keyStore = new InMemoryKeyStore();
+            _keyCommand = new KeyCommand(_keyStore);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("foo", "bar")]
+        public void Remove_ByForce(string passphrase, string inputPassphrase)
+        {
+            PrivateKey privateKey = new PrivateKey();
+            Guid keyId = _keyStore.Add(ProtectedPrivateKey.Protect(privateKey, passphrase));
+            
+            Assert.Contains(keyId, _keyStore.ListIds());
+            _keyCommand.Remove(keyId, passphrase: inputPassphrase, force: true);
+            Assert.DoesNotContain(keyId, _keyStore.ListIds());
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable.Tests/Commands/KeyCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/KeyCommandTest.cs
@@ -21,13 +21,13 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         [Theory]
         [InlineData("", "")]
         [InlineData("foo", "bar")]
-        public void Remove_ByForce(string passphrase, string inputPassphrase)
+        public void Remove_WithNoPassphrase(string passphrase, string inputPassphrase)
         {
             PrivateKey privateKey = new PrivateKey();
             Guid keyId = _keyStore.Add(ProtectedPrivateKey.Protect(privateKey, passphrase));
             
             Assert.Contains(keyId, _keyStore.ListIds());
-            _keyCommand.Remove(keyId, passphrase: inputPassphrase, force: true);
+            _keyCommand.Remove(keyId, passphrase: inputPassphrase, noPassphrase: true);
             Assert.DoesNotContain(keyId, _keyStore.ListIds());
         }
     }

--- a/NineChronicles.Headless.Executable.Tests/KeyStore/InMemoryKeyStore.cs
+++ b/NineChronicles.Headless.Executable.Tests/KeyStore/InMemoryKeyStore.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet.KeyStore;
+
+namespace NineChronicles.Headless.Executable.Tests.KeyStore
+{
+    public class InMemoryKeyStore : IKeyStore
+    {
+        private IDictionary<Guid, ProtectedPrivateKey> _protectedPrivateKeys;
+
+        public InMemoryKeyStore()
+        {
+            _protectedPrivateKeys = new Dictionary<Guid, ProtectedPrivateKey>();
+        }
+        
+        public IEnumerable<Guid> ListIds()
+        {
+            return _protectedPrivateKeys.Keys;
+        }
+
+        public IEnumerable<Tuple<Guid, ProtectedPrivateKey>> List()
+        {
+            return _protectedPrivateKeys.Select(pair => new Tuple<Guid, ProtectedPrivateKey>(pair.Key, pair.Value));
+        }
+
+        public ProtectedPrivateKey Get(Guid id)
+        {
+            return _protectedPrivateKeys[id];
+        }
+
+        public Guid Add(ProtectedPrivateKey key)
+        {
+            Guid guid = Guid.NewGuid();
+            _protectedPrivateKeys.Add(guid, key);
+            return guid;
+        }
+
+        public void Remove(Guid id)
+        {
+            _protectedPrivateKeys.Remove(id);
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable/Commands/KeyCommands.cs
+++ b/NineChronicles.Headless.Executable/Commands/KeyCommands.cs
@@ -12,9 +12,9 @@ namespace Libplanet.Extensions.Cocona.Commands
 
     public class KeyCommand
     {
-        public KeyCommand()
+        public KeyCommand(IKeyStore keyStore)
         {
-            KeyStore = Web3KeyStore.DefaultKeyStore;
+            KeyStore = keyStore;
         }
 
         public IKeyStore KeyStore { get; }

--- a/NineChronicles.Headless.Executable/Commands/KeyCommands.cs
+++ b/NineChronicles.Headless.Executable/Commands/KeyCommands.cs
@@ -50,12 +50,12 @@ namespace Libplanet.Extensions.Cocona.Commands
                 Description = "Take passphrase through this option instead of prompt."
             )]
             string? passphrase = null,
-            bool force = false
+            bool noPassphrase = false
         )
         {
             try
             {
-                if (!force)
+                if (!noPassphrase)
                 {
                     UnprotectKey(keyId, passphrase);
                 }

--- a/NineChronicles.Headless.Executable/Commands/KeyCommands.cs
+++ b/NineChronicles.Headless.Executable/Commands/KeyCommands.cs
@@ -49,12 +49,16 @@ namespace Libplanet.Extensions.Cocona.Commands
                 ValueName = "PASSPHRASE",
                 Description = "Take passphrase through this option instead of prompt."
             )]
-            string? passphrase = null
+            string? passphrase = null,
+            bool force = false
         )
         {
             try
             {
-                UnprotectKey(keyId, passphrase);
+                if (!force)
+                {
+                    UnprotectKey(keyId, passphrase);
+                }
                 KeyStore.Remove(keyId);
             }
             catch (NoKeyException)

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -42,7 +42,11 @@ namespace NineChronicles.Headless.Executable
             using var _ = SentrySdk.Init(ConfigureSentryOptions);
 #endif
             await CoconaLiteApp.Create()
-                .ConfigureServices(services => services.AddSingleton<IConsole, StandardConsole>())
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<IConsole, StandardConsole>();
+                    services.AddSingleton<IKeyStore>(Web3KeyStore.DefaultKeyStore);
+                })
                 .RunAsync<Program>(args);
         }
 


### PR DESCRIPTION
It introduces a new option `--no-passphrase` to remove key without passphrase. I also suggested to https://github.com/planetarium/libplanet/issues/1213.