### PR TITLE
Add default timeout to CheckPeer

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -282,7 +282,7 @@ namespace Libplanet.Headless.Hosting
         {
             var address = new Address(addr);
             var boundPeer = await Swarm.FindSpecificPeerAsync(
-                address, -1, cancellationToken: SwarmCancellationToken);
+                address, 10, cancellationToken: SwarmCancellationToken);
             return !(boundPeer is null);
         }
 


### PR DESCRIPTION
It appears that over time connections can get exhausted with unlimited timeouts.  With this small change my local node has had no problems for over 6 hours without restarting.