### PR TITLE
Decrease `RocksDBStore`'s `dbConnectionCacheSize` option

### DIFF
--- a/NineChronicles.Headless.Executable/Store/StoreTypeExtensions.cs
+++ b/NineChronicles.Headless.Executable/Store/StoreTypeExtensions.cs
@@ -8,7 +8,7 @@ namespace NineChronicles.Headless.Executable.Store
     {
         public static IStore CreateStore(this StoreType storeType, string storePath) => storeType switch
         {
-            StoreType.RocksDb => new RocksDBStore(storePath),
+            StoreType.RocksDb => new RocksDBStore(storePath, dbConnectionCacheSize: 5),
             StoreType.Default => new DefaultStore(storePath),
             _ => throw new ArgumentOutOfRangeException(nameof(storeType))
         };


### PR DESCRIPTION
Currently, there is an issue that seems like a memory leak because the headless application goes to use more and more memory and meets OOM crash. When I researched about it with dotMemory snapshot. There were two problems. One was to keep the `RocksDB` instance on unmanaged memory by `_blockDbCache` and `_txDbCache`. And another one was to keep `BattleLog` and `AvatarState` in `RankingBattle` actions.

`_blockDbCache` and `_txDbCache` are variables typed as `LRUCache<TKey, TValue>` and it manages the cache nodes with parameterized cache size but it became a memory issue because the default cache size was 100 and it means 100 RocksDB instances will be alive over 100 days (there is a DB by an epoch, 1 day). Each `RocksDB` instance takes some memory for its index and filters. So the set of `RocksDB` instances used but not disposed occurred OOM.

This pull request decreases the cache size to 5 (5 days) and it expects to prevent using too much memory.