### PR TITLE
fix: support monorocksdb also in `chain tip` command

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -30,6 +30,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         [Theory]
         [InlineData(StoreType.Default)]
         [InlineData(StoreType.RocksDb)]
+        [InlineData(StoreType.MonoRocksDb)]
         public void Tip(StoreType storeType)
         {
             Block<NCAction> genesisBlock = BlockChain<NCAction>.MakeGenesisBlock();

--- a/NineChronicles.Headless.Executable.Tests/Store/IStoreExtensionsTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Store/IStoreExtensionsTest.cs
@@ -21,6 +21,7 @@ namespace NineChronicles.Headless.Executable.Tests.Store
         [Theory]
         [InlineData(StoreType.Default)]
         [InlineData(StoreType.RocksDb)]
+        [InlineData(StoreType.MonoRocksDb)]
         public void GetGenesisBlock(StoreType storeType)
         {
             IStore store = storeType.CreateStore(_storePath);
@@ -38,6 +39,7 @@ namespace NineChronicles.Headless.Executable.Tests.Store
         [Theory]
         [InlineData(StoreType.Default)]
         [InlineData(StoreType.RocksDb)]
+        [InlineData(StoreType.MonoRocksDb)]
         public void GetGenesisBlock_ThrowsInvalidOperationException_IfChainIdNotExist(StoreType storeType)
         {
             IStore store = storeType.CreateStore(_storePath);

--- a/NineChronicles.Headless.Executable.Tests/Store/StoreTypeExtensionsTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Store/StoreTypeExtensionsTest.cs
@@ -17,6 +17,7 @@ namespace NineChronicles.Headless.Executable.Tests.Store
         }
 
         [Theory]
+        [InlineData(StoreType.MonoRocksDb, typeof(MonoRocksDBStore))]
         [InlineData(StoreType.RocksDb, typeof(RocksDBStore))]
         [InlineData(StoreType.Default, typeof(DefaultStore))]
         public void ToStoreConstructor(StoreType storeType, Type expectedType)

--- a/NineChronicles.Headless.Executable/Store/StoreType.cs
+++ b/NineChronicles.Headless.Executable/Store/StoreType.cs
@@ -2,6 +2,7 @@ namespace NineChronicles.Headless.Executable.Store
 {
     public enum StoreType
     {
+        MonoRocksDb,
         RocksDb,
         Default,
     }

--- a/NineChronicles.Headless.Executable/Store/StoreTypeExtensions.cs
+++ b/NineChronicles.Headless.Executable/Store/StoreTypeExtensions.cs
@@ -8,6 +8,7 @@ namespace NineChronicles.Headless.Executable.Store
     {
         public static IStore CreateStore(this StoreType storeType, string storePath) => storeType switch
         {
+            StoreType.MonoRocksDb => new MonoRocksDBStore(storePath),
             StoreType.RocksDb => new RocksDBStore(storePath),
             StoreType.Default => new DefaultStore(storePath),
             _ => throw new ArgumentOutOfRangeException(nameof(storeType))


### PR DESCRIPTION
#354 introduced `monorocksdb` but `chain tip` subcommand didn't apply it. It resolves the issue.