### PR TITLE
Update Transaction API with actionQuery Compatibility

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/KeyCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/KeyCommandTest.cs
@@ -1,7 +1,11 @@
 using System;
+using Libplanet;
 using Libplanet.Crypto;
+using Libplanet.Extensions.Cocona;
 using Libplanet.KeyStore;
 using NineChronicles.Headless.Executable.Commands;
+using NineChronicles.Headless.Executable.IO;
+using NineChronicles.Headless.Executable.Tests.IO;
 using NineChronicles.Headless.Executable.Tests.KeyStore;
 using Xunit;
 
@@ -11,11 +15,13 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
     {
         private readonly IKeyStore _keyStore;
         private readonly KeyCommand _keyCommand;
+        private readonly IConsole _console;
 
         public KeyCommandTest()
         {
             _keyStore = new InMemoryKeyStore();
-            _keyCommand = new KeyCommand(_keyStore);
+            _console = new StringIOConsole();
+            _keyCommand = new KeyCommand(_console, _keyStore);
         }
 
         [Theory]
@@ -29,6 +35,19 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             Assert.Contains(keyId, _keyStore.ListIds());
             _keyCommand.Remove(keyId, passphrase: inputPassphrase, noPassphrase: true);
             Assert.DoesNotContain(keyId, _keyStore.ListIds());
+        }
+
+        [Fact]
+        public void PublicKey()
+        {
+            PrivateKey privateKey = new PrivateKey();
+            Guid keyId = _keyStore.Add(ProtectedPrivateKey.Protect(privateKey, "1234"));
+
+            Assert.Contains(keyId, _keyStore.ListIds());
+            var passPhrase = new PassphraseParameters();
+            passPhrase.Passphrase = "1234";
+            _keyCommand.PublicKey(keyId, passPhrase);
+            Assert.Equal(_console.Out.ToString()!.Trim(), ByteUtil.Hex(privateKey.PublicKey.Format(false)));
         }
     }
 }

--- a/NineChronicles.Headless.Executable.Tests/IO/StringIOConsole.cs
+++ b/NineChronicles.Headless.Executable.Tests/IO/StringIOConsole.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using NineChronicles.Headless.Executable.IO;
 
@@ -22,6 +23,10 @@ namespace NineChronicles.Headless.Executable.Tests.IO
         public StringWriter Out { get; }
 
         public StringWriter Error { get; }
+        public Stream OpenStandardOutput()
+        {
+            throw new NotImplementedException();
+        }
 
         TextReader IConsole.In => In;
 

--- a/NineChronicles.Headless.Executable/Commands/KeyCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/KeyCommand.cs
@@ -186,6 +186,62 @@ namespace NineChronicles.Headless.Executable.Commands
             }
         }
 
+        [Command(Description = "Sign a message.")]
+        public void Sign(
+            [Argument("KEY-ID", Description = "A key UUID to sign.")]
+            Guid keyId,
+            [Argument(
+                "FILE",
+                Description = "A path of the file to sign. If you pass '-' dash character, " +
+                              "it will receive the message to sign from stdin."
+            )]
+            string path,
+            PassphraseParameters passphrase,
+            [Option(Description = "A path of the file to save the signature. " +
+                                  "If you pass '-' dash character, it will print to stdout " +
+                                  "as raw bytes not hexadecimal string or else. " +
+                                  "If this option isn't given, it will print hexadecimal string " +
+                                  "to stdout as default behaviour.")]
+            string? binaryOutput = null
+        )
+        {
+            // FIXME Call Libplanet.Extensions.Cocona.Commands.KeyCommand.Sign after
+            // Libplanet.Extensions.Cocona.Commands.KeyCommand can configure KeyStore.
+            PrivateKey key = UnprotectKey(keyId, passphrase.Passphrase);
+
+            byte[] message;
+            if (path == "-")
+            {
+                // Stream for stdin does not support .Seek()
+                using MemoryStream buffer = new MemoryStream();
+                using (Stream stream = Console.OpenStandardInput())
+                {
+                    stream.CopyTo(buffer);
+                }
+
+                message = buffer.ToArray();
+            }
+            else
+            {
+                message = File.ReadAllBytes(path);
+            }
+
+            var signature = key.Sign(message);
+            if (binaryOutput is null)
+            {
+                Console.WriteLine(ByteUtil.Hex(signature));
+            }
+            else if (binaryOutput == "-")
+            {
+                using Stream stdout = Console.OpenStandardOutput();
+                stdout.Write(signature, 0, signature.Length);
+            }
+            else
+            {
+                File.WriteAllBytes(binaryOutput, signature);
+            }
+        }
+
         public void PublicKey(
             [Argument("KEY-ID", Description = "A key UUID to sign.")]
             Guid keyId,

--- a/NineChronicles.Headless.Executable/IO/IConsole.cs
+++ b/NineChronicles.Headless.Executable/IO/IConsole.cs
@@ -7,5 +7,6 @@ namespace NineChronicles.Headless.Executable.IO
         TextReader In { get; }
         TextWriter Out { get; }
         TextWriter Error { get; }
+        Stream OpenStandardOutput();
     }
 }

