### PR TITLE
feat(graphql): add `transferNCGHistories` query

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -582,12 +582,14 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.NotNull(StandaloneContextFx.Store?.GetTxExecution(block.Hash, tx.Id));
 
             var blockHashHex = ByteUtil.Hex(block.Hash.ToByteArray());
-            var result = await ExecuteQueryAsync($"{{ transferNCGHistories(blockHash: \"{blockHashHex}\") {{ sender recipient amount }} }}");
+            var result = await ExecuteQueryAsync($"{{ transferNCGHistories(blockHash: \"{blockHashHex}\") {{ blockHash txId sender recipient amount }} }}");
             Assert.Null(result.Errors);
             Assert.Equal(new List<object>
             {
                 new Dictionary<string, object>
                 {
+                    ["blockHash"] = block.Hash.ToString(),
+                    ["txId"] = tx.Id.ToString(),
                     ["sender"] = transferAsset.Sender.ToString(),
                     ["recipient"] = transferAsset.Recipient.ToString(),
                     ["amount"] = transferAsset.Amount.RawValue,

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -578,7 +578,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var currency = new GoldCurrencyState((Dictionary)BlockChain.GetState(Addresses.GoldCurrency)).Currency;
             var transferAsset = new TransferAsset(sender, recipient, new FungibleAssetValue(currency, 10, 0));
             var tx = BlockChain.MakeTransaction(minerPrivateKey, new PolymorphicAction<ActionBase>[] { transferAsset });
-            var block = await BlockChain.MineBlock(minerPrivateKey.ToAddress());
+            var block = await BlockChain.MineBlock(minerPrivateKey.ToAddress(), append: false);
+            BlockChain.Append(block);
             Assert.NotNull(StandaloneContextFx.Store?.GetTxExecution(block.Hash, tx.Id));
 
             var blockHashHex = ByteUtil.Hex(block.Hash.ToByteArray());
@@ -592,7 +593,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                     ["txId"] = tx.Id.ToString(),
                     ["sender"] = transferAsset.Sender.ToString(),
                     ["recipient"] = transferAsset.Recipient.ToString(),
-                    ["amount"] = transferAsset.Amount.RawValue,
+                    ["amount"] = transferAsset.Amount.GetQuantityString(),
                 }
             }, result.Data.As<Dictionary<string, object>>()["transferNCGHistories"]);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/TransferNCGHistoryTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/TransferNCGHistoryTypeTest.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Libplanet;
