### PR TITLE
Correct `--rpc-http-server` option feature

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -182,8 +182,6 @@ namespace NineChronicles.Headless.Executable
             int txQuotaPerSigner = 10,
             bool rpcRemoteServer = false,
             bool rpcHttpServer = false,
-            string rpcHttpListenHost = "localhost",
-            int rpcHttpListenPort = 5000,
             [Option(Description = "The interval between block polling.  15 seconds by default.")]
             int pollInterval = 15,
             [Option(Description = "The maximum number of peers to poll blocks.  int.MaxValue by default.")]
@@ -294,6 +292,9 @@ namespace NineChronicles.Headless.Executable
                         SecretToken = secretToken,
                         NoCors = noCors,
                         UseMagicOnion = rpcServer,
+                        HttpOptions = rpcServer && rpcHttpServer
+                            ? new GraphQLNodeServiceProperties.MagicOnionHttpOptions($"{rpcListenHost}:{rpcListenPort}")
+                            : (GraphQLNodeServiceProperties.MagicOnionHttpOptions?)null,
                     };
 
                     var graphQLService = new GraphQLService(graphQLNodeServiceProperties);
@@ -367,8 +368,7 @@ namespace NineChronicles.Headless.Executable
                 {
                     hostBuilder.UseNineChroniclesRPC(
                         NineChroniclesNodeServiceProperties
-                        .GenerateRpcNodeServiceProperties(
-                            rpcListenHost, rpcListenPort, rpcRemoteServer, rpcHttpServer, rpcHttpListenHost, rpcHttpListenPort)
+                        .GenerateRpcNodeServiceProperties(rpcListenHost, rpcListenPort, rpcRemoteServer)
                     );
                 }
 

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -93,45 +93,11 @@ namespace NineChronicles.Headless
                 {
                     hostBuilder.ConfigureKestrel(options =>
                     {
-                        if (properties.HttpOptions is { } httpOptions)
-                        {
-                            options.ListenAnyIP(httpOptions.Port, listenOptions =>
-                            {
-                                listenOptions.Protocols = HttpProtocols.Http1;
-                            });   
-                        }
-
                         options.ListenAnyIP(properties.RpcListenPort, listenOptions =>
                         {
                             listenOptions.Protocols = HttpProtocols.Http2;
                         });
                     });
-
-                    if (properties.HttpOptions is { })
-                    {
-                        hostBuilder.Configure(app =>
-                        {
-                            app.UseRouting();
-
-                            app.UseEndpoints(endpoints =>
-                            {
-                                var options = new GrpcChannelOptions
-                                {
-                                    Credentials = ChannelCredentials.Insecure,
-                                    MaxReceiveMessageSize = null,
-                                };
-
-                                endpoints.MapMagicOnionHttpGateway("_",
-                                    app.ApplicationServices.GetService<MagicOnion.Server.MagicOnionServiceDefinition>()
-                                        .MethodHandlers, GrpcChannel.ForAddress($"http://{properties.RpcListenHost}:{properties.RpcListenPort}", options));
-                                endpoints.MapMagicOnionSwagger("swagger",
-                                    app.ApplicationServices.GetService<MagicOnion.Server.MagicOnionServiceDefinition>()
-                                        .MethodHandlers, "/_/");
-
-                                endpoints.MapMagicOnionService();
-                            });
-                        });   
-                    }
                 });
         }
     }

--- a/NineChronicles.Headless/Properties/GraphQLNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/GraphQLNodeServiceProperties.cs
@@ -13,5 +13,17 @@ namespace NineChronicles.Headless.Properties
         public bool NoCors { get; set; }
 
         public bool UseMagicOnion { get; set; }
+
+        public MagicOnionHttpOptions? HttpOptions { get; set; }
+
+        public readonly struct MagicOnionHttpOptions
+        {
+            public MagicOnionHttpOptions(string target)
+            {
+                Target = target;
+            }
+
+            public string Target { get; }
+        }
     }
 }

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -124,10 +124,7 @@ namespace NineChronicles.Headless.Properties
         public static RpcNodeServiceProperties GenerateRpcNodeServiceProperties(
             string rpcListenHost = "0.0.0.0",
             int? rpcListenPort = null,
-            bool rpcRemoteServer = false,
-            bool rpcHttpServer = false,
-            string rpcHttpListenHost = "localhost",
-            int rpcHttpListenPort = 5000)
+            bool rpcRemoteServer = false)
         {
 
             if (string.IsNullOrEmpty(rpcListenHost))
@@ -147,9 +144,6 @@ namespace NineChronicles.Headless.Properties
                 RpcListenHost = rpcListenHost,
                 RpcListenPort = rpcPortValue,
                 RpcRemoteServer = rpcRemoteServer,
-                HttpOptions = rpcHttpServer
-                    ? new RpcNodeServiceProperties.MagicOnionHttpOptions(rpcHttpListenHost, rpcHttpListenPort)
-                    : (RpcNodeServiceProperties.MagicOnionHttpOptions?)null,
             };
         }
     }

--- a/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
@@ -7,20 +7,5 @@ namespace NineChronicles.Headless.Properties
         public int RpcListenPort { get; set; }
 
         public bool RpcRemoteServer { get; set; }
-
-        public MagicOnionHttpOptions? HttpOptions { get; set; }
-
-        public readonly struct MagicOnionHttpOptions
-        {
-            public MagicOnionHttpOptions(string host, int port)
-            {
-                Host = host;
-                Port = port;
-            }
-
-            public string Host { get; }
-
-            public int Port { get; }
-        }
     }
 }


### PR DESCRIPTION
This pull request will close #1031, #1032.

It is not good practice to call the `UseKerstel` method twice times. It reset the previous state after calling it the second time. This pull request moves all initialization to `GraphQLService`.

And `--rpc-http-listen-host` and `--rpc-http-listen-port` are meaningless so this pull request removes them.