### PR TITLE
add rankingMapAddress back to HAS mutation

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -328,6 +328,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Address avatarAddress, 
             int worldId, 
             int stageId,
+            Address rankingMapAddress,
             List<Guid> costumeIds, 
             List<Guid> equipmentIds, 
             List<Guid> consumableIds
@@ -339,7 +340,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             {
                 ranking.RankingMap[RankingState.Derive(i)] = new HashSet<Address>().ToImmutableHashSet();
             }
-            var queryArgs = $"avatarAddress: \"{avatarAddress}\", worldId: {worldId}, stageId: {stageId}";
+            var queryArgs = $"avatarAddress: \"{avatarAddress}\", worldId: {worldId}, stageId: {stageId}, rankingMapAddress: \"{rankingMapAddress}\"";
             if (costumeIds.Any())
             {
                 queryArgs += $", costumeIds: [{string.Join(",", costumeIds.Select(r => string.Format($"\"{r}\"")))}]";
@@ -384,6 +385,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 new Address(),
                 1,
                 2,
+                new Address(),
                 new List<Guid>(),
                 new List<Guid>(),
                 new List<Guid>(),
@@ -393,6 +395,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 new Address(),
                 2,
                 3,
+                new Address(),
                 new List<Guid>
                 {
                     Guid.NewGuid(),

--- a/NineChronicles.Headless/GraphTypes/ActionMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionMutation.cs
@@ -115,6 +115,11 @@ namespace NineChronicles.Headless.GraphTypes
                         Name = "stageId",
                         Description = "Stage ID."
                     },
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "rankingMapAddress",
+                        Description = "Address of RankingMapState containing the avatar address."
+                    },
                     new QueryArgument<ListGraphType<GuidGraphType>>
                     {
                         Name = "costumeIds",
@@ -144,6 +149,7 @@ namespace NineChronicles.Headless.GraphTypes
                         Address avatarAddress = context.GetArgument<Address>("avatarAddress");
                         int worldId = context.GetArgument<int>("worldId");
                         int stageId = context.GetArgument<int>("stageId");
+                        Address rankingMapAddress = context.GetArgument<Address>("rankingMapAddress");
                         List<Guid> costumeIds = context.GetArgument<List<Guid>>("costumeIds") ?? new List<Guid>();
                         List<Guid> equipmentIds = context.GetArgument<List<Guid>>("equipmentIds") ?? new List<Guid>();
                         List<Guid> consumableIds = context.GetArgument<List<Guid>>("consumableIds") ?? new List<Guid>();
@@ -153,6 +159,7 @@ namespace NineChronicles.Headless.GraphTypes
                             avatarAddress = avatarAddress,
                             worldId = worldId,
                             stageId = stageId,
+                            rankingMapAddress = rankingMapAddress,
                             costumes = costumeIds,
                             equipments = equipmentIds,
                             foods = consumableIds,


### PR DESCRIPTION
This PR reverts the `rankingMapAddress` parameter of `HackAndSlash` mutation in GQL back to `v100074` (Ref: https://github.com/planetarium/NineChronicles.Headless/blob/rc-v100074-b/NineChronicles.Headless/GraphTypes/ActionMutation.cs#L123-L127) to resolve https://github.com/planetarium/NineChronicles.Headless/issues/722.