### PR TITLE
Restore GraphQL API

### DIFF
--- a/NineChronicles.Headless/GraphTypes/States/ArenaInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/ArenaInfoType.cs
@@ -9,8 +9,14 @@ namespace NineChronicles.Headless.GraphTypes.States
         public ArenaInfoType()
         {
             Field<NonNullGraphType<AddressType>>(
+                nameof(ArenaInfo.AgentAddress),
+                resolve: context => context.Source.AgentAddress);
+            Field<NonNullGraphType<AddressType>>(
                 nameof(ArenaInfo.AvatarAddress),
                 resolve: context => context.Source.AvatarAddress);
+            Field<NonNullGraphType<StringGraphType>>(
+                nameof(ArenaInfo.AvatarName),
+                resolve: context => context.Source.AvatarName);
             Field<NonNullGraphType<ArenaRecordType>>(
                 nameof(ArenaInfo.ArenaRecord),
                 resolve: context => context.Source.ArenaRecord);


### PR DESCRIPTION
This PR bumps lib9c and restores AgentAddress and AvatarName for `ArenaInfoType`.