### PR TITLE
Divide subscription by agent address for monster collection

### DIFF
--- a/NineChronicles.Headless.Tests/Controllers/GraphQLControllerTest.cs
+++ b/NineChronicles.Headless.Tests/Controllers/GraphQLControllerTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Reactive.Subjects;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Libplanet;
@@ -15,7 +17,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Nekoyume.Action;
+using Nekoyume.Model.State;
 using NineChronicles.Headless.Controllers;
+using NineChronicles.Headless.GraphTypes;
 using NineChronicles.Headless.Requests;
 using Xunit;
 using IPAddress = System.Net.IPAddress;
@@ -52,7 +56,7 @@ namespace NineChronicles.Headless.Tests.Controllers
             _configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
             _httpContextAccessor = new HttpContextAccessor();
             _httpContextAccessor.HttpContext = new DefaultHttpContext();
-            
+            ConfigureNineChroniclesNodeService();
             _controller = new GraphQLController(_standaloneContext, _httpContextAccessor, _configuration);
         }
 
@@ -128,6 +132,24 @@ namespace NineChronicles.Headless.Tests.Controllers
         {
             ConfigureSecretToken();
             Assert.IsType<UnauthorizedResult>(_controller.SetPrivateKey(new SetPrivateKeyRequest()));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RemoveSubscribe(bool exist)
+        {
+            var address = new PrivateKey().ToAddress();
+            if (exist)
+            {
+                _standaloneContext.AgentAddresses[address] = (new ReplaySubject<MonsterCollectionStatus>(), new ReplaySubject<MonsterCollectionState>());
+            }
+            Assert.Equal(exist, _standaloneContext.AgentAddresses.Any());
+            _controller.RemoveSubscribe(new AddressRequest
+            {
+                AddressString = address.ToHex()
+            });
+            Assert.Empty(_standaloneContext.AgentAddresses);
         }
 
         private string CreateSecretToken() => Guid.NewGuid().ToString();

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -590,40 +590,55 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             );
         }
 
-        [Fact]
-        public async Task MonsterCollectionStatus_AgentState_Null()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MonsterCollectionStatus_AgentState_Null(bool miner)
         {
             var userPrivateKey = new PrivateKey();
             var userAddress = userPrivateKey.ToAddress();
             var service = MakeMineChroniclesNodeService(userPrivateKey);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm!.BlockChain;
-            const string query = @"query {
-                monsterCollectionStatus {
-                    fungibleAssetValue {
+            if (!miner)
+            {
+                StandaloneContextFx.NineChroniclesNodeService.MinerPrivateKey = null;
+            }
+            Assert.Equal(miner, StandaloneContextFx.NineChroniclesNodeService.MinerPrivateKey!.Equals(userPrivateKey));
+            string queryArgs = miner ? "" : $@"(address: ""{userAddress}"")";
+            string query = $@"query {{
+                monsterCollectionStatus{queryArgs} {{
+                    fungibleAssetValue {{
                         quantity
                         currency
-                    }
-                    rewardInfos {
+                    }}
+                    rewardInfos {{
                         itemId
                         quantity
-                    }
-                }
-            }";
+                    }}
+                }}
+            }}";
             var queryResult = await ExecuteQueryAsync(query);
             Assert.Single(queryResult.Errors);
             Assert.Equal($"{nameof(AgentState)} Address: {userAddress} is null.", queryResult.Errors.First().Message);
         }
 
 
