### PR TITLE
Use `Server Garbage Collection` mode

### DIFF
--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -6,6 +6,7 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
In .NET, there are two GC modes, *Workstation* and *Server*. You can see the difference between them at https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/workstation-server-gc.

This pull request makes the headless application to use Server GC mode.