### PR TITLE
Add `shardedShop` in `stateQuery`.

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
@@ -81,7 +81,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 
         private void Assert_Tx(long txNonce, string filePath)
         {
-            var timeStamp = default(DateTimeOffset);
+            var timeStamp = DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
             var hashHex = ByteUtil.Hex(_blockHash.ByteArray);
             _command.Sign(ByteUtil.Hex(_privateKey.ByteArray), txNonce, hashHex, timeStamp.ToString(),
                 new[] { filePath });

--- a/NineChronicles.Headless.Tests/Common/Fixtures.cs
+++ b/NineChronicles.Headless.Tests/Common/Fixtures.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using System.Linq;
+using Lib9c.Model.Order;
 using Libplanet;
 using Libplanet.Assets;
 using Libplanet.Crypto;
@@ -54,6 +54,42 @@ namespace NineChronicles.Headless.Tests
                 shopState.Register(shopItem);
             }
             return shopState;
+        }
+
+        public static ShardedShopStateV2 ShardedWeapon0ShopStateV2FX()
+        {
+            Address shardedWeapon0ShopStateV2Address = ShardedShopStateV2.DeriveAddress(ItemSubType.Weapon, "0");
+            var shardedShopV2State = new ShardedShopStateV2(shardedWeapon0ShopStateV2Address);
+
+            var orderDigest = new OrderDigest(
+                default,
+                1,
+                3,
+                new Guid("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4"),
+                new Guid("45082f35-699c-41f0-9332-9143966933a3"),
+                new FungibleAssetValue(new Currency("NCG", 2, minter: null), 1, 0),
+                0,
+                0,
+                10110000,
+                1
+            );
+            var orderDigest2 = new OrderDigest(
+                default,
+                2,
+                4,
+                new Guid("936DA01F-9ABD-4d9d-80C7-02AF85C822A8"),
+                new Guid("dae32f1b-6b43-4bdb-933e-fd51d003283e"),
+                new FungibleAssetValue(new Currency("NCG", 2, minter: null), 2, 0),
+                0,
+                0,
+                10110000,
+                1
+            );
+
+            shardedShopV2State.Add(orderDigest, 1);
+            shardedShopV2State.Add(orderDigest2, 2);
+
+            return shardedShopV2State;
         }
     }
 }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/ShardedShopStateV2TypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/ShardedShopStateV2TypeTest.cs
