### PR TITLE
Fix key length error

### DIFF
--- a/NineChronicles.Headless/Controllers/GraphQLController.cs
+++ b/NineChronicles.Headless/Controllers/GraphQLController.cs
@@ -64,7 +64,11 @@ namespace NineChronicles.Headless.Controllers
 
             try
             {
-                var privateKey = new PrivateKey(ByteUtil.ParseHex(request.PrivateKeyString));
+                // For users with private keys less than 32 bytes in length, increase this accordingly.
+                var destArray = new byte[32];
+                var srcArray = ByteUtil.ParseHex(request.PrivateKeyString);
+                Array.Copy(srcArray, 0, destArray, destArray.Length - srcArray.Length, srcArray.Length);
+                var privateKey = new PrivateKey(destArray);
                 StandaloneContext.NineChroniclesNodeService.MinerPrivateKey = privateKey;
                 var msg =
                     $"Private key set ({StandaloneContext.NineChroniclesNodeService.MinerPrivateKey.PublicKey.ToAddress()}).";


### PR DESCRIPTION
This PR extends key length from the game launcher to avoid `ArgumentOutOfRangeException` when the given key is shorter than 32 bytes.