### PR TITLE
Introduce `query.actionQuery`

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
@@ -1,0 +1,81 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading.Tasks;
+using Bencodex;
+using Bencodex.Types;
+using GraphQL.Execution;
+using Libplanet;
+using Libplanet.Crypto;
+using Nekoyume.Action;
+using NineChronicles.Headless.GraphTypes;
+using Xunit;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
+
+namespace NineChronicles.Headless.Tests.GraphTypes
+{
+    public class ActionQueryTest
+    {
+        private readonly Codec _codec;
+
+        public ActionQueryTest()
+        {
+            _codec = new Codec();
+        }
+
+        [Theory]
+        [ClassData(typeof(StakeFixture))]
+        public async Task Stake(BigInteger amount)
+        {
+            string query = $@"
+            {{
+                stake(amount: {amount})
+            }}";
+
+            var queryResult = await ExecuteQueryAsync<ActionQuery>(query);
+            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var action = new Stake(amount);
+            var expected = new Dictionary<string, object>()
+            {
+                ["stake"] = ByteUtil.Hex(_codec.Encode(action.PlainValue)),
+            };
+            Assert.Equal(expected, data);
+        }
+        
+        [Fact]
+        public async Task ClaimStakeReward()
+        {
+            var avatarAddress = new PrivateKey().ToAddress();
+            string query = $@"
+            {{
+                claimStakeReward(avatarAddress: ""{avatarAddress.ToString()}"")
+            }}";
+
+            var queryResult = await ExecuteQueryAsync<ActionQuery>(query);
+            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var plainValue = _codec.Decode(ByteUtil.ParseHex((string) data["claimStakeReward"]));
+            Assert.IsType<Dictionary>(plainValue);
+            var dictionary = (Dictionary) plainValue;
+            Assert.Equal((Binary) dictionary[Lib9c.SerializeKeys.AvatarAddressKey], avatarAddress.ToByteArray());
+        }
+
+        private class StakeFixture : IEnumerable<object[]>
+        {
+            private readonly List<object[]> _data = new List<object[]>
+            {
+                new object[]
+                {
+                    new BigInteger(1),
+                },
+                new object[]
+                {
+                    new BigInteger(100),
+                },
+            };
+
+            public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => _data.GetEnumerator();
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -1,0 +1,37 @@
+using System.Numerics;
+using Bencodex;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet;
+using Libplanet.Explorer.GraphTypes;
+using Nekoyume.Action;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public class ActionQuery : ObjectGraphType
+    {
+        public ActionQuery()
+        {
+            var codec = new Codec();
+            Field<ByteStringType>(
+                name: "stake",
+                arguments: new QueryArguments(new QueryArgument<BigIntGraphType>
+                {
+                    Name = "amount",
+                    Description = "An amount to stake.",
+                }),
+                resolve: context => codec.Encode(new Stake(context.GetArgument<BigInteger>("amount")).PlainValue));
+
+            Field<ByteStringType>(
+                name: "claimStakeReward",
+                arguments: new QueryArguments(
+                    new QueryArgument<AddressType>
+                    {
+                        Name = "avatarAddress",
+                        Description = "The avatar address to receive staking rewards."
+                    }),
+                resolve: context =>
+                    codec.Encode(new ClaimStakeReward(context.GetArgument<Address>("avatarAddress")).PlainValue));
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -59,6 +59,11 @@ namespace NineChronicles.Headless.GraphTypes
                 }
             );
 
+            Field<NonNullGraphType<ActionQuery>>(
+                name: "actionQuery",
+                resolve: _ => new ActionQuery()
+            );
+
             Field<ByteStringType>(
                 name: "state",
                 arguments: new QueryArguments(


### PR DESCRIPTION
This pull request introduces `actionQuery` query to generate actions with GraphQL API.

```graphql
query {
  actionQuery {
    stake(amount: BigInt!): ByteString;
    claimStakeReward(avatarAddress: Address!): ByteString;
  }
}
```