### PR TITLE
fix(graphql): correct `stateQuery`'s `hash` argument logic

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -43,14 +43,8 @@ namespace NineChronicles.Headless.GraphTypes
                     BlockHash? blockHash = context.GetArgument<byte[]>("hash") switch
                     {
                         byte[] bytes => new BlockHash(bytes),
-                        null => null,
+                        null => standaloneContext.BlockChain?.GetDelayedRenderer()?.Tip?.Hash,
                     };
-
-                    if (standaloneContext.BlockChain is { } blockChain)
-                    {
-                        DelayedRenderer<NCAction>? delayedRenderer = blockChain.GetDelayedRenderer();
-                        blockHash = delayedRenderer?.Tip?.Hash;
-                    }
 
                     return (standaloneContext.BlockChain?.ToAccountStateGetter(blockHash),
                         standaloneContext.BlockChain?.ToAccountBalanceGetter(blockHash));


### PR DESCRIPTION
Since #556, `stateQuery` became to ignore `hash` argument and to use the latest tip hash from the delayed renderer in force.

This pull request fixes the bug to use `hash` argument correctly.