### PR TITLE
Install curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=build-env /app/out .
 # Install native deps & utilities for production
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
-        libc6-dev jq \
+        libc6-dev jq curl \
      && rm -rf /var/lib/apt/lists/*
 
 VOLUME /data

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -32,7 +32,7 @@ COPY --from=build-env /app/out .
 # Install native deps & utilities for production
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
-        libc6-dev jq \
+        libc6-dev jq curl \
      && rm -rf /var/lib/apt/lists/*
 
 VOLUME /data

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -32,7 +32,7 @@ COPY --from=build-env /app/out .
 # Install native deps & utilities for production
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
-        libc6-dev jq \
+        libc6-dev jq curl \
      && rm -rf /var/lib/apt/lists/*
 
 VOLUME /data


### PR DESCRIPTION
Currently, it doesn't install the `curl` package because the base image already has it. But we always want to stay in the state prepared for .NET 6 except for only the target framework. In the .NET 6 image, it doesn't have the `curl` package so this pull request makes it install the package manually.