### PR TITLE
Enable docker-from-docker in VS Code devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,5 +19,11 @@
         23061
     ],
     "postCreateCommand": "dotnet restore",
+    "features": {
+        "docker-from-docker": {
+            "version": "latest",
+            "moby": true
+        }
+    },
     "remoteUser": "vscode"
 }


### PR DESCRIPTION
This turns on [docker-from-docker][1] in VS Code devcontainer so that we can build Docker images inside GitHub Codespaces.

[1]: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md