### PR TITLE
Bump lib9c & Add store migration support

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -307,6 +307,14 @@ namespace Libplanet.Headless.Hosting
             {
                 try
                 {
+                    Log.Debug("Migrating RocksDB.");
+                    var chainPath = Path.Combine(path, "chain");
+                    if (Directory.Exists(chainPath) &&
+                        RocksDBStore.RocksDBStore.MigrateChainDBFromColumnFamilies(chainPath))
+                    {
+                        Log.Debug("RocksDB is migrated.");
+                    }
+
                     store = new RocksDBStore.RocksDBStore(
                         path,
                         maxTotalWalSize: 16 * 1024 * 1024,

--- a/Libplanet.Headless/Libplanet.Headless.csproj
+++ b/Libplanet.Headless/Libplanet.Headless.csproj
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
-    <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+    <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Supports migration for RocksDB which removes column family. Please check https://github.com/planetarium/libplanet/pull/1862 for details.