### PR TITLE
Support options for gRPC HTTP1 endpoint

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -180,6 +180,9 @@ namespace NineChronicles.Headless.Executable
                 "The number of maximum transactions can be included in stage per signer.")]
             int txQuotaPerSigner = 10,
             bool rpcRemoteServer = false,
+            bool rpcHttpServer = false,
+            string rpcHttpListenHost = "localhost",
+            int rpcHttpListenPort = 5000,
             [Option(Description = "The interval between block polling.  15 seconds by default.")]
             int pollInterval = 15,
             [Option(Description = "The maximum number of peers to poll blocks.  int.MaxValue by default.")]
@@ -361,7 +364,8 @@ namespace NineChronicles.Headless.Executable
                 {
                     hostBuilder.UseNineChroniclesRPC(
                         NineChroniclesNodeServiceProperties
-                        .GenerateRpcNodeServiceProperties(rpcListenHost, rpcListenPort, rpcRemoteServer)
+                        .GenerateRpcNodeServiceProperties(
+                            rpcListenHost, rpcListenPort, rpcRemoteServer, rpcHttpServer, rpcHttpListenHost, rpcHttpListenPort)
                     );
                 }
 

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NineChronicles.Headless.Properties;
 using System.Net;
+using Grpc.Core;
 using Grpc.Net.Client;
 using Lib9c.Formatters;
 using MagicOnion.Server;
@@ -111,9 +112,15 @@ namespace NineChronicles.Headless
 
                             app.UseEndpoints(endpoints =>
                             {
+                                var options = new GrpcChannelOptions
+                                {
+                                    Credentials = ChannelCredentials.Insecure,
+                                    MaxReceiveMessageSize = null,
+                                };
+
                                 endpoints.MapMagicOnionHttpGateway("_",
                                     app.ApplicationServices.GetService<MagicOnion.Server.MagicOnionServiceDefinition>()
-                                        .MethodHandlers, GrpcChannel.ForAddress($"http://{properties.RpcListenHost}:{properties.RpcListenPort}"));
+                                        .MethodHandlers, GrpcChannel.ForAddress($"http://{properties.RpcListenHost}:{properties.RpcListenPort}", options));
                                 endpoints.MapMagicOnionSwagger("swagger",
                                     app.ApplicationServices.GetService<MagicOnion.Server.MagicOnionServiceDefinition>()
                                         .MethodHandlers, "/_/");

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="MagicOnion" Version="4.3.1" />
     <PackageReference Include="MagicOnion.Abstractions" Version="4.3.1" />
     <PackageReference Include="MagicOnion.Server" Version="4.3.1" />
+    <PackageReference Include="MagicOnion.Server.HttpGateway" Version="4.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="GraphQL" Version="4.7.1" />

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -124,7 +124,10 @@ namespace NineChronicles.Headless.Properties
         public static RpcNodeServiceProperties GenerateRpcNodeServiceProperties(
             string rpcListenHost = "0.0.0.0",
             int? rpcListenPort = null,
-            bool rpcRemoteServer = false)
+            bool rpcRemoteServer = false,
+            bool rpcHttpServer = false,
+            string rpcHttpListenHost = "localhost",
+            int rpcHttpListenPort = 5000)
         {
 
             if (string.IsNullOrEmpty(rpcListenHost))
@@ -143,7 +146,10 @@ namespace NineChronicles.Headless.Properties
             {
                 RpcListenHost = rpcListenHost,
                 RpcListenPort = rpcPortValue,
-                RpcRemoteServer = rpcRemoteServer
+                RpcRemoteServer = rpcRemoteServer,
+                HttpOptions = rpcHttpServer
+                    ? new RpcNodeServiceProperties.MagicOnionHttpOptions(rpcHttpListenHost, rpcHttpListenPort)
+                    : (RpcNodeServiceProperties.MagicOnionHttpOptions?)null,
             };
         }
     }

--- a/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
@@ -7,5 +7,20 @@ namespace NineChronicles.Headless.Properties
         public int RpcListenPort { get; set; }
 
         public bool RpcRemoteServer { get; set; }
+
+        public MagicOnionHttpOptions? HttpOptions { get; set; }
+
+        public readonly struct MagicOnionHttpOptions
+        {
+            public MagicOnionHttpOptions(string host, int port)
+            {
+                Host = host;
+                Port = port;
+            }
+
+            public string Host { get; }
+
+            public int Port { get; }
+        }
     }
 }


### PR DESCRIPTION
`MagicOnion` supports to open `MagicOnion` RPC services' endpoints as HTTP1 with `MagicOnion.Server.HttpGateway` package. With them, we can run general HTTP1 tools like locust.

This pull request introduces 3 options:

- `--rpc-http-server`
- `--rpc-http-listen-port`
- `--rpc-http-listen-host`

To turn on this feature, it requires `--rpc-server` flag option.