### PR TITLE
Capture HTTP requests

### DIFF
--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -133,6 +133,9 @@ namespace NineChronicles.Headless
                     app.UseDeveloperExceptionPage();
                 }
 
+                // Capture requests
+                app.UseMiddleware<HttpCaptureMiddleware>();
+
                 app.UseMiddleware<LocalAuthenticationMiddleware>();
                 if (Configuration[NoCorsKey] is null)
                 {

--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace NineChronicles.Headless.Middleware
+{
+    public class HttpCaptureMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger _logger;
+
+        public HttpCaptureMiddleware(RequestDelegate next)
+        {
+            _next = next;
+            _logger = Log.Logger.ForContext<HttpCaptureMiddleware>();
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            context.Request.EnableBuffering();
+            var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
+            _logger.Debug("[REQUEST-CAPTURE] {Method} {Path}\n{Body}", context.Request.Method, context.Request.Path, body);
+
+            await _next(context);
+        }
+    }
+}


### PR DESCRIPTION
Originally there was no way to see GraphQL requests' bodies. This pull request makes the headless application capture all requests' bodies with its path and method.