### PR TITLE
Bump Libplanet and add migration for rocksdb store

### DIFF
--- a/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
+++ b/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
@@ -22,11 +22,11 @@
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+      <PackageReference Include="coverlet.collector" Version="1.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Libplanet.Headless\Libplanet.Headless.csproj" />
+    <ItemGroup>
+      <ProjectReference Include="..\Libplanet.Headless\Libplanet.Headless.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -313,6 +313,11 @@ namespace Libplanet.Headless.Hosting
                         maxLogFileSize: 16 * 1024 * 1024,
                         keepLogFileNum: 1
                     );
+                    if (RocksDBStore.RocksDBStore.MigrateChainDBFromColumnFamilies(
+                            Path.Combine(path, "chain")))
+                    {
+                        Log.Debug("RocksDB is migrated.");
+                    }
                     Log.Debug("RocksDB is initialized.");
                 }
                 catch (TypeInitializationException e)

--- a/Libplanet.Headless/Libplanet.Headless.csproj
+++ b/Libplanet.Headless/Libplanet.Headless.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+    <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR includes changes from https://github.com/planetarium/lib9c/pull/879, so lib9c commit hash should be fixed after it merged.