### PR TITLE
Fixes a bug for terminated monster collection

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -288,6 +288,10 @@ namespace NineChronicles.Headless.GraphTypes
                         new MonsterCollectionState(state)
                     );
                 }
+                else
+                {
+                    StandaloneContext.MonsterCollectionStateSubject.OnNext(null!);
+                }
             }
 
         }


### PR DESCRIPTION
This PR fixes a bug where the monster collection subscription wasn't updated when the monster collection had been terminated. 