### PR TITLE
Introduce transaction result query

### DIFF
--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -13,7 +13,9 @@ using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 using System.Text.Json;
 using System.Linq;
 using System.Collections.Generic;
+using Libplanet.Blocks;
 using Libplanet.Crypto;
+using Libplanet.Store;
 using Newtonsoft.Json.Linq;
 
 namespace NineChronicles.Headless.GraphTypes
@@ -129,6 +131,56 @@ namespace NineChronicles.Headless.GraphTypes
 
                     return Convert.ToBase64String(signedTransaction.Serialize(true));
                 });
+            
+            Field<NonNullGraphType<TxResultType>>(
+                name: "transactionResult",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<TxIdType>>
+                        {Name = "txId", Description = "transaction id."}
+                ),
+                resolve: context =>
+                {
+                    if (!(standaloneContext.BlockChain is BlockChain<PolymorphicAction<ActionBase>> blockChain))
+                    {
+                        throw new ExecutionError(
+                            $"{nameof(StandaloneContext)}.{nameof(StandaloneContext.BlockChain)} was not set yet!");
+                    }
+
+                    if (!(standaloneContext.Store is IStore store))
+                    {
+                        throw new ExecutionError(
+                            $"{nameof(StandaloneContext)}.{nameof(StandaloneContext.Store)} was not set yet!");
+                    }
+                    
+                    TxId txId = context.GetArgument<TxId>("txId");
+                    BlockHash txExecutedBlockHash;
+                    try
+                    {
+                        txExecutedBlockHash = store
+                            .IterateTxIdBlockHashIndex(txId)
+                            .First(x => blockChain.ContainsBlock(x));
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        return store.IterateStagedTransactionIds().Contains(txId) 
+                            ? new TxResult(TxStatus.STAGING, null, null) 
+                            : new TxResult(TxStatus.INVALID, null, null);
+                    }
+
+                    TxExecution execution = blockChain.GetTxExecution(txExecutedBlockHash, txId);
+                    Block<PolymorphicAction<ActionBase>> txExecutedBlock = blockChain[txExecutedBlockHash];
+
+                    switch (execution)
+                    {
+                        case TxSuccess txSuccess:
+                            return new TxResult(TxStatus.SUCCESS, txExecutedBlock.Index, txExecutedBlock.Hash.ToString());
+                        case TxFailure txFailure:
+                            return new TxResult(TxStatus.FAILURE, txExecutedBlock.Index, txExecutedBlock.Hash.ToString());
+                        default:
+                            throw new NotImplementedException($"{nameof(execution)} is not expected concrete class.");
+                    }
+                }
+            );
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -153,23 +153,16 @@ namespace NineChronicles.Headless.GraphTypes
                     }
                     
                     TxId txId = context.GetArgument<TxId>("txId");
-                    BlockHash txExecutedBlockHash;
-                    try
+                    if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } txExecutedBlockHash))
                     {
-                        txExecutedBlockHash = store
-                            .IterateTxIdBlockHashIndex(txId)
-                            .First(x => blockChain.ContainsBlock(x));
-                    }
-                    catch (InvalidOperationException)
-                    {
-                        return store.IterateStagedTransactionIds().Contains(txId) 
-                            ? new TxResult(TxStatus.STAGING, null, null) 
+                        return store.IterateStagedTransactionIds().Contains(txId)
+                            ? new TxResult(TxStatus.STAGING, null, null)
                             : new TxResult(TxStatus.INVALID, null, null);
                     }
 
                     TxExecution execution = blockChain.GetTxExecution(txExecutedBlockHash, txId);
                     Block<PolymorphicAction<ActionBase>> txExecutedBlock = blockChain[txExecutedBlockHash];
-
+  
                     switch (execution)
                     {
                         case TxSuccess txSuccess:

--- a/NineChronicles.Headless/GraphTypes/TxResult.cs
+++ b/NineChronicles.Headless/GraphTypes/TxResult.cs
@@ -1,0 +1,16 @@
+﻿namespace NineChronicles.Headless.GraphTypes
+{
+    public class TxResult
+    {
+        public readonly TxStatus TxStatus;
+        public readonly long? BlockIndex;
+        public readonly string? BlockHash;
+
+        public TxResult(TxStatus status, long? blockIndex, string? blockHash)
+        {
+            TxStatus = status;
+            BlockIndex = blockIndex;
+            BlockHash = blockHash;
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/TxResultType.cs
+++ b/NineChronicles.Headless/GraphTypes/TxResultType.cs
@@ -1,0 +1,32 @@
+﻿using System.ComponentModel;
+using GraphQL.Types;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Tx;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public class TxResultType : ObjectGraphType<TxResult>
+    {
+        public TxResultType()
+        {
+            Field<NonNullGraphType<TxStatusType>>(
+                nameof(TxResult.TxStatus),
+                description: "The transaction status.",
+                resolve: context => context.Source.TxStatus
+            );
+
+            Field<LongGraphType>(
+                nameof(TxResult.BlockIndex),
+                description: "The block index which the target transaction executed.",
+                resolve: context => context.Source.BlockIndex
+            );
+
+            Field<StringGraphType>(
+                nameof(TxResult.BlockHash),
+                description: "The block hash which the target transaction executed.",
+                resolve: context => context.Source.BlockHash
+            );
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/TxStatusType.cs
+++ b/NineChronicles.Headless/GraphTypes/TxStatusType.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using GraphQL.Types;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    [Description("The result of querying transaction.")]
+    public enum TxStatus
+    {
+        [Description("The Transaction doesn't staged or invalid.")]
+        INVALID,
+        
+        [Description("The Transaction do not executed yet.")]
+        STAGING,
+        
+        [Description("The Transaction is success.")]
+        SUCCESS,
+        
+        [Description("The Transaction is failure.")]
+        FAILURE,
+    }
+
+    public class TxStatusType : EnumerationGraphType<TxStatus>
+    {
+        
+    }
+}


### PR DESCRIPTION
Since libplanet 0.13. introduce new API `TxExecution` for transaction execution summary. This PR implement support `TxExecution` on GraphQL Query.