### PR TITLE
ci(gh-actions): fix invalid action input

### DIFF
--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -9,10 +9,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          submodules: recursive
           node-version: '14'
       - name: Cache node modules
         uses: actions/cache@v2


### PR DESCRIPTION
The workflow `deploy_gh_pages` was introduced in https://github.com/planetarium/NineChronicles.Headless/pull/331. Since https://github.com/planetarium/NineChronicles.Headless/pull/331, the `actions/checkout` action hasn't had `submodules` input and `actions/setup-node` action has had incorrect input. This pull request fixes it.