### PR TITLE
Allow running headless without authorized mining

### DIFF
--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -343,6 +343,7 @@ namespace NineChronicles.Headless
                 NetworkType.Internal => source.GetInternalPolicy(),
                 NetworkType.Permanent => source.GetPermanentPolicy(),
                 NetworkType.Test => source.GetTestPolicy(),
+                NetworkType.Default => source.GetDefaultPolicy(),
                 _ => throw new ArgumentOutOfRangeException(nameof(networkType), networkType, null),
             };
         }

--- a/NineChronicles.Headless/Properties/NetworkType.cs
+++ b/NineChronicles.Headless/Properties/NetworkType.cs
@@ -6,5 +6,6 @@
         Internal,
         Permanent,
         Test,
+        Default,
     }
 }


### PR DESCRIPTION
Since this pull request, you can run headless without authorized mining.