### PR TITLE
add chain inspect command

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -1,14 +1,23 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Libplanet;
+using Libplanet.Action;
 using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 using Libplanet.Store;
+using Nekoyume.Action;
+using Nekoyume.BlockChain;
 using NineChronicles.Headless.Executable.Commands;
 using NineChronicles.Headless.Executable.Store;
 using NineChronicles.Headless.Executable.Tests.IO;
+using Serilog.Core;
 using Xunit;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
@@ -20,6 +29,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         private readonly ChainCommand _command;
 
         private readonly string _storePath;
+        private readonly string _storePath2;
 
         public ChainCommandTest()
         {
@@ -27,6 +37,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             _command = new ChainCommand(_console);
 
             _storePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            _storePath2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         }
 
         [Theory]
@@ -54,11 +65,67 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             Assert.Equal(JsonSerializer.Serialize(genesisBlock.Header), _console.Out.ToString().Trim());
         }
 
+        [Theory]
+        [InlineData(StoreType.Default)]
+        [InlineData(StoreType.RocksDb)]
+        [InlineData(StoreType.MonoRocksDb)]
+        public async Task Inspect(StoreType storeType)
+        {
+            Block<NCAction> genesisBlock = BlockChain<NCAction>.MakeGenesisBlock(
+                HashAlgorithmType.Of<SHA256>()
+            );
+            IStore store = storeType.CreateStore(_storePath2);
+            Guid chainId = Guid.NewGuid();
+            store.SetCanonicalChainId(chainId);
+            store.PutBlock(genesisBlock);
+            store.AppendIndex(chainId, genesisBlock.Hash);
+
+            const int minimumDifficulty = 5000000, maximumTransactions = 100;
+            IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
+            IBlockPolicy<NCAction> blockPolicy = new BlockPolicySource(Logger.None).GetPolicy(minimumDifficulty, maximumTransactions);
+            BlockChain<NCAction> chain = new BlockChain<NCAction>(
+                blockPolicy,
+                stagePolicy,
+                store,
+                new NoOpStateStore(),
+                genesisBlock);
+
+            var action = new HackAndSlash
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 1,
+                avatarAddress = default
+            };
+
+            var minerKey = new PrivateKey();
+            var miner = minerKey.ToAddress();
+            chain.MakeTransaction(minerKey, new PolymorphicAction<ActionBase>[] { action });
+            await chain.MineBlock(miner, DateTimeOffset.Now);
+            store.Dispose();
+
+            _command.Inspect(storeType, _storePath2);
+            List<double> output = _console.Out.ToString().Split("\n")[1]
+                .Split(',').Select(double.Parse).ToList();
+            var totalTxCount = Convert.ToInt32(output[2]);
+            var hackandslashCount = Convert.ToInt32(output[3]);
+
+            Assert.Equal(1, totalTxCount);
+            Assert.Equal(1, hackandslashCount);
+        }
+
         public void Dispose()
         {
             if (Directory.Exists(_storePath))
             {
                 Directory.Delete(_storePath, true);
+            }
+
+            if (Directory.Exists(_storePath2))
+            {
+                Directory.Delete(_storePath2, true);
             }
         }
     }

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -134,99 +134,33 @@ namespace NineChronicles.Headless.Executable.Commands
                     txCount++;
                     foreach (var action in tx.Actions)
                     {
-                        if (action.InnerAction is HackAndSlash hackandslashAction)
+                        switch (action.InnerAction)
                         {
-                            hackandslashCount++;
-                        }
-
-                        if (action.InnerAction is HackAndSlash7 hackandslashAction7)
-                        {
-                            hackandslashCount++;
-                        }
-
-                        if (action.InnerAction is HackAndSlash6 hackandslashAction6)
-                        {
-                            hackandslashCount++;
-                        }
-
-                        if (action.InnerAction is HackAndSlash5 hackandslashAction5)
-                        {
-                            hackandslashCount++;
-                        }
-
-                        if (action.InnerAction is HackAndSlash4 hackandslashAction4)
-                        {
-                            hackandslashCount++;
-                        }
-
-                        if (action.InnerAction is HackAndSlash3 hackandslashAction3)
-                        {
-                            hackandslashCount++;
-                        }
-
-                        if (action.InnerAction is HackAndSlash2 hackandslashAction2)
-                        {
-                            hackandslashCount++;
-                        }
-
-                        if (action.InnerAction is HackAndSlash0 hackandslashAction0)
-                        {
-                            hackandslashCount++;
-                        }
-
-                        if (action.InnerAction is MimisbrunnrBattle mimisbrunnrAction)
-                        {
-                            mimisbrunnrCount++;
-                        }
-
-                        if (action.InnerAction is MimisbrunnrBattle4 mimisbrunnrAction4)
-                        {
-                            mimisbrunnrCount++;
-                        }
-
-                        if (action.InnerAction is MimisbrunnrBattle3 mimisbrunnrAction3)
-                        {
-                            mimisbrunnrCount++;
-                        }
-
-                        if (action.InnerAction is MimisbrunnrBattle2 mimisbrunnrAction2)
-                        {
-                            mimisbrunnrCount++;
-                        }
-
-                        if (action.InnerAction is MimisbrunnrBattle0 mimisbrunnrAction0)
-                        {
-                            mimisbrunnrCount++;
-                        }
-
-                        if (action.InnerAction is RankingBattle rankingbattleAction)
-                        {
-                            rankingbattleCount++;
-                        }
-
-                        if (action.InnerAction is RankingBattle5 rankingbattleAction5)
-                        {
-                            rankingbattleCount++;
-                        }
-
-                        if (action.InnerAction is RankingBattle4 rankingbattleAction4)
-                        {
-                            rankingbattleCount++;
-                        }
-
-                        if (action.InnerAction is RankingBattle3 rankingbattleAction3)
-                        {
-                            rankingbattleCount++;
-                        }
-
-                        if (action.InnerAction is RankingBattle2 rankingbattleAction2)
-                        {
-                            rankingbattleCount++;
-                        }
-
-                        if (action.InnerAction is RankingBattle0 rankingbattleAction0)
-                        {
-                            rankingbattleCount++;
+                            case HackAndSlash _:
+                            case HackAndSlash0 _:
+                            case HackAndSlash1 _:
+                            case HackAndSlash2 _:
+                            case HackAndSlash3 _:
+                            case HackAndSlash4 _:
+                            case HackAndSlash5 _:
+                            case HackAndSlash6 _:
+                                hackandslashCount++;
+                                break;
+                            caee MimisbrunnrBattle  _:
+                            caee MimisbrunnrBattle0  _:
+                            caee MimisbrunnrBattle2  _:
+                            caee MimisbrunnrBattle3  _:
+                            caee MimisbrunnrBattle4  _:
+                                mimisbrunnrCount++;
+                                break;
+                            case RankingBattle _:
+                            case RankingBattle0 _:
+                            case RankingBattle2 _:
+                            case RankingBattle3 _:
+                            case RankingBattle4 _:
+                            case RankingBattle5 _:
+                                rankingbattleCount++;
+                                break;
                         }
                     }
                 }

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -138,7 +138,6 @@ namespace NineChronicles.Headless.Executable.Commands
                         {
                             case HackAndSlash _:
                             case HackAndSlash0 _:
-                            case HackAndSlash1 _:
                             case HackAndSlash2 _:
                             case HackAndSlash3 _:
                             case HackAndSlash4 _:
@@ -146,11 +145,11 @@ namespace NineChronicles.Headless.Executable.Commands
                             case HackAndSlash6 _:
                                 hackandslashCount++;
                                 break;
-                            caee MimisbrunnrBattle  _:
-                            caee MimisbrunnrBattle0  _:
-                            caee MimisbrunnrBattle2  _:
-                            caee MimisbrunnrBattle3  _:
-                            caee MimisbrunnrBattle4  _:
+                            case MimisbrunnrBattle  _:
+                            case MimisbrunnrBattle0  _:
+                            case MimisbrunnrBattle2  _:
+                            case MimisbrunnrBattle3  _:
+                            case MimisbrunnrBattle4  _:
                                 mimisbrunnrCount++;
                                 break;
                             case RankingBattle _:

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using Cocona;
 using Cocona.Help;
@@ -56,6 +57,188 @@ namespace NineChronicles.Headless.Executable.Commands
                 new NoOpStateStore(),
                 genesisBlock);
             _console.Out.WriteLine(JsonSerializer.Serialize(chain.Tip.Header));
