### PR TITLE
Libplanet logging change

### DIFF
--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -6,8 +6,8 @@
             {
                 "Name": "Console",
                 "Args": {
-                    "outputTemplate": 
-                        "[{Timestamp:HH:mm:ss} {Level:u3}{SubLevel}] {Message:lj}{NewLine}{Exception}"
+                    "outputTemplate":
+                        "[{Timestamp:HH:mm:ss} {Level:u3}] {Source}{Message:lj}{NewLine}{Exception}"
                 }
             }
         ],


### PR DESCRIPTION
Should be merged after related [Lib9c PR](https://github.com/planetarium/lib9c/pull/558).

Additional logging information added to `Libplanet` as general QoL improvement.

Logging format `outputTemplate` in `appsettings.json` updated to relfect the changes in `Libplanet`.

---

[Libplanet PR](https://github.com/planetarium/libplanet/pull/1433)
[Lib9c PR](https://github.com/planetarium/lib9c/pull/558)
[NineChronicles.Headless PR](https://github.com/planetarium/NineChronicles.Headless/pull/626)