### PR TITLE
Fix invalid currency in transferAsset action query

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/ScenarioTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ScenarioTest.cs
@@ -11,6 +11,7 @@ using Libplanet.Extensions.Cocona;
 using Libplanet.KeyStore;
 using Libplanet.Tx;
 using Nekoyume.Action;
+using Nekoyume.Helper;
 using NineChronicles.Headless.Executable.Commands;
 using NineChronicles.Headless.Executable.Tests.IO;
 using NineChronicles.Headless.Executable.Tests.KeyStore;
@@ -40,7 +41,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             // Create Action.
             var args = $"recipient: \"{recipient}\", sender: \"{sender}\", amount: \"17.5\", currency: CRYSTAL";
             var actionQuery = $"{{ transferAsset({args}) }}";
-            var actionQueryResult = await ExecuteQueryAsync<ActionQuery>(actionQuery);
+            var actionQueryResult = await ExecuteQueryAsync<ActionQuery>(actionQuery, standaloneContext: StandaloneContextFx);
             var actionData = (Dictionary<string, object>) ((ExecutionNode) actionQueryResult.Data!).ToValue()!;
             var plainValue = actionData["transferAsset"];
 
@@ -109,7 +110,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var action = Assert.IsType<TransferAsset>(signedTx.Actions.Single().InnerAction);
             Assert.Equal(recipient, action.Recipient);
             Assert.Equal(sender, action.Sender);
-            Assert.Equal(FungibleAssetValue.Parse(CurrencyType.CRYSTAL, "17.5"), action.Amount);
+            Assert.Equal(FungibleAssetValue.Parse(CrystalCalculator.CRYSTAL, "17.5"), action.Amount);
 
             // Staging Transaction.
             var stageTxMutation = $"mutation {{ stageTransaction(payload: \"{hex}\") }}";

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -163,8 +163,8 @@ namespace NineChronicles.Headless.GraphTypes
                         CurrencyEnum.NCG => new GoldCurrencyState(
                             (Dictionary)standaloneContext.BlockChain!.GetState(GoldCurrencyState.Address)
                         ).Currency,
-                    CurrencyEnum.CRYSTAL => CrystalCalculator.CRYSTAL,
-                    _ => throw new ExecutionError("Unsupported Currency type.")
+                        CurrencyEnum.CRYSTAL => CrystalCalculator.CRYSTAL,
+                        _ => throw new ExecutionError("Unsupported Currency type.")
                     };
                     var amount = FungibleAssetValue.Parse(currency, context.GetArgument<string>("amount"));
                     var memo = context.GetArgument<string?>("memo");

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -2,12 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Bencodex;
+using Bencodex.Types;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet;
 using Libplanet.Assets;
 using Libplanet.Explorer.GraphTypes;
 using Nekoyume.Action;
+using Nekoyume.Helper;
+using Nekoyume.Model.State;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Headless.GraphTypes
@@ -15,7 +18,8 @@ namespace NineChronicles.Headless.GraphTypes
     public class ActionQuery : ObjectGraphType
     {
         private static readonly Codec Codec = new Codec();
-        public ActionQuery()
+
+        public ActionQuery(StandaloneContext standaloneContext)
         {
             Field<ByteStringType>(
                 name: "stake",
@@ -156,9 +160,11 @@ namespace NineChronicles.Headless.GraphTypes
                     var recipient = context.GetArgument<Address>("recipient");
                     Currency currency = context.GetArgument<CurrencyEnum>("currency") switch
                     {
-                        CurrencyEnum.NCG => CurrencyType.NCG,
-                        CurrencyEnum.CRYSTAL => CurrencyType.CRYSTAL,
-                        _ => throw new ExecutionError("Unsupported Currency type.")
+                        CurrencyEnum.NCG => new GoldCurrencyState(
+                            (Dictionary)standaloneContext.BlockChain!.GetState(GoldCurrencyState.Address)
+                        ).Currency,
+                    CurrencyEnum.CRYSTAL => CrystalCalculator.CRYSTAL,
+                    _ => throw new ExecutionError("Unsupported Currency type.")
                     };
                     var amount = FungibleAssetValue.Parse(currency, context.GetArgument<string>("amount"));
                     var memo = context.GetArgument<string?>("memo");

--- a/NineChronicles.Headless/GraphTypes/CurrencyType.cs
+++ b/NineChronicles.Headless/GraphTypes/CurrencyType.cs
@@ -1,7 +1,5 @@
 using System.ComponentModel;
 using GraphQL.Types;
-using Libplanet.Assets;
-using Nekoyume.Helper;
 
 namespace NineChronicles.Headless.GraphTypes
 {
@@ -14,7 +12,5 @@ namespace NineChronicles.Headless.GraphTypes
 
     public class CurrencyType: EnumerationGraphType<CurrencyEnum>
     {
-        public static readonly Currency NCG = new Currency("NCG", 2, minters: null);
-        public static Currency CRYSTAL => CrystalCalculator.CRYSTAL;
     }
 }

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -423,7 +423,7 @@ namespace NineChronicles.Headless.GraphTypes
 
             Field<NonNullGraphType<ActionQuery>>(
                 name: "actionQuery",
-                resolve: context => new ActionQuery());
+                resolve: context => new ActionQuery(standaloneContext));
         }
     }
 }


### PR DESCRIPTION
- Fix hardcoded `NCG currency`. because NCG minter is different for each network settings.