+            (store as IDisposable)?.Dispose();
+        }
+
+        [Command(Description = "Print each block's mining time and tx stats (total tx, hack and slash, ranking battle, " +
+                               "mimisbrunnr) of a given chain in csv format.")]
+        public void Inspect(
+            [Argument("STORE-TYPE",
+                Description = "Store type of RocksDb (rocksdb or monorocksdb).")]
+            StoreType storeType,
+            [Argument("STORE-PATH",
+                Description = "Store path to inspect.")]
+            string storePath,
+            [Argument("OFFSET",
+                Description = "Offset of block index.")]
+            int? offset = null,
+            [Argument("LIMIT",
+                Description = "Limit of block count.")]
+            int? limit = null)
+        {
+            if (!Directory.Exists(storePath))
+            {
+                throw new CommandExitedException($"The given STORE-PATH, {storePath} seems not existed.", -1);
+            }
+
+            const int minimumDifficulty = 5000000, maximumTransactions = 100;
+            IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
+            IBlockPolicy<NCAction> blockPolicy = new BlockPolicySource(Logger.None).GetPolicy(minimumDifficulty, maximumTransactions);
+            IStore store = storeType.CreateStore(storePath);
+            Block<NCAction> genesisBlock = store.GetGenesisBlock<NCAction>();
+            if (!(store.GetCanonicalChainId() is { } chainId))
+            {
+                throw new CommandExitedException($"There is no canonical chain: {storePath}", -1);
+            }
+
+            if (!(store.IndexBlockHash(chainId, 0) is { } gHash))
+            {
+                throw new CommandExitedException($"There is no genesis block: {storePath}", -1);
+            }
+
+            BlockChain<NCAction> chain = new BlockChain<NCAction>(
+                blockPolicy,
+                stagePolicy,
+                store,
+                new NoOpStateStore(),
+                genesisBlock);
+
+            long height = chain.Tip.Index;
+            if (offset + limit > (int)height)
+            {
+                throw new CommandExitedException(
+                    $"The sum of the offset and limit is greater than the chain tip index: {height}",
+                    -1);
+            }
+
+            _console.Out.WriteLine("Block Index," +
+                                   "Mining Time (sec)," +
+                                   "Total Tx #," +
+                                   "HAS #," +
+                                   "RankingBattle #," +
+                                   "Mimisbrunnr #");
+            foreach (var item in
+                store.IterateIndexes(chain.Id, offset + 1 ?? 1, limit).Select((value, i) => new { i, value }))
+            {
+                var block = store.GetBlock<NCAction>(item.value);
+
+                var previousBlock = store.GetBlock<NCAction>(block.PreviousHash ?? block.Hash);
+
+                var miningTime = block.Timestamp - previousBlock.Timestamp;
+                var txCount = 0;
+                var hackandslashCount = 0;
+                var rankingbattleCount = 0;
+                var mimisbrunnrCount = 0;
+                foreach (var tx in block.Transactions)
+                {
+                    txCount++;
+                    foreach (var action in tx.Actions)
+                    {
+                        if (action.InnerAction is HackAndSlash hackandslashAction)
+                        {
+                            hackandslashCount++;
+                        }
+
+                        if (action.InnerAction is HackAndSlash7 hackandslashAction7)
+                        {
+                            hackandslashCount++;
+                        }
+
+                        if (action.InnerAction is HackAndSlash6 hackandslashAction6)
+                        {
+                            hackandslashCount++;
+                        }
+
+                        if (action.InnerAction is HackAndSlash5 hackandslashAction5)
+                        {
+                            hackandslashCount++;
+                        }
+
+                        if (action.InnerAction is HackAndSlash4 hackandslashAction4)
+                        {
+                            hackandslashCount++;
+                        }
+
+                        if (action.InnerAction is HackAndSlash3 hackandslashAction3)
+                        {
+                            hackandslashCount++;
+                        }
+
+                        if (action.InnerAction is HackAndSlash2 hackandslashAction2)
+                        {
+                            hackandslashCount++;
+                        }
+
+                        if (action.InnerAction is HackAndSlash0 hackandslashAction0)
+                        {
+                            hackandslashCount++;
+                        }
+
+                        if (action.InnerAction is MimisbrunnrBattle mimisbrunnrAction)
+                        {
+                            mimisbrunnrCount++;
+                        }
+
+                        if (action.InnerAction is MimisbrunnrBattle4 mimisbrunnrAction4)
+                        {
+                            mimisbrunnrCount++;
+                        }
+
+                        if (action.InnerAction is MimisbrunnrBattle3 mimisbrunnrAction3)
+                        {
+                            mimisbrunnrCount++;
+                        }
+
+                        if (action.InnerAction is MimisbrunnrBattle2 mimisbrunnrAction2)
+                        {
+                            mimisbrunnrCount++;
+                        }
+
+                        if (action.InnerAction is MimisbrunnrBattle0 mimisbrunnrAction0)
+                        {
+                            mimisbrunnrCount++;
+                        }
+
+                        if (action.InnerAction is RankingBattle rankingbattleAction)
+                        {
+                            rankingbattleCount++;
+                        }
+
+                        if (action.InnerAction is RankingBattle5 rankingbattleAction5)
+                        {
+                            rankingbattleCount++;
+                        }
+
+                        if (action.InnerAction is RankingBattle4 rankingbattleAction4)
+                        {
+                            rankingbattleCount++;
+                        }
+
+                        if (action.InnerAction is RankingBattle3 rankingbattleAction3)
+                        {
+                            rankingbattleCount++;
+                        }
+
+                        if (action.InnerAction is RankingBattle2 rankingbattleAction2)
+                        {
+                            rankingbattleCount++;
+                        }
+
+                        if (action.InnerAction is RankingBattle0 rankingbattleAction0)
+                        {
+                            rankingbattleCount++;
+                        }
+                    }
+                }
+
+                _console.Out.WriteLine($"{block.Index}," +
+                                       $"{miningTime:s\\.ff}," +
+                                       $"{txCount}," +
+                                       $"{hackandslashCount}," +
+                                       $"{rankingbattleCount}," +
+                                       $"{mimisbrunnrCount}");
+            }
+
             (store as IDisposable)?.Dispose();
         }
     }


### PR DESCRIPTION
This PR adds a chain `inspect` command to `print each block's mining time and tx stats (total tx, hack and slash, ranking battle, mimisbrunnr) of a given chain in csv format.`

Usage: 
- `dotnet run --project ./NineChronicles.Headless.Executable/ [COMMAND] [SUB-COMMAND] [STORE-TYPE] [STORE-PATH] [OFFSET] [LIMIT]`

Example Command:
- `dotnet run --project ./NineChronicles.Headless.Executable/ chain inspect rocksdb C:\Users\kidon\Desktop\9c-main-partition 2304922 10`

Example Output
```
Block Index,Mining Time (sec),Total Tx #,HAS #,RankingBattle #,Mimisbrunnr #
2304923,23.71,56,44,3,0
2304924,12.57,37,30,2,0
2304925,15.96,12,6,2,0
2304926,14.22,76,50,4,0
2304927,21.63,25,15,1,0
2304928,26.12,24,14,1,0
2304929,7.01,1,0,0,0
2304930,3.90,18,10,3,0
2304931,10.71,44,28,1,0
2304932,15.30,4,2,0,0
```