### PR TITLE
fix: find transaction from chain instead store

### DIFF
--- a/NineChronicles.Headless.Tests/DumbTransferAction.cs
+++ b/NineChronicles.Headless.Tests/DumbTransferAction.cs
@@ -1,0 +1,77 @@
+﻿using Bencodex;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Model.State;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Nekoyume.Action;
+
+namespace NineChronicles.Headless.Tests 
+{
+    [Serializable]
+    [ActionType("dumb_transfer_action")]
+    public class DumbTransferAction : ActionBase, ISerializable
+    {
+        public DumbTransferAction()
+        {
+        }
+
+        public DumbTransferAction(Address sender, Address recipient)
+        {
+            Sender = sender;
+            Recipient = recipient;
+        }
+
+        protected DumbTransferAction(SerializationInfo info, StreamingContext context)
+        {
+            var rawBytes = (byte[])info.GetValue("serialized", typeof(byte[]))!;
+            Dictionary pv = (Dictionary) new Codec().Decode(rawBytes);
+
+            LoadPlainValue(pv);
+        }
+
+        public Address Sender { get; private set; }
+        public Address Recipient { get; private set; }
+
+        public override IValue PlainValue
+        {
+            get
+            {
+                IEnumerable<KeyValuePair<IKey, IValue>> pairs = new[]
+                {
+                    new KeyValuePair<IKey, IValue>((Text) "sender", Sender.Serialize()),
+                    new KeyValuePair<IKey, IValue>((Text) "recipient", Recipient.Serialize()),
+                };
+
+                return new Dictionary(pairs);
+            }
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var state = context.PreviousStates;
+            if (context.Rehearsal)
+            {
+                return state;
+            }
+
+            return state;
+        }
+
+        public override void LoadPlainValue(IValue plainValue)
+        {
+            var asDict = (Dictionary) plainValue;
+
+            Sender = asDict["sender"].ToAddress();
+            Recipient = asDict["recipient"].ToAddress();
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("serialized", new Codec().Encode(PlainValue));
+        }
+    }
+}
+

--- a/NineChronicles.Headless.Tests/GraphTypes/TransactionHeadlessQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/TransactionHeadlessQueryTest.cs
@@ -8,6 +8,7 @@ using Bencodex;
 using GraphQL;
 using Libplanet;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Crypto;
@@ -24,14 +25,18 @@ namespace NineChronicles.Headless.Tests.GraphTypes
     public class TransactionHeadlessQueryTest
     {
         private readonly BlockChain<NCAction> _blockChain;
+        private readonly IStore _store;
+        private readonly IStateStore _stateStore;
 
         public TransactionHeadlessQueryTest()
         {
+            _store = new DefaultStore(null);
+            _stateStore = new TrieStateStore(new DefaultKeyValueStore(null), new DefaultKeyValueStore(null));
             _blockChain = new BlockChain<NCAction>(
                 new BlockPolicy<NCAction>(),
                 new VolatileStagePolicy<NCAction>(),
-                new DefaultStore(null),
-                new TrieStateStore(new DefaultKeyValueStore(null), new DefaultKeyValueStore(null)),
+                _store,
+                _stateStore,
                 BlockChain<NCAction>.MakeGenesisBlock(HashAlgorithmType.Of<SHA256>()));
         }
 
@@ -229,11 +234,86 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.NotNull(result.Errors);
         }
 
