### PR TITLE
Bump lib9c

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -169,7 +169,10 @@ namespace NineChronicles.Headless.Executable
             [Option(Description =
                 "Determines behavior when the chain's tip is stale. \"reboot\" and \"preload\" " +
                 "is available and \"reboot\" option is selected by default.")]
-            string chainTipStaleBehaviorType = "reboot"
+            string chainTipStaleBehaviorType = "reboot",
+            [Option(Description =
+                "The number of maximum transactions can be included in stage per signer.")]
+            int txQuotaPerSigner = 10
         )
         {
 #if SENTRY || ! DEBUG
@@ -328,6 +331,7 @@ namespace NineChronicles.Headless.Executable
                     AuthorizedMiner = authorizedMiner,
                     TxLifeTime = TimeSpan.FromMinutes(txLifeTime),
                     MinerCount = minerCount,
+                    TxQuotaPerSigner = txQuotaPerSigner
                 };
                 hostBuilder.ConfigureServices(services =>
                 {

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -324,8 +324,14 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
         [Theory]
         [MemberData(nameof(HackAndSlashMember))]
-        public async Task HackAndSlash(Address avatarAddress, int worldId, int stageId, Address weeklyArenaAddress,
-            Address rankingArenaAddress, List<Guid> costumeIds, List<Guid> equipmentIds, List<Guid> consumableIds)
+        public async Task HackAndSlash(
+            Address avatarAddress, 
+            int worldId, 
+            int stageId,
+            List<Guid> costumeIds, 
+            List<Guid> equipmentIds, 
+            List<Guid> consumableIds
+        )
         {
             var playerPrivateKey = new PrivateKey();
             var ranking = new RankingState();
@@ -333,7 +339,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             {
                 ranking.RankingMap[RankingState.Derive(i)] = new HashSet<Address>().ToImmutableHashSet();
             }
-            var queryArgs = $"avatarAddress: \"{avatarAddress}\", worldId: {worldId}, stageId: {stageId}, weeklyArenaAddress: \"{weeklyArenaAddress}\", rankingArenaAddress: \"{rankingArenaAddress}\"";
+            var queryArgs = $"avatarAddress: \"{avatarAddress}\", worldId: {worldId}, stageId: {stageId}";
             if (costumeIds.Any())
             {
                 queryArgs += $", costumeIds: [{string.Join(",", costumeIds.Select(r => string.Format($"\"{r}\"")))}]";
@@ -366,8 +372,6 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.Equal(avatarAddress, action.avatarAddress);
             Assert.Equal(worldId, action.worldId);
             Assert.Equal(stageId, action.stageId);
-            Assert.Equal(weeklyArenaAddress, action.WeeklyArenaAddress);
-            Assert.Equal(rankingArenaAddress, action.RankingMapAddress);
             Assert.Equal(costumeIds, action.costumes);
             Assert.Equal(equipmentIds, action.equipments);
             Assert.Equal(consumableIds, action.foods);
@@ -380,8 +384,6 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 new Address(),
                 1,
                 2,
-                new Address(),
-                new Address(),
                 new List<Guid>(),
                 new List<Guid>(),
                 new List<Guid>(),
@@ -391,8 +393,6 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 new Address(),
                 2,
                 3,
