### PR TITLE
fix(graphql): use `BlockRenderer`'s subject directly

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
@@ -88,6 +89,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             {
                 BlockChain = blockChain,
                 KeyStore = keyStore,
+                BlockSubject = new ReplaySubject<(Block<NCAction> OldTip, Block<NCAction> NewTip)>(),
             };
 
             var configurationBuilder = new ConfigurationBuilder();
@@ -101,7 +103,6 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             services.AddSingleton<StateQuery>();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             Schema = new StandaloneSchema(serviceProvider);
-            Schema.Subscription.As<StandaloneSubscription>().RegisterTipChangedSubscription();
 
             DocumentExecutor = new DocumentExecuter();
         }

--- a/NineChronicles.Headless/GraphTypes/TipChangeEventType.cs
+++ b/NineChronicles.Headless/GraphTypes/TipChangeEventType.cs
@@ -1,0 +1,15 @@
+using GraphQL.Types;
+using Libplanet.Blocks;
+using Libplanet.Explorer.GraphTypes;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public class TipChangeEventType : ObjectGraphType<(long Index, BlockHash Hash)>
+    {
+        public TipChangeEventType()
+        {
+            Field<NonNullGraphType<LongGraphType>>("index", resolve: context => context.Source.Index);
+            Field<NonNullGraphType<ByteStringType>>("hash", resolve: context => context.Source.Hash.ToByteArray());
+        }
+    }
+}

--- a/NineChronicles.Headless/StandaloneContext.cs
+++ b/NineChronicles.Headless/StandaloneContext.cs
@@ -6,6 +6,7 @@ using Libplanet.Headless;
 using Libplanet.Store;
 using NineChronicles.Headless.GraphTypes;
 using NineChroniclesActionType = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+using NCBlock = Libplanet.Blocks.Block<Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>>;
 
 namespace NineChronicles.Headless
 {
@@ -18,6 +19,7 @@ namespace NineChronicles.Headless
         public bool IsMining { get; set; }
         public ReplaySubject<NodeStatusType> NodeStatusSubject { get; } = new ReplaySubject<NodeStatusType>();
         public ReplaySubject<PreloadState> PreloadStateSubject { get; } = new ReplaySubject<PreloadState>();
+        public ISubject<(NCBlock OldTip, NCBlock NewTip)>? BlockSubject { get; set; }
         public ReplaySubject<DifferentAppProtocolVersionEncounter> DifferentAppProtocolVersionEncounterSubject { get; }
             = new ReplaySubject<DifferentAppProtocolVersionEncounter>();
         public ReplaySubject<Notification> NotificationSubject { get; } = new ReplaySubject<Notification>(1);

--- a/NineChronicles.Headless/StandaloneServices.cs
+++ b/NineChronicles.Headless/StandaloneServices.cs
@@ -87,6 +87,7 @@ namespace NineChronicles.Headless
                     standaloneContext.PreloadEnded = true;
                     standaloneContext.NodeStatusSubject.OnNext(standaloneContext.NodeStatus);
                 });
+                standaloneContext.BlockSubject = service.BlockRenderer.BlockSubject;
             }
         }
     }


### PR DESCRIPTION
This pull request fixes `subscription.tipChanged` doesn't work and expects a small performance improvement by using `BlockRenderer.BlockSubject` directly, skipping one step.