@@ -1,0 +1,132 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using Libplanet;
+using Nekoyume;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using NineChronicles.Headless.GraphTypes.States;
+using Xunit;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
+
+namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
+{
+    public class ShardedShopStateV2TypeTest
+    {
+        private readonly Address _stateAddress;
+        private readonly ShardedShopStateV2 _state;
+
+        public ShardedShopStateV2TypeTest()
+        {
+            _stateAddress = ShardedShopStateV2.DeriveAddress(ItemSubType.Weapon, "0");
+            _state = new ShardedShopStateV2(_stateAddress);
+        }
+
+        [Fact]
+        public async Task Query()
+        {
+            const string query = @"{
+                address
+                orderDigestList {
+                    sellerAgentAddress
+                    itemId
+                    price
+                    combatPoint
+                    expiredBlockIndex
+                }
+            }";
+            var queryResult = await ExecuteQueryAsync<ShardedShopStateV2Type>(query, source: _state);
+            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            Assert.Equal(
+                new Dictionary<string, object>
+                {
+                    ["address"] = _stateAddress.ToString(),
+                    ["orderDigestList"] = new List<object>()
+                },
+                data
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(Members))]
+        public async Task QueryWithArguments(int id, int? price, int expected)
+        {
+            var queryArgs = $"id: {id}";
+            if (!(price is null))
+            {
+                queryArgs += $", maximumPrice: {price}";
+            }
+            var query = $@"query {{
+                orderDigestList({queryArgs}) {{
+                    sellerAgentAddress
+                    itemId
+                    price
+                    combatPoint
+                    expiredBlockIndex
+                }}
+            }}";
+            var queryResult = await ExecuteQueryAsync<ShardedShopStateV2Type>(query, source: Fixtures.ShardedWeapon0ShopStateV2FX());
+            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var orderDigestList = (IList)data["orderDigestList"];
+            Assert.Equal(expected, orderDigestList.Count!);
+        }
+
+        [Theory]
+        [InlineData("id: 1.0")]
+        [InlineData("maximumPrice: 1.1")]
+        public async Task QueryWithInvalidArguments(string queryArgs)
+        {
+            var query = $@"{{
+                address
+                orderDigestList({queryArgs}) {{
+                    sellerAgentAddress
+                    itemId
+                    price
+                    combatPoint
+                    expiredBlockIndex
+                }}
+            }}";
+            var queryResult = await ExecuteQueryAsync<ShardedShopStateV2Type>(query, source: _state);
+            Assert.Null(queryResult.Data);
+            Assert.NotNull(queryResult.Errors);
+            Assert.Single(queryResult.Errors!);
+            Assert.Equal("ARGUMENTS_OF_CORRECT_TYPE", queryResult.Errors!.First().Code);
+        }
+
+        public static IEnumerable<object?[]> Members => new List<object?[]>
+        {
+            new object?[]
+            {
+                10110000,
+                null,
+                2,
+            },
+            new object?[]
+            {
+                10110000,
+                1,
+                1,
+            },
+            new object?[]
+            {
+                10110000,
+                2,
+                2,
+            },
+            new object?[]
+            {
+                0,
+                0,
+                0,
+            },
+            new object?[]
+            {
+                10110000,
+                -1,
+                0,
+            },
+        };
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/StateQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StateQuery.cs
@@ -4,13 +4,14 @@ using Bencodex.Types;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet;
-using Libplanet.Action;
 using Libplanet.Explorer.GraphTypes;
 using Nekoyume;
 using Nekoyume.Action;
+using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using NineChronicles.Headless.GraphTypes.States;
+using NineChronicles.Headless.GraphTypes.States.Models.Item.Enum;
 using NineChronicles.Headless.GraphTypes.States.Models.Table;
 
 namespace NineChronicles.Headless.GraphTypes
@@ -62,9 +63,36 @@ namespace NineChronicles.Headless.GraphTypes
             Field<ShopStateType>(
                 name: "shop",
                 description: "State for shop.",
+                deprecationReason: "Shop is migrated to ShardedShop and not using now. Use shardedShop() instead.",
                 resolve: context => context.Source.GetState(Addresses.Shop) is { } state
                     ? new ShopState((Dictionary) state)
                     : null);
