### PR TITLE
Fix to broadcast right away

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -69,6 +69,11 @@ namespace NineChronicles.Headless.GraphTypes
                         if (blockChain.Policy.DoesTransactionFollowsPolicy(tx, blockChain))
                         {
                             blockChain.StageTransaction(tx);
+
+                            if (service?.Swarm is { } swarm && swarm.Running)
+                            {
+                                swarm.BroadcastTxs(new[] { tx });
+                            }
                             return true;
                         }
                         else


### PR DESCRIPTION
This PR forces `stageTx()` mutation to broadcast staged tx right away.