### PR TITLE
Provides action commands related to `Stake`

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
@@ -142,5 +142,47 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
                 Assert.Contains("System.FormatException: Could not find any recognizable digits.", _console.Error.ToString());
             }
         }
+
+        [Fact]
+        public void Stake()
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            var resultCode = _command.Stake(1, filePath);
+            Assert.Equal(0, resultCode);
+            var rawAction = Convert.FromBase64String(File.ReadAllText(filePath));
+            var decoded = (List)_codec.Decode(rawAction);
+            string type = (Text)decoded[0];
+            Assert.Equal(nameof(Nekoyume.Action.Stake), type);
+
+            var plainValue = Assert.IsType<Dictionary>(decoded[1]);
+            var action = new Stake();
+            action.LoadPlainValue(plainValue);
+        }
+
+        [Theory]
+        [InlineData("0xab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d", -1)]
+        [InlineData("ab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d", 0)]
+        public void ClaimStakeReward(string addressString, int expectedCode)
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            var resultCode = _command.ClaimStakeReward(addressString, filePath);
+            Assert.Equal(expectedCode, resultCode);
+
+            if (resultCode == 0)
+            {
+                var rawAction = Convert.FromBase64String(File.ReadAllText(filePath));
+                var decoded = (List)_codec.Decode(rawAction);
+                string type = (Text)decoded[0];
+                Assert.Equal(nameof(Nekoyume.Action.ClaimStakeReward), type);
+
+                var plainValue = Assert.IsType<Dictionary>(decoded[1]);
+                var action = new ClaimStakeReward();
+                action.LoadPlainValue(plainValue);
+            }
+            else
+            {
+                Assert.Contains("System.FormatException: Could not find any recognizable digits.", _console.Error.ToString());
+            }
+        }
     }
 }

--- a/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
@@ -78,6 +78,25 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
                 filePath);
             Assert_Tx(1, filePath);
         }
+        
+        [Fact]
+        public void Sign_Stake()
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            var actionCommand = new ActionCommand(_console);
+            actionCommand.Stake(1, filePath);
+            Assert_Tx(1, filePath);
+        }
+
+        [Fact]
+        public void Sign_ClaimStakeReward()
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            var actionCommand = new ActionCommand(_console);
+            var avatarAddress = new Address();
+            actionCommand.ClaimStakeReward(avatarAddress.ToHex(), filePath);
+            Assert_Tx(1, filePath);
+        }
 
         private void Assert_Tx(long txNonce, string filePath)
         {

--- a/NineChronicles.Headless.Executable/Commands/ActionCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ActionCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
+using System.Numerics;
 using Bencodex;
 using Bencodex.Types;
 using Cocona;
@@ -182,6 +183,78 @@ namespace NineChronicles.Headless.Executable.Commands
                     File.WriteAllText(filePath, encoded);
                     Console.Write(encoded);
                 }
+                return 0;
+            }
+            catch (Exception e)
+            {
+                _console.Error.WriteLine(e);
+                return -1;
+            }
+        }
+
+        [Command(Description = "Create Stake action.")]
+        public int Stake(
+            long amount,
+            [Argument("PATH", Description = "A file path of base64 encoded action.")] string? filePath = null
+        )
+        {
+            try
+            {
+                Nekoyume.Action.Stake action = new Stake(amount);
+                byte[] raw = Codec.Encode(new List(
+                    new[]
+                    {
+                        (Text) nameof(Nekoyume.Action.Stake),
+                        action.PlainValue
+                    }
+                ));
+                string encoded = Convert.ToBase64String(raw);
+                if (filePath is null)
+                {
+                    _console.Out.Write(encoded);
+                }
+                else
+                {
+                    File.WriteAllText(filePath, encoded);   
+                }
+
+                return 0;
+            }
+            catch (Exception e)
+            {
+                _console.Error.WriteLine(e);
+                return -1;
+            }
+        }
+
+        [Command(Description = "Create ClaimStakeReward action.")]
+        public int ClaimStakeReward(
+            [Argument("AVATAR-ADDRESS", Description = "A hex-encoded avatar address.")] string encodedAddress,
+            [Argument("PATH", Description = "A file path of base64 encoded action.")] string? filePath = null
+        )
+        {
+            try
+            {
+                Address avatarAddress = new Address(ByteUtil.ParseHex(encodedAddress));
+                Nekoyume.Action.ClaimStakeReward action = new ClaimStakeReward(avatarAddress);
+
+                byte[] raw = Codec.Encode(new List(
+                    new[]
+                    {
+                        (Text) nameof(Nekoyume.Action.ClaimStakeReward),
+                        action.PlainValue
+                    }
+                ));
+                string encoded = Convert.ToBase64String(raw);
+                if (filePath is null)
+                {
+                    _console.Out.Write(encoded);
+                }
+                else
+                {
+                    File.WriteAllText(filePath, encoded);   
+                }
+
                 return 0;
             }
             catch (Exception e)

--- a/NineChronicles.Headless.Executable/Commands/TxCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/TxCommand.cs
@@ -52,6 +52,8 @@ namespace NineChronicles.Headless.Executable.Commands
                     nameof(ActivateAccount) => new ActivateAccount(),
                     nameof(MonsterCollect) => new MonsterCollect(),
                     nameof(ClaimMonsterCollectionReward) => new ClaimMonsterCollectionReward(),
+                    nameof(Stake) => new Stake(),
+                    nameof(ClaimStakeReward) => new ClaimStakeReward(),
                     nameof(TransferAsset) => new TransferAsset(),
                     _ => throw new CommandExitedException($"Unsupported action type was passed '{type}'", 128)
                 };
@@ -59,6 +61,10 @@ namespace NineChronicles.Headless.Executable.Commands
 
                 return (NCAction)action;
             }).ToList();
+            
+            Console.WriteLine(privateKey);
+            Console.WriteLine(genesisHash);
+            Console.WriteLine(timestamp);
 
             Transaction<NCAction> tx = Transaction<NCAction>.Create(
                 nonce: nonce,


### PR DESCRIPTION
The next direction should be focused on the `actionQuery` GraphQL API, but this pull request provides action commands related to `Stake` now.