--- a/NineChronicles.Headless.Executable/IO/StandardConsole.cs
+++ b/NineChronicles.Headless.Executable/IO/StandardConsole.cs
@@ -17,5 +17,9 @@ namespace NineChronicles.Headless.Executable.IO
         public TextWriter Out { get; }
 
         public TextWriter Error { get; }
+        public Stream OpenStandardOutput()
+        {
+            return Console.OpenStandardOutput();
+        }
     }
 }

--- a/NineChronicles.Headless.Tests/GraphTypes/ScenarioTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ScenarioTest.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using Libplanet;
+using Libplanet.Assets;
+using Libplanet.Crypto;
+using Libplanet.Extensions.Cocona;
+using Libplanet.KeyStore;
+using Libplanet.Tx;
+using Nekoyume.Action;
+using NineChronicles.Headless.Executable.Commands;
+using NineChronicles.Headless.Executable.Tests.IO;
+using NineChronicles.Headless.Executable.Tests.KeyStore;
+using NineChronicles.Headless.GraphTypes;
+using Xunit;
+using Xunit.Abstractions;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+
+namespace NineChronicles.Headless.Tests.GraphTypes
+{
+    public class ScenarioTest : GraphQLTestBase
+    {
+        public ScenarioTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task SignTransaction()
+        {
+            var privateKey = new PrivateKey();
+            var privateKey2 = new PrivateKey();
+            var recipient = privateKey.ToAddress();
+            var sender = privateKey2.ToAddress();
+
+            // Create Action.
+            var args = $"recipient: \"{recipient}\", sender: \"{sender}\", amount: \"17.5\", currency: CRYSTAL";
+            var actionQuery = $"{{ transferAsset({args}) }}";
+            var actionQueryResult = await ExecuteQueryAsync<ActionQuery>(actionQuery);
+            var actionData = (Dictionary<string, object>) ((ExecutionNode) actionQueryResult.Data!).ToValue()!;
+            var plainValue = actionData["transferAsset"];
+
+            // Get Nonce.
+            var nonceQuery = $@"query {{
+                    nextTxNonce(address: ""{privateKey.ToAddress()}"")
+                }}";
+            var nonceQueryResult =
+                await ExecuteQueryAsync<TransactionHeadlessQuery>(nonceQuery, standaloneContext: StandaloneContextFx);
+            var nonce =
+                (long) ((Dictionary<string, object>) ((ExecutionNode) nonceQueryResult.Data!)
+                    .ToValue()!)["nextTxNonce"];
+
+            // Get PublicKey.
+            var keyStore = new InMemoryKeyStore();
+            Guid keyId = keyStore.Add(ProtectedPrivateKey.Protect(privateKey, "1234"));
+            var passPhrase = new PassphraseParameters();
+            passPhrase.Passphrase = "1234";
+            var console = new StringIOConsole();
+            var keyCommand = new KeyCommand(console, keyStore);
+            keyCommand.PublicKey(keyId, passPhrase);
+            var hexedPublicKey = console.Out.ToString().Trim();
+
+            Assert.Equal(hexedPublicKey, ByteUtil.Hex(privateKey.PublicKey.Format(false)));
+
+            // Create unsigned Transaction.
+            var unsignedQuery = $@"query {{
+                    unsignedTransaction(publicKey: ""{hexedPublicKey}"", plainValue: ""{plainValue}"", nonce: {nonce})
+                }}";
+            var unsignedQueryResult =
+                await ExecuteQueryAsync<TransactionHeadlessQuery>(unsignedQuery, standaloneContext: StandaloneContextFx);
+            var unsignedData =
+                (string) ((Dictionary<string, object>) ((ExecutionNode) unsignedQueryResult.Data!).ToValue()!)[
+                    "unsignedTransaction"];
+            var unsignedTxBytes = ByteUtil.ParseHex(unsignedData);
+            Transaction<NCAction> unsignedTx = Transaction<NCAction>.Deserialize(unsignedTxBytes, false);
+
+            // Sign Transaction in local.
+            var path = Path.GetTempFileName();
+            await File.WriteAllBytesAsync(path, unsignedTxBytes);
+            var outputPath = Path.GetTempFileName();
+            keyCommand.Sign(keyId, path, passPhrase, outputPath);
+
+            var signature = ByteUtil.Hex(await File.ReadAllBytesAsync(outputPath));
+            Assert.Equal(ByteUtil.Hex(privateKey.Sign(unsignedTxBytes)), signature);
+
+            // Attachment signature & unsigned transaction
+            var signQuery = $@"query {{
+                    signTransaction(unsignedTransaction: ""{unsignedData}"", signature: ""{signature}"")
+                }}";
+            var signQueryResult =
+                await ExecuteQueryAsync<TransactionHeadlessQuery>(signQuery, standaloneContext: StandaloneContextFx);
+            var hex = (string) ((Dictionary<string, object>) ((ExecutionNode) signQueryResult.Data!).ToValue()!)[
+                "signTransaction"];
+            byte[] result = ByteUtil.ParseHex(hex);
+            Transaction<NCAction> signedTx = Transaction<NCAction>.Deserialize(result);
+
+            Assert.Equal(unsignedTx.PublicKey, signedTx.PublicKey);
+            Assert.Equal(unsignedTx.Signer, signedTx.Signer);
+            Assert.Equal(nonce, signedTx.Nonce);
+            Assert.Equal(unsignedTx.UpdatedAddresses, signedTx.UpdatedAddresses);
+            Assert.Equal(unsignedTx.Timestamp, signedTx.Timestamp);
+            Assert.Single(unsignedTx.Actions);
+            Assert.Single(signedTx.Actions);
+            Assert.IsType<TransferAsset>(signedTx.Actions.Single().InnerAction);
+            var action = Assert.IsType<TransferAsset>(signedTx.Actions.Single().InnerAction);
+            Assert.Equal(recipient, action.Recipient);
+            Assert.Equal(sender, action.Sender);
+            Assert.Equal(FungibleAssetValue.Parse(CurrencyType.CRYSTAL, "17.5"), action.Amount);
+
+            // Staging Transaction.
+            var stageTxMutation = $"mutation {{ stageTransaction(payload: \"{hex}\") }}";
+            var stageTxResult = await ExecuteQueryAsync(stageTxMutation);
+            var txId =
+                (string) ((Dictionary<string, object>) ((ExecutionNode) stageTxResult.Data!).ToValue()!)["stageTransaction"];
+            Assert.Equal(signedTx.Id.ToHex(), txId);
+            Assert.Contains(signedTx.Id, StandaloneContextFx.BlockChain!.GetStagedTransactionIds());
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/TransactionHeadlessQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/TransactionHeadlessQueryTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Security.Cryptography;
@@ -13,12 +14,19 @@ using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Crypto;
+using Libplanet.Extensions.Cocona;
+using Libplanet.KeyStore;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Libplanet.Tx;
 using Nekoyume.Action;
