### PR TITLE
Revert 859

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.*
+          dotnet-version: 3.1.301
       - name: Install dependencies
         run: dotnet restore
       - name: Build and test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
 WORKDIR /app
 ARG COMMIT
 
@@ -24,7 +24,7 @@ RUN dotnet publish NineChronicles.Headless.Executable/NineChronicles.Headless.Ex
     --version-suffix $COMMIT
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
 RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .
@@ -32,8 +32,8 @@ COPY --from=build-env /app/out .
 # Install native deps & utilities for production
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
-    libc6-dev jq \
-    && rm -rf /var/lib/apt/lists/*
+        libc6-dev jq \
+     && rm -rf /var/lib/apt/lists/*
 
 VOLUME /data
 

--- a/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
+++ b/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Bencodex;
@@ -604,9 +603,8 @@ namespace Libplanet.Headless.Hosting
                 else
                 {
                     var uri = new Uri(properties.GenesisBlockPath);
-                    using var client = new HttpClient();
-                    // FIXME We should process more asynchronously without .Result.
-                    rawBlock = client.GetAsync(uri).Result.Content.ReadAsByteArrayAsync().Result;
+                    using var client = new WebClient();
+                    rawBlock = client.DownloadData(uri);
                 }
                 var blockDict = (Bencodex.Types.Dictionary)Codec.Decode(rawBlock);
                 return BlockMarshaler.UnmarshalBlock<T>(hashAlgorithmGetter, blockDict);

--- a/Libplanet.Headless/Libplanet.Headless.csproj
+++ b/Libplanet.Headless/Libplanet.Headless.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>

--- a/NineChronicles.Headless.Executable.Tests/NineChronicles.Headless.Executable.Tests.csproj
+++ b/NineChronicles.Headless.Executable.Tests/NineChronicles.Headless.Executable.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -16,7 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\NineChronicles.Headless.Executable\NineChronicles.Headless.Executable.csproj" />
+        <ProjectReference
+            Include="..\NineChronicles.Headless.Executable\NineChronicles.Headless.Executable.csproj" />
     </ItemGroup>
 
 </Project>

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>

--- a/NineChronicles.Headless.Tests/Controllers/GraphQLControllerTest.cs
+++ b/NineChronicles.Headless.Tests/Controllers/GraphQLControllerTest.cs
@@ -173,7 +173,7 @@ namespace NineChronicles.Headless.Tests.Controllers
 
         private void ConfigureAdminClaim()
         {
-            _httpContextAccessor.HttpContext!.User.AddIdentity(new ClaimsIdentity(new[]
+            _httpContextAccessor.HttpContext.User.AddIdentity(new ClaimsIdentity(new[]
             {
                 new Claim("role", "Admin"),
             }));

--- a/NineChronicles.Headless.Tests/GraphQLStartupTest.cs
+++ b/NineChronicles.Headless.Tests/GraphQLStartupTest.cs
@@ -33,7 +33,7 @@ namespace NineChronicles.Headless.Tests
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 
             var options = serviceProvider.GetService<IOptions<CorsOptions>>();
-            Assert.Equal(noCors, !(options!.Value.GetPolicy(GraphQLService.NoCorsPolicyName) is null));
+            Assert.Equal(noCors, !(options.Value.GetPolicy(GraphQLService.NoCorsPolicyName) is null));
         }
     }
 }

--- a/NineChronicles.Headless.Tests/GraphQLTestUtils.cs
+++ b/NineChronicles.Headless.Tests/GraphQLTestUtils.cs
@@ -41,7 +41,7 @@ namespace NineChronicles.Headless.Tests
             object? source = null)
             where TObjectGraphType : IObjectGraphType
         {
-            var graphType = (IObjectGraphType)serviceProvider.GetService(typeof(TObjectGraphType))!;
+            var graphType = (IObjectGraphType)serviceProvider.GetService(typeof(TObjectGraphType));
             var documentExecutor = new DocumentExecuter();
             return documentExecutor.ExecuteAsync(new ExecutionOptions
             {

--- a/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
+++ b/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -167,7 +167,7 @@ namespace NineChronicles.Headless
                             {
                                 extra[nameof(Buy.errors)] = new List(
                                     buy.errors
-                                    .Select(tuple => new List(new []
+                                    .Select(tuple => new List(new[]
                                     {
                                         tuple.orderId.Serialize(),
                                         tuple.errorCode.Serialize()

--- a/NineChronicles.Headless/Controllers/GraphQLController.cs
+++ b/NineChronicles.Headless/Controllers/GraphQLController.cs
@@ -282,6 +282,6 @@ namespace NineChronicles.Headless.Controllers
 
         // FIXME: remove this method with DI.
         private bool HasLocalPolicy() => !(_configuration[GraphQLService.SecretTokenKey] is { }) ||
-                                         _httpContextAccessor.HttpContext!.User.HasClaim("role", "Admin");
+                                         _httpContextAccessor.HttpContext.User.HasClaim("role", "Admin");
     }
 }

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace NineChronicles.Headless
                 services.AddSingleton(provider => service);
                 services.AddSingleton(provider => service.Swarm);
                 services.AddSingleton(provider => service.BlockChain);
-                services.AddSingleton(provider => properties.Libplanet!);
+                services.AddSingleton(provider => properties.Libplanet);
                 services.AddSingleton(provider =>
                 {
                     return new ActionEvaluationPublisher(

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
This PR reverts #859 to downgrade from .NET 6 to .NET Core 3.1 due to performance degradation (more specifically, NineChronicles.Headless seems to have huge memory leak under .NET 6 env). 