### PR TITLE
rename query

### DIFF
--- a/NineChronicles.Headless/GraphQLServiceExtensions.cs
+++ b/NineChronicles.Headless/GraphQLServiceExtensions.cs
@@ -57,7 +57,7 @@ namespace NineChronicles.Headless
             services.TryAddSingleton<NodeStateType<T>>();
             services.TryAddSingleton<BlockQuery<T>>();
             services.TryAddSingleton<TransactionQuery<T>>();
-            services.TryAddSingleton<Query<T>>();
+            services.TryAddSingleton<ExplorerQuery<T>>();
 
             return services;
         }

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -85,7 +85,7 @@ namespace NineChronicles.Headless.GraphTypes
                 }
             );
 
-            Field<NonNullGraphType<Libplanet.Explorer.Queries.Query<NCAction>>>(
+            Field<NonNullGraphType<Libplanet.Explorer.Queries.ExplorerQuery<NCAction>>>(
                 name: "chainQuery",
                 resolve: context => new { }
             );


### PR DESCRIPTION
Renaming `Query<T>` to `ExplorerQuery<T>`. This PR should be merged after the [Libplanet PR #1293](https://github.com/planetarium/libplanet/pull/1293).