### PR TITLE
Chore/logging

### DIFF
--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -18,8 +18,10 @@
     <PackageReference Include="Sentry.Serilog" Version="2.1.*" />
     <PackageReference Include="Serilog.Expressions" Version="1.1.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.*" />
+    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -1,13 +1,76 @@
 {
     "Serilog": {
-        "Using": [ "Serilog.Expressions" ],
+        "Using": [ "Serilog.Expressions", "Serilog.Sinks.Console", "Serilog.Sinks.RollingFile" ],
         "MinimumLevel": "Debug",
         "WriteTo": [
             {
-                "Name": "Console",
+                "Name": "Logger",
                 "Args": {
-                    "outputTemplate":
-                        "[{Timestamp:HH:mm:ss} {Level:u3}] {Source}{Message:lj}{NewLine}{Exception}"
+                    "configureLogger": {
+                        "WriteTo": [
+                            {
+                                "Name": "Console",
+                                "Args": {
+                                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] [{Source}] {Message:lj}{NewLine}{Exception}"
+                                }
+                            }
+                        ],
+                        "Filter": [
+                            {
+                                "Name": "ByIncludingOnly",
+                                "Args": {
+                                    "expression": "Source is not null"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "Name": "Logger",
+                "Args": {
+                    "configureLogger": {
+                        "WriteTo": [
+                            {
+                                "Name": "Console",
+                                "Args": {
+                                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+                                }
+                            }
+                        ],
+                        "Filter": [
+                            {
+                                "Name": "ByExcluding",
+                                "Args": {
+                                    "expression": "Source is not null"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "Name": "Logger",
+                "Args": {
+                    "configureLogger": {
+                        "WriteTo": [
+                            {
+                                "Name": "RollingFile",
+                                "Args": {
+                                    "pathFormat": "./logs/metric-{Hour}.txt",
+                                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+                                }
+                            }
+                        ],
+                        "Filter": [
+                            {
+                                "Name": "ByIncludingOnly",
+                                "Args": {
+                                    "expression": "Tag = 'Metric'"
+                                }
+                            }
+                        ]
+                    }
                 }
             }
         ],


### PR DESCRIPTION
Accommodates changes in https://github.com/planetarium/libplanet/pull/1627 to collect ephemeral metric logs.

Should work fine regardless of submodule change, although log might look a bit odd in case of a rollback of [libplanet], but nothing serious. 🙃 

I've attempted to use new `ExpressionTemplate` feature for `appsettings.json` in `Serilog.Settings.Configuartion` `3.3.0`, which was only supported in code prior to `3.3.0`, but it seems like theming is not yet supported for `ExpressionTemplate` whilst using `appsettings.json`. 😞 

[libplanet]: https://github.com/planetarium/libplanet