### PR TITLE
feat(cli): use default tx lifetime

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -151,8 +151,8 @@ namespace NineChronicles.Headless.Executable
             string? awsSecretKey = null,
             [Option(Description = "The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2).")]
             string? awsRegion = null,
-            [Option(Description = "The lifetime of each transaction, which uses minute as its unit.  60 (m) by default.")]
-            int txLifeTime = 60,
+            [Option(Description = "The lifetime of each transaction, which uses minute as its unit.  180 (m) by default.")]
+            int txLifeTime = 180,
             [Option(Description = "The grace period for new messages, which uses second as its unit.  60 (s) by default.")]
             int messageTimeout = 60,
             [Option(Description = "The grace period for tip update, which uses second as its unit.  60 (s) by default.")]


### PR DESCRIPTION
`Libplanet.Blockchain.Policies.VolatileStagePolicy` uses 180 minutes as default tx lifetime but the headless' option's default value was 60. This pull request makes 180 minutes, 3 hours as default value.