### PR TITLE
Trigger Submodule Updater on every push to rc-v* branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,10 @@ name: release
 
 on:
   push:
-    tags: []
+    tags:
+    - v*
+    branches:
+    - rc-v*
 
 jobs:
   release:
@@ -28,11 +31,23 @@ jobs:
       env:
         WEB_FLOW_KEY_URL: https://github.com/web-flow.gpg
     - name: Update other repos referring NineChronicles.Headless as submodules
-      if: startsWith(github.ref_name, 'v')
       uses: planetarium/submodule-updater@main
       with:
         token: ${{ secrets.SUBMODULE_UPDATER_GH_TOKEN }}
         committer: >
           Submodule Updater <engineering+submodule-updater@planetariumhq.com>
         targets: |
-          planetarium/9c-launcher:rc-${{ github.ref_name }}
+          ${{ github.repository_owner }}/9c-launcher:rc-${{ github.ref_name }}?
+
+  update-submodule:
+    if: github.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update other repos referring NineChronicles.Headless as submodules
+      uses: planetarium/submodule-updater@main
+      with:
+        token: ${{ secrets.SUBMODULE_UPDATER_GH_TOKEN }}
+        committer: >
+          Submodule Updater <engineering+submodule-updater@planetariumhq.com>
+        targets: |
+          ${{ github.repository_owner }}/9c-launcher:${{ github.ref_name }}?


### PR DESCRIPTION
Besides _v\*_ tag pushes, now every push to _rc-v\*_ branches also trigger Submodule Updater.

Note that this patch is almost equivalent to <https://github.com/planetarium/lib9c/pull/920> & <https://github.com/planetarium/NineChronicles/pull/1329>.