### PR TITLE
Limit shared `ReplaySubject`'s buffer size to 1

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -102,7 +102,7 @@ namespace NineChronicles.Headless.GraphTypes
             }
         }
 
-        private ISubject<TipChanged> _subject = new ReplaySubject<TipChanged>();
+        private ISubject<TipChanged> _subject = new ReplaySubject<TipChanged>(1);
 
         private StandaloneContext StandaloneContext { get; }
 

--- a/NineChronicles.Headless/StandaloneContext.cs
+++ b/NineChronicles.Headless/StandaloneContext.cs
@@ -20,12 +20,12 @@ namespace NineChronicles.Headless
         public bool BootstrapEnded { get; set; }
         public bool PreloadEnded { get; set; }
         public bool IsMining { get; set; }
-        public ReplaySubject<NodeStatusType> NodeStatusSubject { get; } = new ReplaySubject<NodeStatusType>();
-        public ReplaySubject<PreloadState> PreloadStateSubject { get; } = new ReplaySubject<PreloadState>();
+        public ReplaySubject<NodeStatusType> NodeStatusSubject { get; } = new ReplaySubject<NodeStatusType>(1);
+        public ReplaySubject<PreloadState> PreloadStateSubject { get; } = new ReplaySubject<PreloadState>(1);
         public ReplaySubject<DifferentAppProtocolVersionEncounter> DifferentAppProtocolVersionEncounterSubject { get; }
-            = new ReplaySubject<DifferentAppProtocolVersionEncounter>();
+            = new ReplaySubject<DifferentAppProtocolVersionEncounter>(1);
         public ReplaySubject<Notification> NotificationSubject { get; } = new ReplaySubject<Notification>(1);
-        public ReplaySubject<NodeException> NodeExceptionSubject { get; } = new ReplaySubject<NodeException>();
+        public ReplaySubject<NodeException> NodeExceptionSubject { get; } = new ReplaySubject<NodeException>(1);
         public ReplaySubject<MonsterCollectionState> MonsterCollectionStateSubject { get; } = new ReplaySubject<MonsterCollectionState>();
         public ReplaySubject<MonsterCollectionStatus> MonsterCollectionStatusSubject { get; } = new ReplaySubject<MonsterCollectionStatus>();
         public NineChroniclesNodeService? NineChroniclesNodeService { get; set; }


### PR DESCRIPTION
There was an internal report which too many `tipChanged` subscription were pushed when starting and it halt the application's performance. I guess it occurred because the `tipChanged` `ReplaySubject` has too big buffer (`int.MaxValue`).

This pull request should be merged and applied carefully because I'm not sure how this affects to other applications. I expect it receive from the latest tip at the time to start subscribing `tipChanged`.