-        [Fact]
-        public async Task MonsterCollectionStatus_MonsterCollectionState_Null()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MonsterCollectionStatus_MonsterCollectionState_Null(bool miner)
         {
             var userPrivateKey = new PrivateKey();
             var userAddress = userPrivateKey.ToAddress();
             var service = MakeMineChroniclesNodeService(userPrivateKey);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm!.BlockChain;
+            if (!miner)
+            {
+                StandaloneContextFx.NineChroniclesNodeService.MinerPrivateKey = null;
+            }
+            Assert.Equal(miner, StandaloneContextFx.NineChroniclesNodeService.MinerPrivateKey!.Equals(userPrivateKey));
             var action = new CreateAvatar2
             {
                 index = 0,
@@ -638,18 +653,19 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             blockChain.StageTransaction(transaction);
             await blockChain.MineBlock(new Address());
 
-            const string query = @"query {
-                monsterCollectionStatus {
-                    fungibleAssetValue {
+            string queryArgs = miner ? "" : $@"(address: ""{userAddress}"")";
+            string query = $@"query {{
+                monsterCollectionStatus{queryArgs} {{
+                    fungibleAssetValue {{
                         quantity
                         currency
-                    }
-                    rewardInfos {
+                    }}
+                    rewardInfos {{
                         itemId
                         quantity
-                    }
-                }
-            }";
+                    }}
+                }}
+            }}";
             var queryResult = await ExecuteQueryAsync(query);
             Assert.Single(queryResult.Errors);
             Assert.Equal(

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -604,7 +604,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             {
                 StandaloneContextFx.NineChroniclesNodeService.MinerPrivateKey = null;
             }
-            Assert.Equal(miner, StandaloneContextFx.NineChroniclesNodeService.MinerPrivateKey!.Equals(userPrivateKey));
+            else
+            {
+                Assert.Equal(userPrivateKey, StandaloneContextFx.NineChroniclesNodeService.MinerPrivateKey!);
+            }
             string queryArgs = miner ? "" : $@"(address: ""{userAddress}"")";
             string query = $@"query {{
                 monsterCollectionStatus{queryArgs} {{

--- a/NineChronicles.Headless/Controllers/GraphQLController.cs
+++ b/NineChronicles.Headless/Controllers/GraphQLController.cs
@@ -39,6 +39,8 @@ namespace NineChronicles.Headless.Controllers
 
         public const string CheckPeerEndpoint = "/check-peer";
 
+        public const string RemoveSubscribeEndPoint = "/remove-subscribe";
+
         public GraphQLController(StandaloneContext standaloneContext, IHttpContextAccessor httpContextAccessor, IConfiguration configuration)
         {
             _httpContextAccessor = httpContextAccessor;
@@ -100,7 +102,7 @@ namespace NineChronicles.Headless.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> CheckPeer([FromBody] CheckPeerRequest request)
+        public async Task<IActionResult> CheckPeer([FromBody] AddressRequest request)
         {
             if (StandaloneContext.NineChroniclesNodeService is null)
             {
@@ -125,6 +127,19 @@ namespace NineChronicles.Headless.Controllers
                 Log.Warning(e, msg);
                 return StatusCode(StatusCodes.Status500InternalServerError, msg);
             }
+        }
+
+        [HttpPost(RemoveSubscribeEndPoint)]
+        public IActionResult RemoveSubscribe([FromBody] AddressRequest request)
+        {
+            if (!HasLocalPolicy())
+            {
+                return Unauthorized();
+            }
+
+            var address = new Address(request.AddressString);
+            StandaloneContext.AgentAddresses.TryRemove(address, out _);
+            return Ok(200);
         }
 
         //TODO : This should be covered in test.

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -260,7 +260,15 @@ namespace NineChronicles.Headless.GraphTypes
 
             Field<MonsterCollectionStatusType>(
                 name: nameof(MonsterCollectionStatus),
-                description: "Current miner's monster collection status.",
+                arguments: new QueryArguments(
+                    new QueryArgument<AddressType>
+                    {
+                        Name = "address",
+                        Description = "agent address.",
+                        DefaultValue = null
+                    }
+                ),
+                description: "Get monster collection status by address.",
                 resolve: context =>
                 {
                     if (!(standaloneContext.BlockChain is BlockChain<NCAction> blockChain))
@@ -269,13 +277,24 @@ namespace NineChronicles.Headless.GraphTypes
                             $"{nameof(StandaloneContext)}.{nameof(StandaloneContext.BlockChain)} was not set yet!");
                     }
 
-                    if (standaloneContext.NineChroniclesNodeService?.MinerPrivateKey is null)
+                    Address? address = context.GetArgument<Address?>("address");
+                    Address agentAddress;
+                    if (address is null)
                     {
-                        throw new ExecutionError(
-                            $"{nameof(StandaloneContext)}.{nameof(StandaloneContext.NineChroniclesNodeService)}.{nameof(StandaloneContext.NineChroniclesNodeService.MinerPrivateKey)} is null.");
+                        if (standaloneContext.NineChroniclesNodeService?.MinerPrivateKey is null)
+                        {
+                            throw new ExecutionError(
+                                $"{nameof(StandaloneContext)}.{nameof(StandaloneContext.NineChroniclesNodeService)}.{nameof(StandaloneContext.NineChroniclesNodeService.MinerPrivateKey)} is null.");
+                        }
+
+                        agentAddress = standaloneContext.NineChroniclesNodeService!.MinerPrivateKey!.ToAddress();
+                    }
+                    else
+                    {
+                        agentAddress = (Address)address;
                     }
 
-                    Address agentAddress = standaloneContext.NineChroniclesNodeService.MinerPrivateKey.ToAddress();
+
                     BlockHash? offset = blockChain.GetDelayedRenderer()?.Tip?.Hash;
                     if (blockChain.GetState(agentAddress, offset) is Dictionary agentDict)
                     {

--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -8,6 +8,7 @@ using Libplanet.Explorer.GraphTypes;
 using Libplanet.Headless;
 using Libplanet.Net;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
@@ -166,6 +167,34 @@ namespace NineChronicles.Headless.GraphTypes
                 Resolver = new FuncFieldResolver<MonsterCollectionStatus>(context => (context.Source as MonsterCollectionStatus)!),
                 Subscriber = new EventStreamResolver<MonsterCollectionStatus>(context => standaloneContext.MonsterCollectionStatusSubject.AsObservable()),
             });
+            AddField(new EventStreamFieldType
+            {
+                Name = $"{nameof(MonsterCollectionStatus)}ByAgent",
+                Arguments = new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Description = "A hex-encoded address of agent.",
+                        Name = "address",
+                    }
+                ),
+                Type = typeof(NonNullGraphType<MonsterCollectionStatusType>),
+                Resolver = new FuncFieldResolver<MonsterCollectionStatus>(context => (context.Source as MonsterCollectionStatus)!),
+                Subscriber = new EventStreamResolver<MonsterCollectionStatus>(SubscribeMonsterCollectionStatus),
+            });
+            AddField(new EventStreamFieldType
+            {
+                Name = $"{nameof(MonsterCollectionState)}ByAgent",
+                Arguments = new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Description = "A hex-encoded address of agent.",
+                        Name = "address",
+                    }
+                ),
+                Type = typeof(NonNullGraphType<MonsterCollectionStateType>),
+                Resolver = new FuncFieldResolver<MonsterCollectionState>(context => (context.Source as MonsterCollectionState)!),
+                Subscriber = new EventStreamResolver<MonsterCollectionState>(SubscribeMonsterCollectionState),
+            });
 
             BlockRenderer blockRenderer = standaloneContext.NineChroniclesNodeService!.BlockRenderer;
             blockRenderer.EveryBlock().Subscribe(RenderBlock);