+using NineChronicles.Headless.Executable.Tests.IO;
+using NineChronicles.Headless.Executable.Tests.KeyStore;
 using NineChronicles.Headless.GraphTypes;
+using NineChronicles.Headless.Tests.Common;
 using Xunit;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
+using KeyCommand = NineChronicles.Headless.Executable.Commands.KeyCommand;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Headless.Tests.GraphTypes
@@ -28,6 +36,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
         private readonly BlockChain<NCAction> _blockChain;
         private readonly IStore _store;
         private readonly IStateStore _stateStore;
+        private readonly NineChroniclesNodeService _service;
 
         public TransactionHeadlessQueryTest()
         {
@@ -39,6 +48,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 _store,
                 _stateStore,
                 BlockChain<NCAction>.MakeGenesisBlock(HashAlgorithmType.Of<SHA256>()));
+            _service = ServiceBuilder.CreateNineChroniclesNodeService(_blockChain.Genesis, new PrivateKey());
         }
 
         [Fact]
@@ -316,8 +326,91 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             return GraphQLTestUtils.ExecuteQueryAsync<TransactionHeadlessQuery>(query, standaloneContext: new StandaloneContext
             {
                 BlockChain = _blockChain,
-                Store = _store
+                Store = _store,
+                NineChroniclesNodeService = _service
             });
