### PR TITLE
fix(graphql): correct non-nullable types

### DIFF
--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardSheetType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardSheetType.cs
@@ -8,7 +8,7 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Table
     {
         public StakeRegularRewardSheetType()
         {
-            Field<ListGraphType<StakeRegularRewardRowType>>(
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<StakeRegularRewardRowType>>>>(
                 nameof(MonsterCollectionSheet.OrderedList),
                 resolve: context => context.Source.OrderedList.ToList());
         }


### PR DESCRIPTION
When the table sheet exists, if the `orderedList` should be `[]`, empty array. And its elements also should be something not `null`. So this pull request fixes `StakeRegularRewardsSheet` type.