@@ -175,6 +204,24 @@ namespace NineChronicles.Headless.GraphTypes
             actionRenderer.EveryRender<MonsterCollect>().Subscribe(RenderMonsterCollectionStateSubject);
             actionRenderer.EveryRender<CancelMonsterCollect>().Subscribe(RenderMonsterCollectionStateSubject);
             actionRenderer.EveryRender<ClaimMonsterCollectionReward>().Subscribe(RenderMonsterCollectionStateSubject);
+        }
+
+        private IObservable<MonsterCollectionState> SubscribeMonsterCollectionState(IResolveEventStreamContext context)
+        {
+            var address = context.GetArgument<Address>("address");
+
+            StandaloneContext.AgentAddresses.TryAdd(address, (new ReplaySubject<MonsterCollectionStatus>(), new ReplaySubject<MonsterCollectionState>()));
+            StandaloneContext.AgentAddresses.TryGetValue(address, out var subjects);
+            return subjects.stateSubject.AsObservable();
+        }
+
+        private IObservable<MonsterCollectionStatus> SubscribeMonsterCollectionStatus(IResolveEventStreamContext context)
+        {
+            var address = context.GetArgument<Address>("address");
+
+            StandaloneContext.AgentAddresses.TryAdd(address, (new ReplaySubject<MonsterCollectionStatus>(), new ReplaySubject<MonsterCollectionState>()));
+            StandaloneContext.AgentAddresses.TryGetValue(address, out var subjects);
+            return subjects.statusSubject.AsObservable();
         }
 
         private TipChanged ResolveTipChanged(IResolveFieldContext context)
