### PR TITLE
fix(graphql): seek HTTP request buffer to begin

### DIFF
--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -22,6 +22,7 @@ namespace NineChronicles.Headless.Middleware
             context.Request.EnableBuffering();
             var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
             _logger.Debug("[REQUEST-CAPTURE] {Method} {Path}\n{Body}", context.Request.Method, context.Request.Path, body);
+            context.Request.Body.Seek(0, SeekOrigin.Begin);
 
             await _next(context);
         }


### PR DESCRIPTION
It was failed in other middleware because the buffer was already read by `HttpCaptureMiddleware`.