### PR TITLE
fix(graphql): prevent to harm HTTP/2 (RPC) messages

### DIFF
--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -19,10 +19,14 @@ namespace NineChronicles.Headless.Middleware
 
         public async Task InvokeAsync(HttpContext context)
         {
-            context.Request.EnableBuffering();
-            var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
-            _logger.Debug("[REQUEST-CAPTURE] {Method} {Path}\n{Body}", context.Request.Method, context.Request.Path, body);
-            context.Request.Body.Seek(0, SeekOrigin.Begin);
+            // Prevent to harm HTTP/2 communication.
+            if (context.Request.Protocol == "HTTP/1.1")
+            {
+                context.Request.EnableBuffering();
+                var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
+                _logger.Debug("[REQUEST-CAPTURE] {Method} {Path}\n{Body}", context.Request.Method, context.Request.Path, body);
+                context.Request.Body.Seek(0, SeekOrigin.Begin);
+            }
 
             await _next(context);
         }


### PR DESCRIPTION
From #1046 PR...

I'm not sure that this pull request can solve all issues about RPC messaging but I tested it and played the game well after injecting DLLs based on the current branch.

I looked at messages the HTTP/2 seems harmed in logs and the game (local node mode) couldn't enter because RPC messaging doesn't work well. So I made it touch request body buffer only `HTTP/1.1` protocol and it seems succeeded.