### PR TITLE
Configurable consensus peer

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -70,7 +70,7 @@ namespace Libplanet.Headless.Hosting
 
         public int DemandBuffer { get; set; } = 1150;
 
-        public ImmutableHashSet<BoundPeer> StaticPeers { get; set; }
+        public ImmutableHashSet<BoundPeer> ConsensusPeers { get; set; }
 
         public bool Preload { get; set; } = true;
 

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -162,9 +162,9 @@ namespace NineChronicles.Headless.Executable
                 "A number that determines how far behind the demand the tip of the chain " +
                 "will publish `NodeException` to GraphQL subscriptions.  1150 blocks by default.")]
             int demandBuffer = 1150,
-            [Option("static-peer",
-                Description = "A list of peers that the node will continue to maintain.")]
-            string[]? staticPeerStrings = null,
+            [Option("consensus-peer",
+                Description = "A list of peers that joining the block consensus.")]
+            string[]? consensusPeerStrings = null,
             [Option(Description ="Run node without preloading.")]
             bool skipPreload = false,
             [Option(Description = "Minimum number of peers to broadcast message.  10 by default.")]
@@ -330,7 +330,7 @@ namespace NineChronicles.Headless.Executable
                         messageTimeout: messageTimeout,
                         tipTimeout: tipTimeout,
                         demandBuffer: demandBuffer,
-                        staticPeerStrings: staticPeerStrings,
+                        consensusPeerStrings: consensusPeerStrings,
                         preload: !skipPreload,
                         minimumBroadcastTarget: minimumBroadcastTarget,
                         bucketSize: bucketSize,

--- a/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
+++ b/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
@@ -53,7 +53,7 @@ namespace NineChronicles.Headless.Tests.Common
                 MessageTimeout = TimeSpan.FromMinutes(1),
                 TipTimeout = TimeSpan.FromMinutes(1),
                 DemandBuffer = 1150,
-                StaticPeers = ImmutableHashSet<BoundPeer>.Empty,
+                ConsensusPeers = ImmutableHashSet<BoundPeer>.Empty,
             };
             return new NineChroniclesNodeService(privateKey, properties, BlockPolicy, NetworkType.Test);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -157,7 +157,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             PublicKey appProtocolVersionSigner,
             Progress<PreloadState>? preloadProgress = null,
             IEnumerable<Peer>? peers = null,
-            ImmutableHashSet<BoundPeer>? staticPeers = null)
+            ImmutableHashSet<BoundPeer>? consensusPeers = null)
             where T : IAction, new()
         {
             var consensusPrivateKey = new PrivateKey();
@@ -182,7 +182,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = peers ?? ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = ImmutableHashSet<PublicKey>.Empty.Add(appProtocolVersionSigner),
-                StaticPeers = staticPeers ?? ImmutableHashSet<BoundPeer>.Empty,
+                ConsensusPeers = consensusPeers ?? ImmutableHashSet<BoundPeer>.Empty,
             };
 
             return new LibplanetNodeService<T>(

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -474,7 +474,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
-                StaticPeers = ImmutableHashSet<BoundPeer>.Empty
+                ConsensusPeers = ImmutableHashSet<BoundPeer>.Empty
             };
             var blockPolicy = NineChroniclesNodeService.GetTestBlockPolicy();
 
@@ -799,7 +799,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
-                StaticPeers = ImmutableHashSet<BoundPeer>.Empty
+                ConsensusPeers = ImmutableHashSet<BoundPeer>.Empty
             };
 
             var blockPolicy = NineChroniclesNodeService.GetBlockPolicy(NetworkType.Test);
@@ -877,7 +877,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
-                StaticPeers = ImmutableHashSet<BoundPeer>.Empty
+                ConsensusPeers = ImmutableHashSet<BoundPeer>.Empty
             };
             var blockPolicy = NineChroniclesNodeService.GetTestBlockPolicy();
 
@@ -941,7 +941,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Render = false,
                 Peers = ImmutableHashSet<Peer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
-                StaticPeers = ImmutableHashSet<BoundPeer>.Empty,
+                ConsensusPeers = ImmutableHashSet<BoundPeer>.Empty,
             };
 
             return new NineChroniclesNodeService(privateKey, properties, blockPolicy, NetworkType.Test);

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -59,7 +59,7 @@ namespace NineChronicles.Headless.Properties
                 int messageTimeout = 60,
                 int tipTimeout = 60,
                 int demandBuffer = 1150,
-                string[]? staticPeerStrings = null,
+                string[]? consensusPeerStrings = null,
                 bool preload = true,
                 int minimumBroadcastTarget = 10,
                 int bucketSize = 16,
@@ -83,11 +83,11 @@ namespace NineChronicles.Headless.Properties
 
             peerStrings ??= Array.Empty<string>();
             iceServerStrings ??= Array.Empty<string>();
-            staticPeerStrings ??= Array.Empty<string>();
+            consensusPeerStrings ??= Array.Empty<string>();
 
             var iceServers = iceServerStrings.Select(PropertyParser.ParseIceServer).ToImmutableArray();
             var peers = peerStrings.Select(PropertyParser.ParsePeer).ToImmutableArray();
-            var staticPeers = staticPeerStrings.Select(PropertyParser.ParsePeer).ToImmutableHashSet();
+            var consensusPeers = consensusPeerStrings.Select(PropertyParser.ParsePeer).ToImmutableHashSet();
             var validators = validatorStrings?.Select(s => new PublicKey(ByteUtil.ParseHex(s))).ToList();
 
             return new LibplanetNodeServiceProperties<NineChroniclesActionType>
@@ -117,7 +117,7 @@ namespace NineChronicles.Headless.Properties
                 MessageTimeout = TimeSpan.FromSeconds(messageTimeout),
                 TipTimeout = TimeSpan.FromSeconds(tipTimeout),
                 DemandBuffer = demandBuffer,
-                StaticPeers = staticPeers,
+                ConsensusPeers = consensusPeers,
                 Preload = preload,
                 MinimumBroadcastTarget = minimumBroadcastTarget,
                 BucketSize = bucketSize,


### PR DESCRIPTION
Program's `staticPeerStrings` argument now replaced with `consensusPeerStrings` which represents the list of peers joining PBFT consensus.