### PR TITLE
Tests involving crlf made OS independent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,22 +3,28 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  build-and-test:
-
-    runs-on: ${{ matrix.os }}
+  build-and-tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.301
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build and test
-      run: dotnet test --configuration Release --no-restore --verbosity normal
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.301
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build and test
+        run: dotnet test --configuration Release --no-restore --verbosity normal
+
+  build-and-test:
+    needs: [build-and-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,10 @@ on: [push, pull_request]
 jobs:
   build-and-test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -47,7 +47,9 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 
             _command.Tip(storeType, _storePath);
 
-            Assert.Equal(JsonSerializer.Serialize(genesisBlock.Header) + "\n",_console.Out.ToString());
+            Assert.Equal(
+                JsonSerializer.Serialize(genesisBlock.Header) + Environment.NewLine,
+                _console.Out.ToString());
         }
 
         public void Dispose()

--- a/NineChronicles.Headless.Executable.Tests/Commands/Key/ConversionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/Key/ConversionCommandTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Cocona;
 using NineChronicles.Headless.Executable.Commands;
 using NineChronicles.Headless.Executable.Commands.Key;
@@ -18,12 +19,12 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         }
 
         [Theory]
-        [InlineData("a1262b4f0911a9cec5e64344c0c9b50d64f8781ade0e09fa79faaa127ccdff89", true, false, "6BC0729733224139b16A4b1f18013C357d6be619\n")]
-        [InlineData("a1262b4f0911a9cec5e64344c0c9b50d64f8781ade0e09fa79faaa127ccdff89", false, true, "02910a0274ece8408a0a166f9a4f0527ad60431b4480d1c96f2c0f26cfe528e994\n")]
+        [InlineData("a1262b4f0911a9cec5e64344c0c9b50d64f8781ade0e09fa79faaa127ccdff89", true, false, "6BC0729733224139b16A4b1f18013C357d6be619")]
+        [InlineData("a1262b4f0911a9cec5e64344c0c9b50d64f8781ade0e09fa79faaa127ccdff89", false, true, "02910a0274ece8408a0a166f9a4f0527ad60431b4480d1c96f2c0f26cfe528e994")]
         public void PrivateKey(string privateKeyHex, bool address, bool publicKey, string expectedOutput)
         {
             _command.PrivateKey(privateKeyHex, publicKey, address);
-            Assert.Equal(expectedOutput, _console.Out.ToString());
+            Assert.Equal(expectedOutput + Environment.NewLine, _console.Out.ToString());
         }
 
         [Fact]

--- a/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ValidationCommandTest.cs
@@ -1,3 +1,4 @@
+using System;
 using NineChronicles.Headless.Executable.Commands;
 using NineChronicles.Headless.Executable.Tests.IO;
 using Xunit;
@@ -16,29 +17,29 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         }
 
         [Theory]
-        [InlineData("", -1, "The given private key, '', had an issue during parsing.\n")]
-        [InlineData("invalid hexadecimal", -1, "The given private key, 'invalid hexadecimal', had an issue during parsing.\n")]
-        [InlineData("000000000000000000000000000000000000000000000000000000000000000000", -1, "The given private key, '000000000000000000000000000000000000000000000000000000000000000000', had an issue during parsing.\n")]
+        [InlineData("", -1, "The given private key, '', had an issue during parsing.")]
+        [InlineData("invalid hexadecimal", -1, "The given private key, 'invalid hexadecimal', had an issue during parsing.")]
+        [InlineData("000000000000000000000000000000000000000000000000000000000000000000", -1, "The given private key, '000000000000000000000000000000000000000000000000000000000000000000', had an issue during parsing.")]
         [InlineData("ab8d591ccdcce263c39eb1f353e44b64869f0afea2df643bf6839ebde650d244", 0, "")]
         [InlineData("d6c3e0d525dac340a132ae05aaa9f3e278d61b70d2b71326570e64aee249e566", 0, "")]
         [InlineData("761f68d68426549df5904395b5ca5bce64a3da759085d8565242db42a5a1b0b9", 0, "")]
         public void PrivateKey(string privateKeyHex, int exitCode, string errorOutput)
         {
             Assert.Equal(exitCode, _command.PrivateKey(privateKeyHex));
-            Assert.Equal(errorOutput, _console.Error.ToString());
+            Assert.Equal(exitCode == 0 ? errorOutput : errorOutput + Environment.NewLine, _console.Error.ToString());
         }
-        
+
         [Theory]
-        [InlineData("", -1, "The given public key, '', had an issue during parsing.\n")]
-        [InlineData("invalid hexadecimal", -1, "The given public key, 'invalid hexadecimal', had an issue during parsing.\n")]
-        [InlineData("000000000000000000000000000000000000000000000000000000000000000000", -1, "The given public key, '000000000000000000000000000000000000000000000000000000000000000000', had an issue during parsing.\n")]
+        [InlineData("", -1, "The given public key, '', had an issue during parsing.")]
+        [InlineData("invalid hexadecimal", -1, "The given public key, 'invalid hexadecimal', had an issue during parsing.")]
+        [InlineData("000000000000000000000000000000000000000000000000000000000000000000", -1, "The given public key, '000000000000000000000000000000000000000000000000000000000000000000', had an issue during parsing.")]
         [InlineData("03b0868d9301b30c512d307ea67af4c8bef637ef099e39d32b808a43e6b41469c5", 0, "")]
         [InlineData("03308c1618a75e85a5fb57f7e453a642c307dc6310e90a7418b1aec565d963534a", 0, "")]
         [InlineData("028a6190bf643175b20e4a2d1d86fe6c4b8f7d5fe3d163632be4e59f83335824b8", 0, "")]
         public void PublicKey(string publicKeyHex, int exitCode, string errorOutput)
         {
             Assert.Equal(exitCode, _command.PublicKey(publicKeyHex));
-            Assert.Equal(errorOutput, _console.Error.ToString());
+            Assert.Equal(exitCode == 0 ? errorOutput : errorOutput + Environment.NewLine, _console.Error.ToString());
         }
     }
 }

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text.Json;
 using Cocona;
@@ -24,13 +25,13 @@ namespace NineChronicles.Headless.Executable.Commands
         {
             _console = console;
         }
-        
+
         [PrimaryCommand]
         public void Help([FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
         {
             _console.Out.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
         }
-        
+
         [Command(Description = "Print the tip's header of the chain placed at given store path.")]
         public void Tip(
             [Argument("STORE-TYPE")]
@@ -55,6 +56,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 new NoOpStateStore(),
                 genesisBlock);
             _console.Out.WriteLine(JsonSerializer.Serialize(chain.Tip.Header));
+            (store as IDisposable)?.Dispose();
         }
     }
 }

--- a/NineChronicles.Headless.Tests/Middleware/GraphQLSchemaMiddlewareTest.cs
+++ b/NineChronicles.Headless.Tests/Middleware/GraphQLSchemaMiddlewareTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -44,7 +45,9 @@ namespace NineChronicles.Headless.Tests.Middleware
 
             httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
             using var reader = new StreamReader(httpContext.Response.Body);
-            Assert.Equal("schema {\n  query: Fruit\n}\n\ntype Fruit {\n\n}\n", await reader.ReadToEndAsync());
+            Assert.Equal(
+                string.Format("schema {{{0}  query: Fruit{0}}}{0}{0}type Fruit {{{0}{0}}}{0}", Environment.NewLine),
+                await reader.ReadToEndAsync());
         }
     }
 }


### PR DESCRIPTION
Bunch of broken tests under Windows environment involving `\n` and `\r\n` fixed. Should now pass in both Linux and Windows.