### PR TITLE
feat(graphql) introduce `actionEvaluations` subscription

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/ActionEvaluationTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionEvaluationTypeTest.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Bencodex;
+using GraphQL;
+using Libplanet;
+using Nekoyume.Action;
+using NineChronicles.Headless.GraphTypes;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests.GraphTypes
+{
+    public class ActionEvaluationTypeTest
+    {
+        [Fact]
+        public async Task Query()
+        {
+            var action = new Buy
+            {
+                purchaseInfos = ImmutableArray<PurchaseInfo>.Empty,
+                buyerAvatarAddress = default,
+                buyerMultipleResult = default,
+                sellerMultipleResult = default,
+            };
+            const long blockIndex = 1000;
+  
+            var actionEvaluation = new ActionBase.ActionEvaluation<ActionBase>
+            {
+                Action = action,
+                Signer = default,
+                BlockIndex = blockIndex,
+            };
+
+            var result = await GraphQLTestUtils.ExecuteQueryAsync<ActionEvaluationType>(@"
+            query {
+                action
+                signer
+                blockIndex
+            }
+            ", source: actionEvaluation);
+
+            var expected = new Dictionary<string, object>
+            {
+                ["action"] = ByteUtil.Hex(new Codec().Encode(action.PlainValue)),
+                ["signer"] = default(Address).ToString(),
+                ["blockIndex"] = blockIndex,
+            };
+            Dictionary<string, object> actual = result.Data.As<Dictionary<string, object>>();
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;

--- a/NineChronicles.Headless/GraphTypes/ActionEvaluationType.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionEvaluationType.cs
@@ -1,0 +1,22 @@
+using Bencodex;
+using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
+using Nekoyume.Action;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public class ActionEvaluationType : ObjectGraphType<ActionBase.ActionEvaluation<ActionBase>>
+    {
+        private static readonly Codec Codec = new Codec();
+
+        public ActionEvaluationType()
+        {
+            Field<NonNullGraphType<ByteStringType>>(name: "action",
+                resolve: context => Codec.Encode(context.Source.Action.PlainValue));
+            Field<NonNullGraphType<AddressType>>(name: "signer",
+                resolve: context => context.Source.Signer);
+            Field<NonNullGraphType<LongGraphType>>(name: "blockIndex",
+                resolve: context => context.Source.BlockIndex);
+        }
+    }
+}

--- a/NineChronicles.Headless/StandaloneContext.cs
+++ b/NineChronicles.Headless/StandaloneContext.cs
@@ -4,6 +4,7 @@ using Libplanet.KeyStore;
 using Libplanet.Net;
 using Libplanet.Headless;
 using Libplanet.Store;
+using Nekoyume.Action;
 using NineChronicles.Headless.GraphTypes;
 using NineChroniclesActionType = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
@@ -22,6 +23,7 @@ namespace NineChronicles.Headless
             = new ReplaySubject<DifferentAppProtocolVersionEncounter>();
         public ReplaySubject<Notification> NotificationSubject { get; } = new ReplaySubject<Notification>(1);
         public ReplaySubject<NodeException> NodeExceptionSubject { get; } = new ReplaySubject<NodeException>();
+        public ISubject<ActionBase.ActionEvaluation<ActionBase>>? ActionEvaluationSubject { get; set; }
         public NineChroniclesNodeService? NineChroniclesNodeService { get; set; }
         public NodeStatusType NodeStatus => new NodeStatusType()
         {

--- a/NineChronicles.Headless/StandaloneServices.cs
+++ b/NineChronicles.Headless/StandaloneServices.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Reactive.Subjects;
 using Libplanet.Net;
 using Libplanet.Headless;
+using Nekoyume.Action;
 using NineChronicles.Headless.Properties;
 
 namespace NineChronicles.Headless
@@ -87,6 +89,7 @@ namespace NineChronicles.Headless
                     standaloneContext.PreloadEnded = true;
                     standaloneContext.NodeStatusSubject.OnNext(standaloneContext.NodeStatus);
                 });
+                standaloneContext.ActionEvaluationSubject = service.ActionRenderer.ActionRenderSubject;
             }
         }
     }


### PR DESCRIPTION
If you want to test this pull request on GraphQL Playground, you MUST run the headless with `--rpc-server` and `--rpc-server-port` option.

```graphql
subscription {
  actionEvaluations(type: "TransferAsset") {
    action
    blockIndex
    signer
  }
}
```