@@ -200,22 +247,56 @@ namespace NineChronicles.Headless.GraphTypes
                     $"{nameof(StandaloneContext.NineChroniclesNodeService)} is null.");
             }
 
+            BlockChain<PolymorphicAction<ActionBase>> blockChain = StandaloneContext.NineChroniclesNodeService.BlockChain;
+            DelayedRenderer<PolymorphicAction<ActionBase>>? delayedRenderer = blockChain.GetDelayedRenderer();
+            BlockHash? offset = delayedRenderer?.Tip?.Hash;
+            Currency currency =
+                new GoldCurrencyState(
+                    (Dictionary) blockChain.GetState(Addresses.GoldCurrency, offset)
+                ).Currency;
+            var rewardSheet = new MonsterCollectionRewardSheet();
+            var csv = blockChain.GetState(
+                Addresses.GetSheetAddress<MonsterCollectionRewardSheet>(),
+                offset
+            ).ToDotnetString();
+            rewardSheet.Set(csv);
+            foreach (var (address, subjects) in StandaloneContext.AgentAddresses)
+            {
+                FungibleAssetValue agentBalance = blockChain.GetBalance(address, currency, offset);
+                if (blockChain.GetState(address, offset) is Dictionary rawAgent)
+                {
+                    AgentState agentState = new AgentState(rawAgent);
+                    Address deriveAddress =
+                        MonsterCollectionState.DeriveAddress(address, agentState.MonsterCollectionRound);
+                    if (blockChain.GetState(deriveAddress, offset) is Dictionary collectDict &&
+                        agentState.avatarAddresses.Any())
+                    {
+                        long tipIndex = blockChain.Tip.Index;
+                        var monsterCollectionState = new MonsterCollectionState(collectDict);
+                        List<MonsterCollectionRewardSheet.RewardInfo> rewards = monsterCollectionState.CalculateRewards(
+                            rewardSheet,
+                            tipIndex
+                        );
+
+                        var monsterCollectionStatus = new MonsterCollectionStatus(
+                            agentBalance,
+                            rewards,
+                            monsterCollectionState.IsLocked(tipIndex)
+                        );
+                        subjects.statusSubject.OnNext(monsterCollectionStatus);
+                    }
+                }
+            }
+
             if (StandaloneContext.NineChroniclesNodeService.MinerPrivateKey is null)
             {
                 Log.Information("PrivateKey is not set. please call SetPrivateKey() first");
                 return;
             }
 
-            BlockChain<PolymorphicAction<ActionBase>> blockChain = StandaloneContext.NineChroniclesNodeService.BlockChain;
-            DelayedRenderer<PolymorphicAction<ActionBase>>? delayedRenderer = blockChain.GetDelayedRenderer();
-            BlockHash? offset = delayedRenderer?.Tip?.Hash;
+            // legacy
             Address agentAddress = StandaloneContext.NineChroniclesNodeService.MinerPrivateKey.ToAddress();
