### PR TITLE
feat(graphql): provide `InventoryItemType.item` field

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/InventoryTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/InventoryTypeTest.cs
@@ -34,6 +34,18 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             
             ExecutionResult queryResult = await ExecuteQueryAsync<InventoryType>(query, source: inventory);
             Assert.Null(queryResult.Errors);
+            Assert.Equal(new Dictionary<string, object>
+            {
+                ["items"] = new List<object>
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["count"] = 1,
+                        ["id"] = row.Id,
+                        ["itemType"] = row.ItemType.ToString().ToUpper(),
+                    },  
+                },
+            }, queryResult.Data.As<Dictionary<string, object>>());
         }
     }
 }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/InventoryTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/InventoryTypeTest.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GraphQL;
+using GraphQL.Utilities;
 using Nekoyume.Model.Item;
 using NineChronicles.Headless.GraphTypes.States.Models.Item;
 using Xunit;
@@ -24,6 +26,13 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                     count
                     id
                     itemType
+                    item {{
+                        id
+                        grade
+                        itemType
+                        itemSubType
+                        elementalType
+                    }}
                 }}
             }}";
             
@@ -34,7 +43,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             
             ExecutionResult queryResult = await ExecuteQueryAsync<InventoryType>(query, source: inventory);
             Assert.Null(queryResult.Errors);
-            Assert.Equal(new Dictionary<string, object>
+            var expected = new Dictionary<string, object>
             {
                 ["items"] = new List<object>
                 {
@@ -43,9 +52,18 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                         ["count"] = 1,
                         ["id"] = row.Id,
                         ["itemType"] = row.ItemType.ToString().ToUpper(),
-                    },  
+                        ["item"] = new Dictionary<string, object>
+                        {
+                            ["id"] = row.Id,
+                            ["grade"] = row.Grade,
+                            ["itemType"] = StringUtils.ToConstantCase(Enum.GetName(row.ItemType.GetType(), row.ItemType)),
+                            ["itemSubType"] = StringUtils.ToConstantCase(Enum.GetName(row.ItemSubType.GetType(), row.ItemSubType)),
+                            ["elementalType"] = StringUtils.ToConstantCase(Enum.GetName(row.ElementalType.GetType(), row.ElementalType)),
+                        },
+                    },
                 },
-            }, queryResult.Data.As<Dictionary<string, object>>());
+            };
+            Assert.Equal(expected, queryResult.Data.As<Dictionary<string, object>>());
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/ConsumableType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/ConsumableType.cs
@@ -10,6 +10,10 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
         {
             Field<NonNullGraphType<GuidGraphType>>(nameof(Consumable.ItemId));
             Field<NonNullGraphType<StatTypeEnumType>>(nameof(Consumable.MainStat));
+
+            Interface<ItemBaseInterfaceType>();
+            
+            IsTypeOf = obj => obj is Consumable;
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/EquipmentType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/EquipmentType.cs
@@ -16,6 +16,10 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
             Field<ListGraphType<SkillType>>(nameof(Equipment.Skills));
             Field<ListGraphType<SkillType>>(nameof(Equipment.BuffSkills));
             Field<NonNullGraphType<StatsMapType>>(nameof(Equipment.StatsMap));
+
+            Interface<ItemBaseInterfaceType>();
+            
+            IsTypeOf = obj => obj is Equipment;
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/InventoryItemType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/InventoryItemType.cs
@@ -20,6 +20,10 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
                 "itemType",
                 description: "An ItemType of item",
                 resolve: context => context.Source.item.ItemType);
+            Field<NonNullGraphType<ItemBaseInterfaceType>>(
+                "item",
+                description: "The item",
+                resolve: context => context.Source.item);
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/ItemBaseInterfaceType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/ItemBaseInterfaceType.cs
@@ -1,0 +1,18 @@
+using GraphQL.Types;
+using Nekoyume.Model.Item;
+using NineChronicles.Headless.GraphTypes.States.Models.Item.Enum;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Item
+{
+    public class ItemBaseInterfaceType : InterfaceGraphType<ItemBase>
+    {
+        public ItemBaseInterfaceType()
+        {
+            Field<NonNullGraphType<IntGraphType>>("id", resolve: ctx => ctx.Source.Id);
+            Field<NonNullGraphType<IntGraphType>>("grade", resolve: ctx => ctx.Source.Grade);
+            Field<NonNullGraphType<ItemTypeEnumType>>("itemType", resolve: ctx => ctx.Source.ItemType);
+            Field<NonNullGraphType<ItemSubTypeEnumType>>("itemSubType", resolve: ctx => ctx.Source.ItemSubType);
+            Field<NonNullGraphType<ElementalTypeEnumType>>("elementalType", resolve: ctx => ctx.Source.ElementalType);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/ItemUsableType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/ItemUsableType.cs
@@ -11,6 +11,10 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
                 nameof(ItemUsable.ItemId),
                 description: "Guid of item."
             );
+
+            Interface<ItemBaseInterfaceType>();
+
+            IsTypeOf = obj => obj is ItemUsable;
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/MaterialType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/MaterialType.cs
@@ -11,6 +11,10 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
             Field<NonNullGraphType<ByteStringType>>(
                 nameof(Material.ItemId),
                 resolve: context => context.Source.ItemId.ToByteArray());
+
+            Interface<ItemBaseInterfaceType>();
+
+            IsTypeOf = obj => obj is Material;
         }
     }
 }


### PR DESCRIPTION
## Description

## Spec

This pull request tries to support the below query:

```graphql
query {
  stateQuery {
    agent(address: "") {
      avatarStates {
        inventory {
          items {
            item {
              ... on EquipmentType {
                buffSkills {
                  chance
                }
              }
              
              ... on MaterialType {
                itemId
              }
            }
          }
        }
      }
    }
  }
}
```

## Reference

- [GraphQL interface](https://graphql-dotnet.github.io/docs/getting-started/interfaces)