+            Field<ShardedShopStateV2Type>(
+                name: "shardedShop",
+                description: "State for sharded shop.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<ItemSubTypeEnumType>>
+                    {
+                        Name = "itemSubType",
+                        Description = "ItemSubType for shard. see from https://github.com/planetarium/lib9c/blob/main/Lib9c/Model/Item/ItemType.cs#L13"
+                    },
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
+                    {
+                        Name = "nonce",
+                        Description = "Nonce for shard. It's not considered if itemSubtype is kind of costume or title. 0 ~ 15"
+                    }),
+                resolve: context =>
+                {
+                    var subType = context.GetArgument<ItemSubType>("itemSubType");
+                    var nonce = context.GetArgument<int>("nonce").ToString("X").ToLower();
+
+                    if (context.Source.GetState(ShardedShopStateV2.DeriveAddress(subType, nonce)) is { } state)
+                    {
+                        return new ShardedShopStateV2((Dictionary) state);
+                    }
+
+                    return null;
+                });
             Field<WeeklyArenaStateType>(
                 name: "weeklyArena",
                 description: "State for weekly arena.",

--- a/NineChronicles.Headless/GraphTypes/States/Models/Order/OrderBaseType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Order/OrderBaseType.cs
@@ -1,0 +1,25 @@
+using GraphQL.Types;
+using Lib9c.Model.Order;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public abstract class OrderBaseType<T> : ObjectGraphType<T>
+        where T : OrderBase
+    {
+        protected OrderBaseType()
+        {
+            Field<NonNullGraphType<GuidGraphType>>(
+                nameof(NonFungibleOrder.OrderId),
+                description: "Guid of order.");
+            Field<NonNullGraphType<GuidGraphType>>(
+                nameof(NonFungibleOrder.TradableId),
+                description: "Tradable guid of order.");
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(NonFungibleOrder.StartedBlockIndex),
+                description: "Block index order started.");
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(NonFungibleOrder.ExpiredBlockIndex),
+                description: "Block index order expired.");
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Order/OrderDigestType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Order/OrderDigestType.cs
@@ -1,0 +1,35 @@
+using GraphQL.Types;
+using Lib9c.Model.Order;
+using Libplanet.Explorer.GraphTypes;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public class OrderDigestType : OrderBaseType<OrderDigest>
+    {
+        public OrderDigestType()
+        {
+            Field<NonNullGraphType<AddressType>>(
+                nameof(OrderDigest.SellerAgentAddress),
+                description: "Address of seller agent.",
+                resolve: context => context.Source.SellerAgentAddress);
+            Field<NonNullGraphType<StringGraphType>>(
+                nameof(OrderDigest.Price),
+                description: "Order price.",
+                resolve: context => context.Source.Price.ToString());
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(OrderDigest.CombatPoint),
+                resolve: context => context.Source.CombatPoint);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(OrderDigest.Level),
+                resolve: context => context.Source.Level);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(OrderDigest.ItemId),
+                description: "Id of item.",
+                resolve: context => context.Source.ItemId);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(OrderDigest.ItemCount),
+                description: "Count of item.",
+                resolve: context => context.Source.ItemCount);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/ShardedShopStateV2Type.cs
+++ b/NineChronicles.Headless/GraphTypes/States/ShardedShopStateV2Type.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL;
+using GraphQL.Types;
+using Lib9c.Model.Order;
+using Libplanet.Explorer.GraphTypes;
+using Nekoyume.Model.State;
+using NineChronicles.Headless.GraphTypes.States.Models.Item;
+
+namespace NineChronicles.Headless.GraphTypes.States
+{
+    public class ShardedShopStateV2Type : ObjectGraphType<ShardedShopStateV2>
+    {
+        public ShardedShopStateV2Type()
+        {
+            Field<NonNullGraphType<AddressType>>(
+                nameof(ShardedShopStateV2.address),
+                description: "Address of sharded shop.",
+                resolve: context => context.Source.address);
+            Field<NonNullGraphType<ListGraphType<OrderDigestType>>>(
+                nameof(ShardedShopStateV2.OrderDigestList),
+                description: "List of OrderDigest.",
+                arguments: new QueryArguments(
+                    new QueryArgument<IntGraphType>
+                    {
+                        Name = "id",
+                        Description = "Filter for item id."
+                    },
+                    new QueryArgument<IntGraphType>
+                    {
+                        Name = "maximumPrice",
+                        Description = "Filter for item maximum price."
+                    }),
+                resolve: context =>
+                {
+                    IEnumerable<OrderDigest> orderDigestList = context.Source.OrderDigestList;
+                    if (context.GetArgument<int?>("id") is int id)
+                    {
+                        orderDigestList = orderDigestList.Where(si => si.ItemId == id);
+                    }
+                    if (context.GetArgument<int?>("maximumPrice") is int maximumPrice)
+                    {
+                        orderDigestList = orderDigestList
+                            .Where(si => si.Price <= maximumPrice * si.Price.Currency);
+                    }
+                    return orderDigestList.ToList();
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
Hi. I've faced the issue that the query `shop` does not returns any products. And I've been noticed that the `Shop` is not using any more and it's products are migrated to `ShardedShop` according to your working logs.

So I made a new query `shardedShop` to get products from `ShardedShop`. This query helps user get the `ShardedShop` they wants using parameters `itemSubType` and `nonce`. And I also added `ShopItemType.expiredBlockIndex` to know products' time to live.

@ipdae would you mind if I requested a review about this PR? I think this PR can resolve #508.

Thanks.