### PR TITLE
Replace transferGold() with transfer()

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -100,7 +100,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.BlockChain;
 
-            Address senderAddress = service.MinerPrivateKey!.ToAddress();
+            Address senderAddress = _privateKey.ToAddress();
 
             var blockChain = StandaloneContextFx.BlockChain;
             var store = service.Store;

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -87,7 +87,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
         }
 
         [Fact]
-        public async Task Trasnfer()
+        public async Task Transfer()
         {
             var goldCurrency = new Currency("NCG", 2, minter: null);
             Block<PolymorphicAction<ActionBase>> genesis =

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -87,6 +87,64 @@ namespace NineChronicles.Headless.Tests.GraphTypes
         }
 
         [Fact]
+        public async Task Trasnfer()
+        {
+            var goldCurrency = new Currency("NCG", 2, minter: null);
+            Block<PolymorphicAction<ActionBase>> genesis =
+                MakeGenesisBlock(
+                    default,
+                    goldCurrency,
+                    ImmutableHashSet<Address>.Empty
+                );
+            NineChroniclesNodeService service = ServiceBuilder.CreateNineChroniclesNodeService(genesis, new PrivateKey());
+            StandaloneContextFx.NineChroniclesNodeService = service;
+            StandaloneContextFx.BlockChain = service.BlockChain;
+
+            Address senderAddress = service.MinerPrivateKey!.ToAddress();
+
+            var blockChain = StandaloneContextFx.BlockChain;
+            var store = service.Store;
+            await blockChain.MineBlock(senderAddress);
+            await blockChain.MineBlock(senderAddress);
+
+            // 10 + 10 (mining rewards)
+            Assert.Equal(
+                20 * goldCurrency,
+                blockChain.GetBalance(senderAddress, goldCurrency)
+            );
+
+            Address recipient = new PrivateKey().ToAddress();
+            long txNonce = blockChain.GetNextTxNonce(senderAddress);
+            var query = $"mutation {{ transfer(recipient: \"{recipient}\", txNonce: {txNonce}, amount: \"17.5\") }}";
+            ExecutionResult result = await ExecuteQueryAsync(query);
+
+            var stagedTxIds = blockChain.GetStagedTransactionIds().ToImmutableList();
+            Assert.Single(stagedTxIds);
+
+            var expectedResult = new Dictionary<string, object>
+            {
+                ["transfer"] = stagedTxIds.Single().ToString(),
+            };
+            Assert.Null(result.Errors);
+            Assert.Equal(expectedResult, result.Data);
+
+            await blockChain.MineBlock(recipient);
+
+            // 10 + 10 - 17.5(transfer)
+            Assert.Equal(
+                FungibleAssetValue.Parse(goldCurrency, "2.5"),
+                blockChain.GetBalance(senderAddress, goldCurrency)
+            );
+
+            // 0 + 17.5(transfer) + 10(mining reward)
+            Assert.Equal(
+                FungibleAssetValue.Parse(goldCurrency, "27.5"),
+                blockChain.GetBalance(recipient, goldCurrency)
+            );
+
+        }
+
+        [Fact]
         public async Task TransferGold()
         {
             var goldCurrency = new Currency("NCG", 2, minter: null);

--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -157,7 +157,7 @@ namespace NineChronicles.Headless.GraphTypes
             ).AuthorizeWith(GraphQLService.UserPolicyKey);
 
             Field<TxIdType>(
-                deprecationReason: "Incorrect remittance may occur when doing to the same address consecutively. Use transfer() instead.",
+                deprecationReason: "Incorrect remittance may occur when using transferGold() to the same address consecutively. Use transfer() instead.",
                 name: "transferGold",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<AddressType>>


### PR DESCRIPTION
This PR adds new field(`transfer()`) to the mutation to replacing `transferGold()` that calculated transaction nonce automatically. (it's very handy but it also easy to make mistakes.)

it closes #387