### PR TITLE
Use static peer in Liplanet

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -159,6 +159,7 @@ namespace Libplanet.Headless.Hosting
                 {
                     MaxTimeout = TimeSpan.FromSeconds(10),
                     BlockHashRecvTimeout = TimeSpan.FromSeconds(10),
+                    StaticPeers = Properties.StaticPeers,
                 }
             );
 
@@ -196,11 +197,6 @@ namespace Libplanet.Headless.Hosting
                         tasks.Add(CheckPeerTable(cancellationToken));
                     }
 
-                    if (Properties.StaticPeers.Any())
-                    {
-                        tasks.Add(
-                            CheckStaticPeersAsync(Properties.StaticPeers, cancellationToken));
-                    }
                     await await Task.WhenAny(tasks);
                 }
             });
@@ -540,41 +536,6 @@ namespace Libplanet.Headless.Hosting
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
-            }
-        }
-
-        private async Task CheckStaticPeersAsync(
-            IEnumerable<Peer> peers,
-            CancellationToken cancellationToken)
-        {
-            var peerArray = peers as Peer[] ?? peers.ToArray();
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                try
-                {
-                    await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
-                    Log.Warning("Checking static peers. {Peers}", peerArray);
-                    var peersToAdd = peerArray.Where(peer => !Swarm.Peers.Contains(peer)).ToArray();
-                    if (peersToAdd.Any())
-                    {
-                        Log.Warning("Some of peers are not in routing table. {Peers}", peersToAdd);
-                        await Swarm.AddPeersAsync(
-                            peersToAdd,
-                            TimeSpan.FromSeconds(5),
-                            cancellationToken);
-                    }
-                }
-                catch (OperationCanceledException e)
-                {
-                    Log.Warning(e, $"{nameof(CheckStaticPeersAsync)}() is cancelled.");
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    var msg = "Unexpected exception occurred during " +
-                              $"{nameof(CheckStaticPeersAsync)}(): {{0}}";
-                    Log.Warning(e, msg, e);
-                }
             }
         }
 

--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
@@ -59,7 +60,7 @@ namespace Libplanet.Headless.Hosting
 
         public int DemandBuffer { get; set; } = 1150;
 
-        public IEnumerable<Peer> StaticPeers { get; set; }
+        public ImmutableHashSet<BoundPeer> StaticPeers { get; set; }
 
         public bool Preload { get; set; } = true;
     }

--- a/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
+++ b/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
@@ -45,7 +45,7 @@ namespace NineChronicles.Headless.Tests.Common
                 MessageTimeout = TimeSpan.FromMinutes(1),
                 TipTimeout = TimeSpan.FromMinutes(1),
                 DemandBuffer = 1150,
-                StaticPeers = ImmutableHashSet<Peer>.Empty,
+                StaticPeers = ImmutableHashSet<BoundPeer>.Empty,
             };
             return new NineChroniclesNodeService(privateKey, properties, null);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -135,7 +135,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             PublicKey appProtocolVersionSigner,
             Progress<PreloadState>? preloadProgress = null,
             IEnumerable<Peer>? peers = null,
-            IEnumerable<Peer>? staticPeers = null)
+            ImmutableHashSet<BoundPeer>? staticPeers = null)
             where T : IAction, new()
         {
             var properties = new LibplanetNodeServiceProperties<T>
@@ -152,7 +152,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = peers ?? ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = ImmutableHashSet<PublicKey>.Empty.Add(appProtocolVersionSigner),
-                StaticPeers = staticPeers ?? ImmutableHashSet<Peer>.Empty,
+                StaticPeers = staticPeers ?? ImmutableHashSet<BoundPeer>.Empty,
             };
 
             return new LibplanetNodeService<T>(

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -403,7 +403,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
-                StaticPeers = ImmutableHashSet<Peer>.Empty
+                StaticPeers = ImmutableHashSet<BoundPeer>.Empty
             };
 
             var service = new NineChroniclesNodeService(userPrivateKey, properties, null);
@@ -778,7 +778,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
-                StaticPeers = ImmutableHashSet<Peer>.Empty,
+                StaticPeers = ImmutableHashSet<BoundPeer>.Empty,
             };
 
             return new NineChroniclesNodeService(privateKey, properties, null);

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -75,7 +75,7 @@ namespace NineChronicles.Headless.Properties
 
             var iceServers = iceServerStrings.Select(PropertyParser.ParseIceServer).ToImmutableArray();
             var peers = peerStrings.Select(PropertyParser.ParsePeer).ToImmutableArray();
-            var staticPeers = staticPeerStrings.Select(PropertyParser.ParsePeer).ToImmutableArray();
+            var staticPeers = staticPeerStrings.Select(PropertyParser.ParsePeer).ToImmutableHashSet();
 
             return new LibplanetNodeServiceProperties<NineChroniclesActionType>
             {


### PR DESCRIPTION
This patch use static peer implemented in Libplanet, and remove previous static peer checking task. Use `--static-peer {peer}` to use this option. 