### PR TITLE
Docker build for Apple Silicon

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,40 @@
+FROM mcr.microsoft.com/dotnet/sdk:3.1-bullseye-arm64v8 AS build-env
+WORKDIR /app
+ARG COMMIT
+
+# Copy csproj and restore as distinct layers
+COPY ./Lib9c/Lib9c/Lib9c.csproj ./Lib9c/
+COPY ./Libplanet.Headless/Libplanet.Headless.csproj ./Libplanet.Headless/
+COPY ./NineChronicles.RPC.Shared/NineChronicles.RPC.Shared/NineChronicles.RPC.Shared.csproj ./NineChronicles.RPC.Shared/
+COPY ./NineChronicles.Headless/NineChronicles.Headless.csproj ./NineChronicles.Headless/
+COPY ./NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj ./NineChronicles.Headless.Executable/
+RUN dotnet restore Lib9c
+RUN dotnet restore Libplanet.Headless
+RUN dotnet restore NineChronicles.RPC.Shared
+RUN dotnet restore NineChronicles.Headless
+RUN dotnet restore NineChronicles.Headless.Executable
+
+# Copy everything else and build
+COPY . ./
+RUN dotnet publish NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj \
+    -c Release \
+    -r linux-x64 \
+    -o out \
+    --self-contained \
+    --version-suffix $COMMIT
+
+# Build runtime image
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/core/aspnet:3.1
+WORKDIR /app
+RUN apt-get update && apt-get install -y libc6-dev
+COPY --from=build-env /app/out .
+
+# Install native deps & utilities for production
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+        libc6-dev jq \
+     && rm -rf /var/lib/apt/lists/*
+
+VOLUME /data
+
+ENTRYPOINT ["dotnet", "NineChronicles.Headless.Executable.dll"]

--- a/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
+++ b/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
@@ -10,12 +10,6 @@
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition="
-    '$([System.Runtime.InteropServices.RuntimeInformation]::
-      OSArchitecture.ToString())' == 'Arm64' ">
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">

--- a/NineChronicles.Headless.Executable.Tests/NineChronicles.Headless.Executable.Tests.csproj
+++ b/NineChronicles.Headless.Executable.Tests/NineChronicles.Headless.Executable.Tests.csproj
@@ -8,12 +8,6 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-      <PropertyGroup Condition="
-        '$([System.Runtime.InteropServices.RuntimeInformation]::
-          OSArchitecture.ToString())' == 'Arm64' ">
-        <TargetFramework>net6.0</TargetFramework>
-      </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
         <PackageReference Include="xunit" Version="2.4.0" />

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -9,12 +9,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="
-    '$([System.Runtime.InteropServices.RuntimeInformation]::
-      OSArchitecture.ToString())' == 'Arm64' ">
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.7.0.5" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.0.6" />

--- a/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
+++ b/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
@@ -10,12 +10,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="
-    '$([System.Runtime.InteropServices.RuntimeInformation]::
-      OSArchitecture.ToString())' == 'Arm64' ">
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296">


### PR DESCRIPTION
This PR enables to build a Docker image(linux/amd64) from Apple Silicon (a.k.a. M1). To archive this, I added dedicated Dockerfile(`Dockerfile.arm64v8`) has different two things than regular `Dockerfile`.

1. `Dockerfile.arm64v8` uses `mcr.microsoft.com/dotnet/sdk:3.1-bullseye-arm64v8` instead of `mcr.microsoft.com/dotnet/sdk:3.1`. 
2. `Dockerfile.arm64v8` has `--platform linux/amd64` flags on `FROM` statement for runtime image.

Also, removing target platform redirection was needed because I still want to use 3.1 SDK on Apple Silicon.