### PR TITLE
ci: add auto-assign bot

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+addReviewers: true
+addAssignees: author
+
+reviewers:
+    - longfin
+    - ipdae
+    - area363
+    - moreal


### PR DESCRIPTION
Hello @planetarium/9c-backend, I suggest to use *auto-assign* bot to automate assign reviewers and assignees.