### PR TITLE
Fix timeout property

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -159,7 +159,7 @@ namespace Libplanet.Headless.Hosting
                 {
                     MaxTimeout = TimeSpan.FromSeconds(10),
                     BlockHashRecvTimeout = TimeSpan.FromSeconds(10),
-                    BlockDownloadTimeout = TimeSpan.FromSeconds(1),
+                    BlockRecvTimeout = TimeSpan.FromSeconds(1),
                     BranchpointThreshold = 50,
                     StaticPeers = Properties.StaticPeers,
                 }


### PR DESCRIPTION
This PR addresses an issue where `BlockRecvTimeout` was unintentionally incorrectly set to `BlockDownloadTimeout`.