### PR TITLE
Release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  push:
+    tags: []
+
+jobs:
+  release:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check if a new tag refers a merge commit
+      run: |
+        set -evx
+        curl -o /tmp/web-flow.gpg "$WEB_FLOW_KEY_URL"
+        gpg --import /tmp/web-flow.gpg
+        if ! git verify-commit "$GITHUB_REF_NAME" && \
+           [[ "$( git cat-file -p "$GITHUB_REF_NAME" \
+                | grep -Ei '^parent\s+[0-9a-f]{40}$' | wc -l )" -lt 2 ]]; then
+          echo "::error title=Invalid tag commit::Tags must refer to a merge" \
+               "commit or a commit signed by GitHub web-flow" \
+               "($WEB_FLOW_KEY_URL).  The tag $GITHUB_REF_NAME refers to " \
+               "a commit $(git rev-parse $GITHUB_REF_NAME) which is neither" \
+               "a merge commit nor signed by GitHub web-flow."
+          exit 1
+        fi
+      env:
+        WEB_FLOW_KEY_URL: https://github.com/web-flow.gpg
+    - name: Update other repos referring NineChronicles.Headless as submodules
+      if: startsWith(github.ref_name, 'v')
+      uses: planetarium/submodule-updater@main
+      with:
+        token: ${{ secrets.SUBMODULE_UPDATER_GH_TOKEN }}
+        committer: >
+          Submodule Updater <engineering+submodule-updater@planetariumhq.com>
+        targets: |
+          planetarium/9c-launcher:rc-${{ github.ref_name }}


### PR DESCRIPTION
This patch is equivalent to <https://github.com/planetarium/lib9c/pull/898> and does the same thing except that it updates the *9c-launcher* repository:

> I worked on the GitHub Actions workflow triggered by tag pushes.  Now it does the following process for every tag push:
>
> 1. Check if the tag refers to a property merge commit, or a commit signed by GitHub @web-flow.  In other words, it ensures that the tagged commit is made by the merge button on GitHub web.
>
> 2. Open pull requests to _rc-v\*_ branches of *NineChronicles.Headless* & *NineChronicles* so that their submodules become to refer to the just released tag.  It will be done by @planet-submodule-updater account.  See also [Submodule Updater].

[Submodule Updater]: https://github.com/planetarium/submodule-updater