### PR TITLE
Add option for determining behavior when the chain's tip is stale

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -457,7 +457,8 @@ namespace Libplanet.Headless.Hosting
         {
             var lastTipChanged = DateTimeOffset.Now;
             var lastTip = BlockChain.Tip;
-            while (!cancellationToken.IsCancellationRequested)
+            bool exit = false;
+            while (!cancellationToken.IsCancellationRequested && !exit)
             {
                 await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
                 if (!Swarm.Running)
@@ -479,27 +480,45 @@ namespace Libplanet.Headless.Hosting
                     Log.Error(message);
 
                     // TODO: Use flag to determine behavior when the chain's tip is stale.
-                    try
+                    switch (Properties.ChainTipStaleBehavior)
                     {
-                        Log.Error("Start preloading due to staled tip.");
-                        await Swarm.PreloadAsync(
-                            TimeSpan.FromSeconds(5),
-                            PreloadProgress,
-                            cancellationToken: cancellationToken
-                        );
-                        Log.Error(
-                            "Preloading successfully finished. " +
-                            "(index: {Index}, hash: {Hash})",
-                            BlockChain.Tip?.Index,
-                            BlockChain.Tip?.Hash);
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error(
-                            e,
-                            $"An unexpected exception occurred during {nameof(Swarm.PreloadAsync)}: {{Message}}",
-                            e.Message
-                        );
+                        case "reboot":
+                            Properties.NodeExceptionOccurred(
+                                NodeExceptionType.TipNotChange,
+                                message);
+                            _stopRequested = true;
+                            exit = true;
+                            break;
+
+                        case "preload":
+                            try
+                            {
+                                Log.Error("Start preloading due to staled tip.");
+                                await Swarm.PreloadAsync(
+                                    TimeSpan.FromSeconds(5),
+                                    PreloadProgress,
+                                    render: true,
+                                    cancellationToken: cancellationToken
+                                );
+                                Log.Error(
+                                    "Preloading successfully finished. " +
+                                    "(index: {Index}, hash: {Hash})",
+                                    BlockChain.Tip?.Index,
+                                    BlockChain.Tip?.Hash);
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Error(
+                                    e,
+                                    $"An unexpected exception occurred during " +
+                                    $"{nameof(Swarm.PreloadAsync)}: {{Message}}",
+                                    e.Message
+                                );
+                            }
+                            break;
+
+                        default:
+                            throw new ArgumentException(nameof(Properties.ChainTipStaleBehavior));
                     }
                 }
 

--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -67,5 +67,7 @@ namespace Libplanet.Headless.Hosting
         public int MinimumBroadcastTarget { get; set; } = 10;
 
         public int BucketSize { get; set; } = 16;
+
+        public string ChainTipStaleBehavior { get; set; } = "reboot";
     }
 }

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -165,7 +165,11 @@ namespace NineChronicles.Headless.Executable
             int minimumBroadcastTarget = 10,
             [Option(Description =
                 "Number of the peers can be stored in each bucket.  16 by default.")]
-            int bucketSize = 16
+            int bucketSize = 16,
+            [Option(Description =
+                "Determines behavior when the chain's tip is stale. \"reboot\" and \"preload\" " +
+                "is available and \"reboot\" option is selected by default.")]
+            string chainTipStaleBehaviorType = "reboot"
         )
         {
 #if SENTRY || ! DEBUG
@@ -295,7 +299,8 @@ namespace NineChronicles.Headless.Executable
                         staticPeerStrings: staticPeerStrings,
                         preload: !skipPreload,
                         minimumBroadcastTarget: minimumBroadcastTarget,
-                        bucketSize: bucketSize
+                        bucketSize: bucketSize,
+                        chainTipStaleBehaviorType: chainTipStaleBehaviorType
                     );
 
                 if (rpcServer)

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -65,7 +65,8 @@ namespace NineChronicles.Headless.Properties
                 string[]? staticPeerStrings = null,
                 bool preload = true,
                 int minimumBroadcastTarget = 10,
-                int bucketSize = 16)
+                int bucketSize = 16,
+                string chainTipStaleBehaviorType = "reboot")
         {
             var swarmPrivateKey = string.IsNullOrEmpty(swarmPrivateKeyString)
                 ? new PrivateKey()
@@ -107,6 +108,7 @@ namespace NineChronicles.Headless.Properties
                 Preload = preload,
                 MinimumBroadcastTarget = minimumBroadcastTarget,
                 BucketSize = bucketSize,
+                ChainTipStaleBehavior = chainTipStaleBehaviorType,
             };
         }
 


### PR DESCRIPTION
Used `string` instead of `enum` because `LibplanetNodeServiceProperties<T>` is generic class and it's very annoying.