-        }  
-    }     
+        }
+
+        [Fact]
+        public async Task SignTransaction()
+        {
+            var privateKey = new PrivateKey();
+            var privateKey2 = new PrivateKey();
+            var recipient = privateKey.ToAddress();
+            var sender = privateKey2.ToAddress();
+
+            // Create Action.
+            var args = $"recipient: \"{recipient}\", sender: \"{sender}\", amount: \"17.5\", currency: CRYSTAL";
+            var actionQuery = $"{{ transferAsset({args}) }}";
+            var actionQueryResult = await ExecuteQueryAsync<ActionQuery>(actionQuery);
+            var actionData = (Dictionary<string, object>) ((ExecutionNode) actionQueryResult.Data!).ToValue()!;
+            var plainValue = actionData["transferAsset"];
+
+            // Get Nonce.
+            var nonceQuery = $@"query {{
+                nextTxNonce(address: ""{privateKey.ToAddress()}"")
+            }}";
+            var nonceQueryResult = await ExecuteAsync(nonceQuery);
+            var nonce = (long) ((Dictionary<string, object>) ((ExecutionNode) nonceQueryResult.Data!).ToValue()!)["nextTxNonce"];
+
+            // Get PublicKey.
+            var keyStore = new InMemoryKeyStore();
+            Guid keyId = keyStore.Add(ProtectedPrivateKey.Protect(privateKey, "1234"));
+            var passPhrase = new PassphraseParameters();
+            passPhrase.Passphrase = "1234";
+            var console = new StringIOConsole();
+            var keyCommand = new KeyCommand(console, keyStore);
+            keyCommand.PublicKey(keyId, passPhrase);
+            var hexedPublicKey = console.Out.ToString().Trim();
+
+            Assert.Equal(hexedPublicKey, ByteUtil.Hex(privateKey.PublicKey.Format(false)));
+
+            // Create unsigned Transaction.
+            var unsignedQuery = $@"query {{
+                unsignedTransaction(publicKey: ""{hexedPublicKey}"", plainValue: ""{plainValue}"", nonce: {nonce})
+            }}";
+            var unsignedQueryResult = await ExecuteAsync(unsignedQuery);
+            var unsignedData = (string)((Dictionary<string, object>)((ExecutionNode) unsignedQueryResult.Data!).ToValue()!)["unsignedTransaction"];
+            var unsignedTxBytes = ByteUtil.ParseHex(unsignedData);
+            Transaction<NCAction> unsignedTx = Transaction<NCAction>.Deserialize(unsignedTxBytes, false);
+
+            // Sign Transaction in local.
+            var path = Path.GetTempFileName();
+            await File.WriteAllBytesAsync(path, unsignedTxBytes);
+            var outputPath = Path.GetTempFileName();
+            keyCommand.Sign(keyId, path, passPhrase, outputPath);
+
+            var signature = ByteUtil.Hex(await File.ReadAllBytesAsync(outputPath));
+            Assert.Equal(ByteUtil.Hex(privateKey.Sign(unsignedTxBytes)), signature);
+
+            // Attachment signature & unsigned transaction
+            var signQuery = $@"query {{
+                signTransaction(unsignedTransaction: ""{unsignedData}"", signature: ""{signature}"")
+            }}";
+            var signQueryResult = await ExecuteAsync(signQuery);
+            var hex = (string) ((Dictionary<string, object>) ((ExecutionNode) signQueryResult.Data!).ToValue()!)[
+                "signTransaction"];
+            byte[] result = ByteUtil.ParseHex(hex);
+            Transaction<NCAction> signedTx = Transaction<NCAction>.Deserialize(result);
+
+            Assert.Equal(unsignedTx.PublicKey, signedTx.PublicKey);
+            Assert.Equal(unsignedTx.Signer, signedTx.Signer);
+            Assert.Equal(nonce, signedTx.Nonce);
+            Assert.Equal(unsignedTx.UpdatedAddresses, signedTx.UpdatedAddresses);
+            Assert.Equal(unsignedTx.Timestamp, signedTx.Timestamp);
+            Assert.Single(unsignedTx.Actions);
+            Assert.Single(signedTx.Actions);
+            Assert.IsType<TransferAsset>(signedTx.Actions.Single().InnerAction);
+            var action = Assert.IsType<TransferAsset>(signedTx.Actions.Single().InnerAction);
+            Assert.Equal(recipient, action.Recipient);
+            Assert.Equal(sender, action.Sender);
+
+            // Staging Transaction.
+            var stageTxQuery = $"query {{ stageTx(payload: \"{hex}\") }}";
+            var stageTxResult = await ExecuteAsync(stageTxQuery);
+            var txId = (string)((Dictionary<string, object>) ((ExecutionNode) stageTxResult.Data!).ToValue()!)["stageTx"];
+            Assert.Equal(signedTx.Id.ToHex(), txId);
+            Assert.Contains(signedTx.Id, _service.BlockChain.GetStagedTransactionIds());
+        }
+    }
 }

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -5,6 +5,7 @@ using Bencodex;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet;
+using Libplanet.Assets;
 using Libplanet.Explorer.GraphTypes;
 using Nekoyume.Action;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