-            Currency currency =
-                new GoldCurrencyState(
-                    (Dictionary) blockChain.GetState(Addresses.GoldCurrency, offset)
-                ).Currency;
             FungibleAssetValue balance = blockChain.GetBalance(agentAddress, currency, offset);
-            var rewards = new List<MonsterCollectionRewardSheet.RewardInfo>();
             if (blockChain.GetState(agentAddress, offset) is Dictionary agentDict)
             {
                 AgentState agentState = new AgentState(agentDict);
@@ -223,15 +304,10 @@ namespace NineChronicles.Headless.GraphTypes
                 if (blockChain.GetState(deriveAddress, offset) is Dictionary collectDict && 
                     agentState.avatarAddresses.Any())
                 {
-                    var rewardSheet = new MonsterCollectionRewardSheet();
-                    var csv = blockChain.GetState(
-                        Addresses.GetSheetAddress<MonsterCollectionRewardSheet>(),
-                        offset
-                    ).ToDotnetString();
                     rewardSheet.Set(csv);
                     long tipIndex = blockChain.Tip.Index;
                     var monsterCollectionState = new MonsterCollectionState(collectDict);
-                    rewards = monsterCollectionState.CalculateRewards(
+                    var rewards = monsterCollectionState.CalculateRewards(
                         rewardSheet,
                         tipIndex
                     );
@@ -269,6 +345,27 @@ namespace NineChronicles.Headless.GraphTypes
                     $"{nameof(NineChroniclesNodeService)} is null.");
             }
 
+            foreach (var (address, subjects) in StandaloneContext.AgentAddresses)
+            {
+                if (eval.Signer.Equals(address) &&
+                    eval.Exception is null &&
+                    service.BlockChain.GetState(address) is Dictionary agentDict)
+                {
+                    var agentState = new AgentState(agentDict);
+                    Address deriveAddress = MonsterCollectionState.DeriveAddress(address, agentState.MonsterCollectionRound);
+                    var subject = subjects.stateSubject;
+                    if (eval.OutputStates.GetState(deriveAddress) is Dictionary state)
+                    {
+                        subject.OnNext(new MonsterCollectionState(state));
+                    }
+                    else
+                    {
+                        subject.OnNext(null!);
+                    }
+                }
+            }
+
+            // legacy
             if (!(service.MinerPrivateKey is { } privateKey))
             {
                 Log.Information("PrivateKey is not set. please call SetPrivateKey() first");

--- a/NineChronicles.Headless/Requests/AddressRequest.cs
+++ b/NineChronicles.Headless/Requests/AddressRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace NineChronicles.Headless.Requests
 {
-  public struct CheckPeerRequest
+  public struct AddressRequest
   {
     public string AddressString { get; set; }
   }

--- a/NineChronicles.Headless/StandaloneContext.cs
+++ b/NineChronicles.Headless/StandaloneContext.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Reactive.Subjects;
+using Libplanet;
 using Libplanet.Blockchain;
 using Libplanet.KeyStore;
 using Libplanet.Net;
@@ -26,6 +28,12 @@ namespace NineChronicles.Headless
         public ReplaySubject<MonsterCollectionState> MonsterCollectionStateSubject { get; } = new ReplaySubject<MonsterCollectionState>();
         public ReplaySubject<MonsterCollectionStatus> MonsterCollectionStatusSubject { get; } = new ReplaySubject<MonsterCollectionStatus>();
         public NineChroniclesNodeService? NineChroniclesNodeService { get; set; }
+
+        public ConcurrentDictionary<Address,
+                (ReplaySubject<MonsterCollectionStatus> statusSubject, ReplaySubject<MonsterCollectionState> stateSubject)>
+            AgentAddresses { get; } = new ConcurrentDictionary<Address,
+                (ReplaySubject<MonsterCollectionStatus>, ReplaySubject<MonsterCollectionState>)>();
+
         public NodeStatusType NodeStatus => new NodeStatusType(this)
         {
             BootstrapEnded = BootstrapEnded,


### PR DESCRIPTION
- Divide monster collection subscription for rpc node
- add agent address query arguments for rpc node