+using Libplanet.Assets;
+using Libplanet.Crypto;
+using NineChronicles.Headless.GraphTypes;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests.GraphTypes
+{
+    public class TransferNCGHistoryTypeTest
+    {
+        [Fact]
+        public async Task Query()
+        {
+            Address sender = new PrivateKey().ToAddress(),
+                recipient = new PrivateKey().ToAddress();
+            Currency currency = new Currency("NCG", 2, minter: null);
+            FungibleAssetValue amount = new FungibleAssetValue(currency, 10, 10);
+            var result = await GraphQLTestUtils.ExecuteQueryAsync<TransferNCGHistoryType>(
+                "{ sender recipient amount }",
+                source: new TransferNCGHistory(sender, recipient, amount));
+            Assert.Equal(new Dictionary<string, object>
+            {
+                ["sender"] = sender.ToString(),
+                ["recipient"] = recipient.ToString(),
+                ["amount"] = amount.GetQuantityString(),
+            }, result.Data);
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/TransferNCGHistoryTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/TransferNCGHistoryTypeTest.cs
@@ -1,8 +1,12 @@
+using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Libplanet;
 using Libplanet.Assets;
+using Libplanet.Blocks;
 using Libplanet.Crypto;
+using Libplanet.Tx;
 using NineChronicles.Headless.GraphTypes;
 using Xunit;
 
@@ -13,15 +17,24 @@ namespace NineChronicles.Headless.Tests.GraphTypes
         [Fact]
         public async Task Query()
         {
+            Random random = new Random();
             Address sender = new PrivateKey().ToAddress(),
                 recipient = new PrivateKey().ToAddress();
             Currency currency = new Currency("NCG", 2, minter: null);
+            byte[] buffer = new byte[HashDigest<SHA256>.Size];
+            random.NextBytes(buffer);
+            BlockHash blockHash = new BlockHash(buffer);
+            buffer = new byte[TxId.Size];
+            random.NextBytes(buffer);
+            TxId txId = new TxId(buffer);
             FungibleAssetValue amount = new FungibleAssetValue(currency, 10, 10);
             var result = await GraphQLTestUtils.ExecuteQueryAsync<TransferNCGHistoryType>(
-                "{ sender recipient amount }",
-                source: new TransferNCGHistory(sender, recipient, amount));
+                "{ blockHash txId sender recipient amount }",
+                source: new TransferNCGHistory(blockHash, txId, sender, recipient, amount));
             Assert.Equal(new Dictionary<string, object>
             {
+                ["blockHash"] = blockHash.ToString(),
+                ["txId"] = txId.ToString(),
                 ["sender"] = sender.ToString(),
                 ["recipient"] = recipient.ToString(),
                 ["amount"] = amount.GetQuantityString(),

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -114,6 +114,8 @@ namespace NineChronicles.Headless.GraphTypes
                                 ? (rawTransferNcgHistories[1], rawTransferNcgHistories[0])
                                 : (rawTransferNcgHistories[0], rawTransferNcgHistories[1]);
                         return new TransferNCGHistory(
+                            txSuccess.BlockHash,
+                            txSuccess.TxId,
                             senderAddress,
                             recipientAddress,
                             amount);

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System;
+using System.Linq;
 using Bencodex;
 using Bencodex.Types;
 using GraphQL;
@@ -67,6 +69,61 @@ namespace NineChronicles.Headless.GraphTypes
                     return new Codec().Encode(state);
                 }
             );
+
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<TransferNCGHistoryType>>>>(
+                "transferNCGHistories",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<ByteStringType>>
+                    {
+                        Name = "blockHash"
+                    },
+                    new QueryArgument<AddressType>
+                    {
+                        Name = "recipient"
+                    }
+                ), resolve: context =>
+                {
+                    BlockHash blockHash = new BlockHash(context.GetArgument<byte[]>("blockHash"));
+
+                    if (!(standaloneContext.Store is { } store))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    if (!(store.GetBlock<NCAction>(blockHash) is { } block))
+                    {
+                        throw new ArgumentException("blockHash");
+                    }
+
+                    var recipient = context.GetArgument<Address?>("recipient");
+
+                    var txs = block.Transactions.Where(tx =>
+                        tx.Actions.Count == 1 &&
+                        tx.Actions.First().InnerAction is TransferAsset transferAsset &&
+                        (!recipient.HasValue || transferAsset.Recipient == recipient) &&
+                        transferAsset.Amount.Currency.Ticker == "NCG" &&
+                        store.GetTxExecution(blockHash, tx.Id) is TxSuccess);
+
+                    TransferNCGHistory ToTransferNCGHistory(TxSuccess txSuccess)
+                    {
+                        var rawTransferNcgHistories = txSuccess.FungibleAssetsDelta.Select(pair =>
+                                (pair.Key, pair.Value.Values.First(fav => fav.Currency.Ticker == "NCG")))
+                            .ToArray();
+                        var ((senderAddress, _), (recipientAddress, amount)) =
+                            rawTransferNcgHistories[0].Item2.RawValue > rawTransferNcgHistories[1].Item2.RawValue
+                                ? (rawTransferNcgHistories[1], rawTransferNcgHistories[0])
+                                : (rawTransferNcgHistories[0], rawTransferNcgHistories[1]);
+                        return new TransferNCGHistory(
+                            senderAddress,
+                            recipientAddress,
+                            amount);
+                    }
+
+                    var histories = txs.Select(tx =>
+                        ToTransferNCGHistory((TxSuccess) store.GetTxExecution(blockHash, tx.Id)));
+
+                    return histories;
+                });
 
             Field<KeyStoreType>(
                 name: "keyStore",

--- a/NineChronicles.Headless/GraphTypes/TransferNCGHistoryType.cs
+++ b/NineChronicles.Headless/GraphTypes/TransferNCGHistoryType.cs
@@ -7,6 +7,12 @@ namespace NineChronicles.Headless.GraphTypes
     {
         public TransferNCGHistoryType()
         {
+            Field<NonNullGraphType<ByteStringType>>(
+                name: "blockHash",
+                resolve: context => context.Source.BlockHash.ToByteArray());
+            Field<NonNullGraphType<ByteStringType>>(
+                name: "txId",
+                resolve: context => context.Source.TxId.ToByteArray());
             Field<NonNullGraphType<AddressType>>(
                 name: "sender",
                 resolve: context => context.Source.Sender);

--- a/NineChronicles.Headless/GraphTypes/TransferNCGHistoryType.cs
+++ b/NineChronicles.Headless/GraphTypes/TransferNCGHistoryType.cs
@@ -1,0 +1,21 @@
+using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public class TransferNCGHistoryType : ObjectGraphType<TransferNCGHistory>
+    {
+        public TransferNCGHistoryType()
+        {
+            Field<NonNullGraphType<AddressType>>(
+                name: "sender",
+                resolve: context => context.Source.Sender);
+            Field<NonNullGraphType<AddressType>>(
+                name: "recipient",
+                resolve: context => context.Source.Recipient);
+            Field<NonNullGraphType<StringGraphType>>(
+                name: "amount",
+                resolve: context => context.Source.Amount.GetQuantityString());
+        }
+    }
+}

--- a/NineChronicles.Headless/TransferNCGHistory.cs
+++ b/NineChronicles.Headless/TransferNCGHistory.cs
@@ -1,18 +1,31 @@
 using Libplanet;
 using Libplanet.Assets;
+using Libplanet.Blocks;
+using Libplanet.Tx;
 
 namespace NineChronicles.Headless
 {
     public class TransferNCGHistory
     {
+        public BlockHash BlockHash { get; }
+        
+        public TxId TxId { get; }
+
         public Address Sender { get; }
         
         public Address Recipient { get; }
 
         public FungibleAssetValue Amount { get; }
 
-        public TransferNCGHistory(Address sender, Address recipient, FungibleAssetValue amount)
+        public TransferNCGHistory(
+            BlockHash blockHash,
+            TxId txId,
+            Address sender,
+            Address recipient,
+            FungibleAssetValue amount)
         {
+            BlockHash = blockHash;
+            TxId = txId;
             Sender = sender;
             Recipient = recipient;
             Amount = amount;

--- a/NineChronicles.Headless/TransferNCGHistory.cs
+++ b/NineChronicles.Headless/TransferNCGHistory.cs
@@ -1,0 +1,21 @@
+using Libplanet;
+using Libplanet.Assets;
+
+namespace NineChronicles.Headless
+{
+    public class TransferNCGHistory
+    {
+        public Address Sender { get; }
+        
+        public Address Recipient { get; }
+
+        public FungibleAssetValue Amount { get; }
+
+        public TransferNCGHistory(Address sender, Address recipient, FungibleAssetValue amount)
+        {
+            Sender = sender;
+            Recipient = recipient;
+            Amount = amount;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces `query.transferNCGHistories` query to show the list of histories of NCG transfer event.