### PR TITLE
add error log to `LibplanetNodeService<T>`

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -348,26 +348,29 @@ namespace Libplanet.Headless.Hosting
                     _preloadStatusHandlerAction(true);
                     try
                     {
-                        await Swarm.PreloadAsync(
-                            TimeSpan.FromSeconds(5),
-                            PreloadProgress,
-                            cancellationToken: cancellationToken
-                        );
-                    }
-                    catch (AggregateException e)
-                    {
-                        if (!_ignorePreloadFailure)
+                        try
                         {
-                            throw;
+                            await Swarm.PreloadAsync(
+                                TimeSpan.FromSeconds(5),
+                                PreloadProgress,
+                                cancellationToken: cancellationToken
+                            );
                         }
+                        catch (AggregateException e)
+                        {
+                            if (!_ignorePreloadFailure)
+                            {
+                                throw;
+                            }
 
-                        Log.Error(e, "{Message}", e.Message);
+                            Log.Error(e, "{Message}", e.Message);
+                        }
                     }
                     catch (Exception e)
                     {
                         Log.Error(
                             e,
-                            "An exception occurred during preload async: {Message}",
+                            $"An unexpected exception occurred during {nameof(Swarm.PreloadAsync)}: {{Message}}",
                             e.Message
                         );
                     }

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -363,6 +363,14 @@ namespace Libplanet.Headless.Hosting
 
                         Log.Error(e, "{Message}", e.Message);
                     }
+                    catch (Exception e)
+                    {
+                        Log.Error(
+                            e,
+                            "An exception occurred during preload async: {Message}",
+                            e.Message
+                        );
+                    }
 
                     PreloadEnded.Set();
                     _preloadStatusHandlerAction(false);

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -348,22 +348,18 @@ namespace Libplanet.Headless.Hosting
                     _preloadStatusHandlerAction(true);
                     try
                     {
-                        try
+                        await Swarm.PreloadAsync(
+                            TimeSpan.FromSeconds(5),
+                            PreloadProgress,
+                            cancellationToken: cancellationToken
+                        );
+                    }
+                    catch (AggregateException e)
+                    {
+                        Log.Error(e, "{Message}", e.Message);
+                        if (!_ignorePreloadFailure)
                         {
-                            await Swarm.PreloadAsync(
-                                TimeSpan.FromSeconds(5),
-                                PreloadProgress,
-                                cancellationToken: cancellationToken
-                            );
-                        }
-                        catch (AggregateException e)
-                        {
-                            if (!_ignorePreloadFailure)
-                            {
-                                throw;
-                            }
-
-                            Log.Error(e, "{Message}", e.Message);
+                            throw;
                         }
                     }
                     catch (Exception e)
@@ -373,6 +369,10 @@ namespace Libplanet.Headless.Hosting
                             $"An unexpected exception occurred during {nameof(Swarm.PreloadAsync)}: {{Message}}",
                             e.Message
                         );
+                        if (!_ignorePreloadFailure)
+                        {
+                            throw;
+                        }
                     }
 
                     PreloadEnded.Set();


### PR DESCRIPTION
This PR logs the overall error messages when `LibplanetNodeService` is disposed during preloading.