@@ -118,6 +119,50 @@ namespace NineChronicles.Headless.GraphTypes
                         AvatarAddress = avatarAddress,
                         WorldIds = worldIds,
                     };
+                    return Codec.Encode(action.PlainValue);
+                });
+            Field<ByteStringType>(
+                name: "transferAsset",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Description = "Address of sender.",
+                        Name = "sender",
+                    },
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Description = "Address of recipient.",
+                        Name = "recipient",
+                    },
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Description = "A string value to be transferred.",
+                        Name = "amount",
+                    },
+                    new QueryArgument<NonNullGraphType<CurrencyType>>
+                    {
+                        Description = "A currency value to be transferred.",
+                        Name = "currency",
+                    },
+                    new QueryArgument<StringGraphType>
+                    {
+                        Description = "A 80-max length string to note.",
+                        Name = "memo",
+                    }
+                ),
+                resolve: context =>
+                {
+                    var sender = context.GetArgument<Address>("sender");
+                    var recipient = context.GetArgument<Address>("recipient");
+                    Currency currency = context.GetArgument<CurrencyEnum>("currency") switch
+                    {
+                        CurrencyEnum.NCG => CurrencyType.NCG,
+                        CurrencyEnum.CRYSTAL => CurrencyType.CRYSTAL,
+                        _ => throw new ExecutionError($"Unsupported Currency type.")
+                    };
+                    var amount = FungibleAssetValue.Parse(currency, context.GetArgument<string>("amount"));
+                    var memo = context.GetArgument<string?>("memo");
+                    NCAction action = new TransferAsset(sender, recipient, amount, memo);
                     return Codec.Encode(action.PlainValue);
                 });
         }

--- a/NineChronicles.Headless/GraphTypes/CurrencyType.cs
+++ b/NineChronicles.Headless/GraphTypes/CurrencyType.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using GraphQL.Types;
+using Libplanet.Assets;
+using Nekoyume.Helper;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    [Description("The currency type.")]
+    public enum CurrencyEnum
+    {
+        CRYSTAL,
+        NCG,
+    }
+
+    public class CurrencyType: EnumerationGraphType<CurrencyEnum>
+    {
+        public static readonly Currency NCG = new Currency("NCG", 2, minters: null);
+        public static Currency CRYSTAL => CrystalCalculator.CRYSTAL;
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -270,6 +270,55 @@ namespace NineChronicles.Headless.GraphTypes
                     return tx.Id;
                 }
             );
