### PR TITLE
Revert "Support options for gRPC HTTP1 endpoint"

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -180,9 +180,6 @@ namespace NineChronicles.Headless.Executable
                 "The number of maximum transactions can be included in stage per signer.")]
             int txQuotaPerSigner = 10,
             bool rpcRemoteServer = false,
-            bool rpcHttpServer = false,
-            string rpcHttpListenHost = "localhost",
-            int rpcHttpListenPort = 5000,
             [Option(Description = "The interval between block polling.  15 seconds by default.")]
             int pollInterval = 15,
             [Option(Description = "The maximum number of peers to poll blocks.  int.MaxValue by default.")]
@@ -364,8 +361,7 @@ namespace NineChronicles.Headless.Executable
                 {
                     hostBuilder.UseNineChroniclesRPC(
                         NineChroniclesNodeServiceProperties
-                        .GenerateRpcNodeServiceProperties(
-                            rpcListenHost, rpcListenPort, rpcRemoteServer, rpcHttpServer, rpcHttpListenHost, rpcHttpListenPort)
+                        .GenerateRpcNodeServiceProperties(rpcListenHost, rpcListenPort, rpcRemoteServer)
                     );
                 }
 

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -2,13 +2,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NineChronicles.Headless.Properties;
 using System.Net;
-using Grpc.Core;
-using Grpc.Net.Client;
 using Lib9c.Formatters;
 using MagicOnion.Server;
 using MessagePack;
 using MessagePack.Resolvers;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 
@@ -90,45 +87,11 @@ namespace NineChronicles.Headless
                 {
                     hostBuilder.ConfigureKestrel(options =>
                     {
-                        if (properties.HttpOptions is { } httpOptions)
-                        {
-                            options.ListenAnyIP(httpOptions.Port, listenOptions =>
-                            {
-                                listenOptions.Protocols = HttpProtocols.Http1;
-                            });   
-                        }
-
                         options.ListenAnyIP(properties.RpcListenPort, listenOptions =>
                         {
                             listenOptions.Protocols = HttpProtocols.Http2;
                         });
                     });
-
-                    if (properties.HttpOptions is { })
-                    {
-                        hostBuilder.Configure(app =>
-                        {
-                            app.UseRouting();
-
-                            app.UseEndpoints(endpoints =>
-                            {
-                                var options = new GrpcChannelOptions
-                                {
-                                    Credentials = ChannelCredentials.Insecure,
-                                    MaxReceiveMessageSize = null,
-                                };
-
-                                endpoints.MapMagicOnionHttpGateway("_",
-                                    app.ApplicationServices.GetService<MagicOnion.Server.MagicOnionServiceDefinition>()
-                                        .MethodHandlers, GrpcChannel.ForAddress($"http://{properties.RpcListenHost}:{properties.RpcListenPort}", options));
-                                endpoints.MapMagicOnionSwagger("swagger",
-                                    app.ApplicationServices.GetService<MagicOnion.Server.MagicOnionServiceDefinition>()
-                                        .MethodHandlers, "/_/");
-
-                                endpoints.MapMagicOnionService();
-                            });
-                        });   
-                    }
                 });
         }
     }

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="MagicOnion" Version="4.3.1" />
     <PackageReference Include="MagicOnion.Abstractions" Version="4.3.1" />
     <PackageReference Include="MagicOnion.Server" Version="4.3.1" />
-    <PackageReference Include="MagicOnion.Server.HttpGateway" Version="4.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="GraphQL" Version="4.7.1" />

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -124,10 +124,7 @@ namespace NineChronicles.Headless.Properties
         public static RpcNodeServiceProperties GenerateRpcNodeServiceProperties(
             string rpcListenHost = "0.0.0.0",
             int? rpcListenPort = null,
-            bool rpcRemoteServer = false,
-            bool rpcHttpServer = false,
-            string rpcHttpListenHost = "localhost",
-            int rpcHttpListenPort = 5000)
+            bool rpcRemoteServer = false)
         {
 
             if (string.IsNullOrEmpty(rpcListenHost))
@@ -146,10 +143,7 @@ namespace NineChronicles.Headless.Properties
             {
                 RpcListenHost = rpcListenHost,
                 RpcListenPort = rpcPortValue,
-                RpcRemoteServer = rpcRemoteServer,
-                HttpOptions = rpcHttpServer
-                    ? new RpcNodeServiceProperties.MagicOnionHttpOptions(rpcHttpListenHost, rpcHttpListenPort)
-                    : (RpcNodeServiceProperties.MagicOnionHttpOptions?)null,
+                RpcRemoteServer = rpcRemoteServer
             };
         }
     }

--- a/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
@@ -7,20 +7,5 @@ namespace NineChronicles.Headless.Properties
         public int RpcListenPort { get; set; }
 
         public bool RpcRemoteServer { get; set; }
-
-        public MagicOnionHttpOptions? HttpOptions { get; set; }
-
-        public readonly struct MagicOnionHttpOptions
-        {
-            public MagicOnionHttpOptions(string host, int port)
-            {
-                Host = host;
-                Port = port;
-            }
-
-            public string Host { get; }
-
-            public int Port { get; }
-        }
     }
 }


### PR DESCRIPTION
Reverts planetarium/NineChronicles.Headless#1026

Can't work gql port when enable `--rpc-http-server`. maybe `HostBuilderExtension` override `GraphQLService.Configure`