### PR TITLE
Maintain given static peers

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -58,5 +58,7 @@ namespace Libplanet.Headless.Hosting
         public TimeSpan TipTimeout { get; set; } = TimeSpan.FromSeconds(60);
 
         public int DemandBuffer { get; set; } = 1150;
+
+        public IEnumerable<Peer> StaticPeers { get; set; }
     }
 }

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -155,7 +155,10 @@ namespace NineChronicles.Headless.Executable
             [Option(Description =
                 "A number that determines how far behind the demand the tip of the chain " +
                 "will publish `NodeException` to GraphQL subscriptions.  1150 blocks by default.")]
-            int demandBuffer = 1150
+            int demandBuffer = 1150,
+            [Option("static-peer",
+                Description = "A list of peers that the node will continue to maintain.")]
+            string[]? staticPeerStrings = null
         )
         {
 #if SENTRY || ! DEBUG
@@ -289,7 +292,8 @@ namespace NineChronicles.Headless.Executable
                         maximumTransactions: maximumTransactions,
                         messageTimeout: messageTimeout,
                         tipTimeout: tipTimeout,
-                        demandBuffer: demandBuffer);
+                        demandBuffer: demandBuffer,
+                        staticPeerStrings: staticPeerStrings);
 
 
                 if (rpcServer)

--- a/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
+++ b/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
@@ -45,6 +45,7 @@ namespace NineChronicles.Headless.Tests.Common
                 MessageTimeout = TimeSpan.FromMinutes(1),
                 TipTimeout = TimeSpan.FromMinutes(1),
                 DemandBuffer = 1150,
+                StaticPeers = ImmutableHashSet<Peer>.Empty,
             };
             return new NineChroniclesNodeService(privateKey, properties, null);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -153,7 +153,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             AppProtocolVersion appProtocolVersion,
             PublicKey appProtocolVersionSigner,
             Progress<PreloadState>? preloadProgress = null,
-            IEnumerable<Peer>? peers = null)
+            IEnumerable<Peer>? peers = null,
+            IEnumerable<Peer>? staticPeers = null)
             where T : IAction, new()
         {
             var properties = new LibplanetNodeServiceProperties<T>
@@ -170,6 +171,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = peers ?? ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = ImmutableHashSet<PublicKey>.Empty.Add(appProtocolVersionSigner),
+                StaticPeers = staticPeers ?? ImmutableHashSet<Peer>.Empty,
             };
 
             return new LibplanetNodeService<T>(

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -234,6 +234,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
+                StaticPeers = ImmutableHashSet<Peer>.Empty
             };
 
             var service = new NineChroniclesNodeService(userPrivateKey, properties, null);
@@ -376,6 +377,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
+                StaticPeers = ImmutableHashSet<Peer>.Empty,
             };
 
             return new NineChroniclesNodeService(privateKey, properties, null);

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -45,7 +45,8 @@ namespace NineChronicles.Headless.Properties
                 int maximumTransactions = 100,
                 int messageTimeout = 60,
                 int tipTimeout = 60,
-                int demandBuffer = 1150)
+                int demandBuffer = 1150,
+                string[]? staticPeerStrings = null)
         {
             var swarmPrivateKey = string.IsNullOrEmpty(swarmPrivateKeyString)
                 ? new PrivateKey()
@@ -53,9 +54,11 @@ namespace NineChronicles.Headless.Properties
 
             peerStrings ??= Array.Empty<string>();
             iceServerStrings ??= Array.Empty<string>();
+            staticPeerStrings ??= Array.Empty<string>();
 
             var iceServers = iceServerStrings.Select(PropertyParser.ParseIceServer).ToImmutableArray();
             var peers = peerStrings.Select(PropertyParser.ParsePeer).ToImmutableArray();
+            var staticPeers = staticPeerStrings.Select(PropertyParser.ParsePeer).ToImmutableArray();
 
             return new LibplanetNodeServiceProperties<NineChroniclesActionType>
             {
@@ -80,7 +83,8 @@ namespace NineChronicles.Headless.Properties
                 MaximumTransactions = maximumTransactions,
                 MessageTimeout = TimeSpan.FromSeconds(messageTimeout),
                 TipTimeout = TimeSpan.FromSeconds(tipTimeout),
-                DemandBuffer = demandBuffer
+                DemandBuffer = demandBuffer,
+                StaticPeers = staticPeers
             };
         }
 


### PR DESCRIPTION
This PR provides an option `--static-peer` which takes a list of peers to maintain, which will provide minimal countermeasures against eclipse attack.