+        [Fact]
+        public async Task TransactionResultIsStaging()
+        {
+            var privateKey = new PrivateKey();
+            Transaction<NCAction> tx = Transaction<NCAction>.Create(
+                0,
+                privateKey, 
+                _blockChain.Genesis.Hash, 
+                ImmutableArray<NCAction>.Empty);
+            _blockChain.StageTransaction(tx);
+            var queryFormat = @"query {{
+                transactionResult(txId: ""{0}"") {{
+                    blockHash
+                    txStatus
+                }}
+            }}";
+            var result = await ExecuteAsync(string.Format(
+                queryFormat,
+                tx.Id.ToString()));
+            Assert.NotNull(result.Data);
+            var transactionResult = result.Data
+                .As<Dictionary<string, object>>()["transactionResult"];
+            var txStatus = (string) transactionResult.As<Dictionary<string, object>>()["txStatus"];
+            Assert.Equal("STAGING", txStatus);
+        }
+        
+        [Fact]
+        public async Task TransactionResultIsInvalid()
+        {
+            var privateKey = new PrivateKey();
+            Transaction<NCAction> tx = Transaction<NCAction>.Create(
+                0,
+                privateKey, 
+                _blockChain.Genesis.Hash, 
+                ImmutableArray<NCAction>.Empty);
+            var queryFormat = @"query {{
+                transactionResult(txId: ""{0}"") {{
+                    blockHash
+                    txStatus
+                }}
+            }}";
+            var result = await ExecuteAsync(string.Format(
+                queryFormat,
+                tx.Id.ToString()));
+            Assert.NotNull(result.Data);
+            var transactionResult = result.Data
+                .As<Dictionary<string, object>>()["transactionResult"];
+            var txStatus = (string) transactionResult.As<Dictionary<string, object>>()["txStatus"];
+            Assert.Equal("INVALID", txStatus);
+        }
+        
+        [Fact]
+        public async Task TransactionResultIsSuccess()
+        {
+            var privateKey = new PrivateKey();
+            var action = new DumbTransferAction(new Address(), new Address());
+            Transaction<NCAction> tx = _blockChain.MakeTransaction(privateKey, new NCAction[]{action});
+            await _blockChain.MineBlock(new Address());
+            var queryFormat = @"query {{
+                transactionResult(txId: ""{0}"") {{
+                    blockHash
+                    txStatus
+                }}
+            }}";
+            var result = await ExecuteAsync(string.Format(
+                queryFormat,
+                tx.Id.ToString()));
+            Assert.NotNull(result.Data);
+            var transactionResult = result.Data
+                .As<Dictionary<string, object>>()["transactionResult"];
+            var txStatus = (string) transactionResult.As<Dictionary<string, object>>()["txStatus"];
+            Assert.Equal("SUCCESS", txStatus);
+        }
+        
         private Task<ExecutionResult> ExecuteAsync(string query)
         {
             return GraphQLTestUtils.ExecuteQueryAsync<TransactionHeadlessQuery>(query, standaloneContext: new StandaloneContext
             {
                 BlockChain = _blockChain,
+                Store = _store
             });
         }  
     }     

--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -155,7 +155,7 @@ namespace NineChronicles.Headless.GraphTypes
                     TxId txId = context.GetArgument<TxId>("txId");
                     if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } txExecutedBlockHash))
                     {
-                        return store.IterateStagedTransactionIds().Contains(txId)
+                        return blockChain.GetStagedTransactionIds().Contains(txId)
                             ? new TxResult(TxStatus.STAGING, null, null)
                             : new TxResult(TxStatus.INVALID, null, null);
                     }

--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -160,17 +160,23 @@ namespace NineChronicles.Headless.GraphTypes
                             : new TxResult(TxStatus.INVALID, null, null);
                     }
 
-                    TxExecution execution = blockChain.GetTxExecution(txExecutedBlockHash, txId);
-                    Block<PolymorphicAction<ActionBase>> txExecutedBlock = blockChain[txExecutedBlockHash];
-  
-                    switch (execution)
+                    try
                     {
-                        case TxSuccess txSuccess:
-                            return new TxResult(TxStatus.SUCCESS, txExecutedBlock.Index, txExecutedBlock.Hash.ToString());
-                        case TxFailure txFailure:
-                            return new TxResult(TxStatus.FAILURE, txExecutedBlock.Index, txExecutedBlock.Hash.ToString());
-                        default:
-                            throw new NotImplementedException($"{nameof(execution)} is not expected concrete class.");
+                        TxExecution execution = blockChain.GetTxExecution(txExecutedBlockHash, txId);
+                        Block<PolymorphicAction<ActionBase>> txExecutedBlock = blockChain[txExecutedBlockHash];
+                        return execution switch
+                        {
+                            TxSuccess txSuccess => new TxResult(TxStatus.SUCCESS, txExecutedBlock.Index,
+                                txExecutedBlock.Hash.ToString()),
+                            TxFailure txFailure => new TxResult(TxStatus.FAILURE, txExecutedBlock.Index,
+                                txExecutedBlock.Hash.ToString()),
+                            _ => throw new NotImplementedException(
+                                $"{nameof(execution)} is not expected concrete class.")
+                        };
+                    }
+                    catch(Exception)
+                    {
+                        return new TxResult(TxStatus.INVALID, null, null);
                     }
                 }
             );


### PR DESCRIPTION
Previously, we inquired in the store to check if the transaction was staged. However, this method was difficult to find a transaction when it was stale in the store. Therefore, we changed the chain to find the staged chain.

Now, return the value STAGING properly when the transaction is staged.