+
+            Field<NonNullGraphType<TxIdType>>(
+                name: "stageTransaction",
+                description: "Add a new transaction to staging and return TxId",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Name = "payload",
+                        Description = "The hexadecimal of string for staging transaction."
+                    }
+                ),
+                resolve: context =>
+                {
+                    try
+                    {
+                        byte[] bytes = ByteUtil.ParseHex(context.GetArgument<string>("payload"));
+                        Transaction<NCAction> tx = Transaction<NCAction>.Deserialize(bytes);
+                        NineChroniclesNodeService? service = standaloneContext.NineChroniclesNodeService;
+                        BlockChain<NCAction>? blockChain = service?.Swarm.BlockChain;
+
+                        if (blockChain is null)
+                        {
+                            throw new InvalidOperationException($"{nameof(blockChain)} is null.");
+                        }
+
+                        Exception? validationExc = blockChain.Policy.ValidateNextBlockTx(blockChain, tx);
+                        if (validationExc is null)
+                        {
+                            blockChain.StageTransaction(tx);
+
+                            if (service?.Swarm is { } swarm && swarm.Running)
+                            {
+                                swarm.BroadcastTxs(new[] { tx });
+                            }
+
+                            return tx.Id;
+                        }
+
+                        throw new ExecutionError(
+                            $"The given transaction is invalid. (due to: {validationExc.Message})",
+                            validationExc
+                        );
+                    }
+                    catch (Exception e)
+                    {
+                        throw new ExecutionError("An unexpected exception occurred.", e);
+                    }
+                }
+            );
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -93,6 +93,7 @@ namespace NineChronicles.Headless.GraphTypes
             // TODO deprecate stageTx and use this.
             Field<NonNullGraphType<TxIdType>>(
                 name: "stageTxV2",
+                deprecationReason: "API update with action query. use transactionQuery.stageTx",
                 description: "Add a new transaction to staging and return TxId",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<StringGraphType>>

--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -278,7 +278,7 @@ namespace NineChronicles.Headless.GraphTypes
                     new QueryArgument<NonNullGraphType<StringGraphType>>
                     {
                         Name = "payload",
-                        Description = "The hexadecimal of string for staging transaction."
+                        Description = "The hexadecimal string of the transaction to stage."
                     }
                 ),
                 resolve: context =>

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -420,6 +420,10 @@ namespace NineChronicles.Headless.GraphTypes
                 description: "Query for rpc mode information.",
                 resolve: context => new RpcInformationQuery(publisher)
             );
+
+            Field<NonNullGraphType<ActionQuery>>(
+                name: "actionQuery",
+                resolve: context => new ActionQuery());
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -259,55 +259,6 @@ namespace NineChronicles.Headless.GraphTypes
                     return signedTransaction.Serialize(true);
                 }
             );
-
-            Field<NonNullGraphType<TxIdType>>(
-                name: "stageTx",
-                description: "Add a new transaction to staging and return TxId",
-                arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
-                    {
-                        Name = "payload",
-                        Description = "The hexadecimal of string for staging transaction."
-                    }
-                ),
-                resolve: context =>
-                {
-                    try
-                    {
-                        byte[] bytes = ByteUtil.ParseHex(context.GetArgument<string>("payload"));
-                        Transaction<NCAction> tx = Transaction<NCAction>.Deserialize(bytes);
-                        NineChroniclesNodeService? service = standaloneContext.NineChroniclesNodeService;
-                        BlockChain<NCAction>? blockChain = service?.Swarm.BlockChain;
-
-                        if (blockChain is null)
-                        {
-                            throw new InvalidOperationException($"{nameof(blockChain)} is null.");
-                        }
-
-                        Exception? validationExc = blockChain.Policy.ValidateNextBlockTx(blockChain, tx);
-                        if (validationExc is null)
-                        {
-                            blockChain.StageTransaction(tx);
-
-                            if (service?.Swarm is { } swarm && swarm.Running)
-                            {
-                                swarm.BroadcastTxs(new[] { tx });
-                            }
-
-                            return tx.Id;
-                        }
-
-                        throw new ExecutionError(
-                            $"The given transaction is invalid. (due to: {validationExc.Message})",
-                            validationExc
-                        );
-                    }
-                    catch (Exception e)
-                    {
-                        throw new ExecutionError("An unexpected exception occurred.", e);
-                    }
-                }
-            );
         }
     }
 }


### PR DESCRIPTION
- resolve #1271 
- Import KeyCommand from Libplanet.
- Deprecate base64 using Transaction API.
- Update Transaction API with action query.