-                new Address(),
-                new Address(),
                 new List<Guid>
                 {
                     Guid.NewGuid(),

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/ArenaInfoTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/ArenaInfoTypeTest.cs
@@ -16,16 +16,12 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
         {
             const string query = @"
             {
-                agentAddress
                 avatarAddress
                 arenaRecord {
                     win
                     lose
                     draw
                 }
-                level
-                combatPoint
-                armorId
                 active
                 dailyChallengeCount
                 score
@@ -37,7 +33,6 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             Assert.Equal(
                 new Dictionary<string, object>
                 {
-                    ["agentAddress"] = "0xfc2a412ea59122B114B672a5518Bc113955Dd2FE",
                     ["avatarAddress"] = "0x983c3Fbfe8243a0e36D55C6C1aE26A7c8Bb6CBd4",
                     ["arenaRecord"] = new Dictionary<string, object>
                     {
@@ -45,9 +40,6 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                         ["lose"] = 0,
                         ["draw"] = 0,
                     },
-                    ["level"] = 1,
-                    ["combatPoint"] = 1142,
-                    ["armorId"] = 10200000,
                     ["active"] = active,
                     ["dailyChallengeCount"] = 5,
                     ["score"] = 1000,

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/WeeklyArenaStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/WeeklyArenaStateTypeTest.cs
@@ -20,16 +20,12 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 address
                 ended
                 orderedArenaInfos {
-                    agentAddress
                     avatarAddress
                     arenaRecord {
                         win
                         lose
                         draw
                     }
-                    level
-                    combatPoint
-                    armorId
                     active
                     dailyChallengeCount
                     score

--- a/NineChronicles.Headless/GraphTypes/ActionMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionMutation.cs
@@ -115,16 +115,6 @@ namespace NineChronicles.Headless.GraphTypes
                         Name = "stageId",
                         Description = "Stage ID."
                     },
-                    new QueryArgument<NonNullGraphType<AddressType>>
-                    {
-                        Name = "weeklyArenaAddress",
-                        Description = "Address of this WeeklyArenaState"
-                    },
-                    new QueryArgument<NonNullGraphType<AddressType>>
-                    {
-                        Name = "rankingArenaAddress",
-                        Description = "Address of RankingMapState containing the avatar address."
-                    },
                     new QueryArgument<ListGraphType<GuidGraphType>>
                     {
                         Name = "costumeIds",
@@ -151,8 +141,6 @@ namespace NineChronicles.Headless.GraphTypes
                             throw new InvalidOperationException($"{nameof(blockChain)} is null.");
                         }
 
-                        Address weeklyArenaAddress = context.GetArgument<Address>("weeklyArenaAddress");
-                        Address rankingArenaAddress = context.GetArgument<Address>("rankingArenaAddress");
                         Address avatarAddress = context.GetArgument<Address>("avatarAddress");
                         int worldId = context.GetArgument<int>("worldId");
                         int stageId = context.GetArgument<int>("stageId");
@@ -165,8 +153,6 @@ namespace NineChronicles.Headless.GraphTypes
                             avatarAddress = avatarAddress,
                             worldId = worldId,
                             stageId = stageId,
-                            WeeklyArenaAddress = weeklyArenaAddress,
-                            RankingMapAddress = rankingArenaAddress,
                             costumes = costumeIds,
                             equipments = equipmentIds,
                             foods = consumableIds,

--- a/NineChronicles.Headless/GraphTypes/States/ArenaInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/ArenaInfoType.cs
@@ -11,24 +11,9 @@ namespace NineChronicles.Headless.GraphTypes.States
             Field<NonNullGraphType<AddressType>>(
                 nameof(ArenaInfo.AvatarAddress),
                 resolve: context => context.Source.AvatarAddress);
-            Field<NonNullGraphType<AddressType>>(
-                nameof(ArenaInfo.AgentAddress),
-                resolve: context => context.Source.AgentAddress);
-            Field<NonNullGraphType<StringGraphType>>(
-                nameof(ArenaInfo.AvatarName),
-                resolve: context => context.Source.AvatarName);
             Field<NonNullGraphType<ArenaRecordType>>(
                 nameof(ArenaInfo.ArenaRecord),
                 resolve: context => context.Source.ArenaRecord);
-            Field<NonNullGraphType<IntGraphType>>(
-                nameof(ArenaInfo.Level),
-                resolve: context => context.Source.Level);
-            Field<NonNullGraphType<IntGraphType>>(
-                nameof(ArenaInfo.CombatPoint),
-                resolve: context => context.Source.CombatPoint);
-            Field<NonNullGraphType<IntGraphType>>(
-                nameof(ArenaInfo.ArmorId),
-                resolve: context => context.Source.ArmorId);
             Field<NonNullGraphType<BooleanGraphType>>(
                 nameof(ArenaInfo.Active),
                 resolve: context => context.Source.Active);

--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -82,7 +82,8 @@ namespace NineChronicles.Headless
             int blockInterval = 10000,
             int reorgInterval = 0,
             TimeSpan txLifeTime = default,
-            int minerCount = 1
+            int minerCount = 1,
+            int txQuotaPerSigner = 10
         )
         {
             MinerPrivateKey = minerPrivateKey;
@@ -95,10 +96,7 @@ namespace NineChronicles.Headless
             // Policies for dev mode.
             IBlockPolicy<NCAction>? easyPolicy = null;
             IBlockPolicy<NCAction>? hardPolicy = null;
-            IStagePolicy<NCAction> stagePolicy =
-                txLifeTime == default
-                    ? new VolatileStagePolicy<NCAction>()
-                    : new VolatileStagePolicy<NCAction>(txLifeTime);
+            IStagePolicy<NCAction> stagePolicy = new StagePolicy(txLifeTime, txQuotaPerSigner);
             if (isDev)
             {
                 easyPolicy = new ReorgPolicy(new RewardGold(), 1);
@@ -338,7 +336,8 @@ namespace NineChronicles.Headless
                 reorgInterval: properties.ReorgInterval,
                 authorizedMiner: properties.AuthorizedMiner,
                 txLifeTime: properties.TxLifeTime,
-                minerCount: properties.MinerCount
+                minerCount: properties.MinerCount,
+                txQuotaPerSigner: properties.TxQuotaPerSigner
             );
             service.ConfigureContext(context);
             return service;

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -39,6 +39,8 @@ namespace NineChronicles.Headless.Properties
 
         public int MinerCount { get; set; }
 
+        public int TxQuotaPerSigner { get; set; }
+
 
         public static LibplanetNodeServiceProperties<NineChroniclesActionType>
             GenerateLibplanetNodeServiceProperties(

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ```
 $ dotnet run --project ./NineChronicles.Headless.Executable/ -- --help
 Usage: NineChronicles.Headless.Executable [command]
-Usage: NineChronicles.Headless.Executable [--app-protocol-version <String>] [--genesis-block-path <String>] [--no-miner] [--host <String>] [--port <Nullable`1>] [--swarm-private-key <String>] [--minimum-difficulty <Int32>] [--miner-private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--graphql-secret-token-path <String>] [--no-cors] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-action-renders] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--authorized-miner] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--static-peer <String>...] [--miner-count <Int32>] [--skip-preload] [--minimum-broadcast-target <Int32>] [--bucket-size <Int32>] [--completion] [--help] [--version]
+Usage: NineChronicles.Headless.Executable [--app-protocol-version <String>] [--genesis-block-path <String>] [--no-miner] [--host <String>] [--port <Nullable`1>] [--swarm-private-key <String>] [--minimum-difficulty <Int32>] [--miner-private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--graphql-secret-token-path <String>] [--no-cors] [--workers <Int32>] [--confirmations <Int32>] [--max-transactions <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-action-renders] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--authorized-miner] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--static-peer <String>...] [--miner-count <Int32>] [--skip-preload] [--minimum-broadcast-target <Int32>] [--bucket-size <Int32>] [--chain-tip-stale-behavior-type <String>] [--tx-quota-per-signer <Int32>] [--completion] [--help] [--version]
 
 NineChronicles.Headless.Executable
 
@@ -24,6 +24,7 @@ Commands:
   validation
   chain
   key
+  apv
 
 Options:
   -V, --app-protocol-version <String>                      App protocol version token (Required)
@@ -69,6 +70,8 @@ Options:
   --skip-preload                                           Run node without preloading.
   --minimum-broadcast-target <Int32>                       Minimum number of peers to broadcast message.  10 by default. (Default: 10)
   --bucket-size <Int32>                                    Number of the peers can be stored in each bucket.  16 by default. (Default: 16)
+  --chain-tip-stale-behavior-type <String>                 Determines behavior when the chain's tip is stale. "reboot" and "preload" is available and "reboot" option is selected by default. (Default: reboot)
+  --tx-quota-per-signer <Int32>                            The number of maximum transactions can be included in stage per signer. (Default: 10)
   --completion                                             Generate a shell completion code
   -h, --help                                               Show help message
   --version                                                Show version
@@ -115,6 +118,7 @@ $ docker build . -t <IMAGE_TAG> --build-arg COMMIT=<VERSION_SUFFIX>
 - `--skip-preload`: Skipping preloading when starting.
 - `--minimum-broadcast-target`: Minimum number of the peers to broadcast messages.
 - `--bucket-size`: Specifies the number of the peers can be stored in each bucket.
+- `--tx-quota-per-signer`: Specifies the number of maximum transactions can be included in stage per signer.
 
 ### Format
 


### PR DESCRIPTION
This PR bumps lib9c and adds `--tx-quota-per-signer` to apply https://github.com/planetarium/lib9c/pull/600.

And, it also resolves to compile errors on GraphQL query and mutation by reflecting removed props.