### PR TITLE
Fixes delayed rendering ignored

### DIFF
--- a/Libplanet.Headless/BlockChainExtensions.cs
+++ b/Libplanet.Headless/BlockChainExtensions.cs
@@ -1,0 +1,20 @@
+#nullable enable
+using Libplanet.Action;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Renderers;
+using System.Linq;
+
+namespace Libplanet.Headless
+{
+    public static class BlockChainExtensions
+    {
+        public static DelayedRenderer<T>? GetDelayedRenderer<T>(this BlockChain<T> blockChain)
+            where T : IAction, new() =>
+            blockChain.Renderers
+                // We must strip LoggedRenderer since all renderer was warpped by it.
+                .OfType<LoggedRenderer<T>>()
+                .Select(r => r.Renderer)
+                .OfType<DelayedRenderer<T>>()
+                .FirstOrDefault();
+    }
+}

--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -19,30 +19,29 @@ using Nekoyume;
 using Nekoyume.Action;
 using Nekoyume.Shared.Services;
 using Serilog;
-using NineChroniclesActionType = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 using NodeExceptionType = Libplanet.Headless.NodeExceptionType;
+using Libplanet.Headless;
 
 namespace NineChronicles.Headless
 {
     public class BlockChainService : ServiceBase<IBlockChainService>, IBlockChainService
     {
-        private BlockChain<NineChroniclesActionType> _blockChain;
-        private Swarm<NineChroniclesActionType> _swarm;
+        private BlockChain<NCAction> _blockChain;
+        private Swarm<NCAction> _swarm;
         private RpcContext _context;
         private Codec _codec;
-        private LibplanetNodeServiceProperties<NineChroniclesActionType> _libplanetNodeServiceProperties;
-        private DelayedRenderer<NineChroniclesActionType> _delayedRenderer;
+        private LibplanetNodeServiceProperties<NCAction> _libplanetNodeServiceProperties;
+        private DelayedRenderer<NCAction> _delayedRenderer;
         public BlockChainService(
-            BlockChain<NineChroniclesActionType> blockChain,
-            Swarm<NineChroniclesActionType> swarm,
+            BlockChain<NCAction> blockChain,
+            Swarm<NCAction> swarm,
             RpcContext context,
-            LibplanetNodeServiceProperties<NineChroniclesActionType> libplanetNodeServiceProperties
+            LibplanetNodeServiceProperties<NCAction> libplanetNodeServiceProperties
         )
         {
             _blockChain = blockChain;
-            _delayedRenderer = blockChain.Renderers
-                .OfType<DelayedRenderer<NineChroniclesActionType>>()
-                .FirstOrDefault();
+            _delayedRenderer = blockChain.GetDelayedRenderer();
             _swarm = swarm;
             _context = context;
             _codec = new Codec();

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -19,7 +19,9 @@ using Nekoyume;
 using Nekoyume.Action;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
-using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>; 
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+using Libplanet.Blockchain.Renderers;
+using Libplanet.Headless;
 
 namespace NineChronicles.Headless.GraphTypes
 {
@@ -42,6 +44,12 @@ namespace NineChronicles.Headless.GraphTypes
                         byte[] bytes => new BlockHash(bytes),
                         null => null,
                     };
+
+                    if (standaloneContext.BlockChain is { } blockChain)
+                    {
+                        DelayedRenderer<NCAction>? delayedRenderer = blockChain.GetDelayedRenderer();
+                        blockHash = delayedRenderer?.Tip?.Hash;
+                    }
 
                     return (standaloneContext.BlockChain?.ToAccountStateGetter(blockHash),
                         standaloneContext.BlockChain?.ToAccountBalanceGetter(blockHash));


### PR DESCRIPTION
This PR fixes a bug where `stateQuery`(and `BlockChainService` for gRPC) had ignored delayed renderer.

To accomplish it, I added `BlockChainExtensions` to provide `GetDelayedRenderer<T>()` for `BlockChain<T>`.