### PR TITLE
Prevent returning null on stageTxV2 mutation

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -127,14 +127,12 @@ namespace NineChronicles.Headless.GraphTypes
                             return tx.Id;
                         }
 
-                        context.Errors.Add(new ExecutionError("The given transaction is invalid."));
+                        throw new ExecutionError("The given transaction is invalid.");
                     }
                     catch (Exception e)
                     {
-                        context.Errors.Add(new ExecutionError("An unexpected exception occurred.", e));
+                        throw new ExecutionError("An unexpected exception occurred.", e);
                     }
-
-                    return null;
                 }
             );
 


### PR DESCRIPTION
This prevents InvalidOperationException which occurs when trying to return null value on NonNullGraphType.

## Stack trace when returned null
```
System.InvalidOperationException: Cannot return null for a non-null type. Field: stageTxV2, Type: TxId!.
   at GraphQL.Execution.ExecutionStrategy.ValidateNodeResult(ExecutionContext context, ExecutionNode node) in /_/src/GraphQL/Execution/ExecutionStrategy.cs:line 566
   at GraphQL.Execution.ExecutionStrategy.CompleteNode(ExecutionContext context, ExecutionNode node) in /_/src/GraphQL/Execution/ExecutionStrategy.cs:line 480
```

## Reference
 - ["Input errors", GraphQL.NET (Accessed 2022.02.25 KST)](https://graphql-dotnet.github.io/docs/getting-started/errors/#input-errors)