### PR TITLE
Cherry-pick: Remove useless output

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/TxCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/TxCommand.cs
@@ -61,10 +61,6 @@ namespace NineChronicles.Headless.Executable.Commands
 
                 return (NCAction)action;
             }).ToList();
-            
-            Console.WriteLine(privateKey);
-            Console.WriteLine(genesisHash);
-            Console.WriteLine(timestamp);
 
             Transaction<NCAction> tx = Transaction<NCAction>.Create(
                 nonce: nonce,


### PR DESCRIPTION
This commit was merged into the `previewnet` branch as hotfix through #1335. It was a hotfix so I opened a new pull request to apply it also to other branches.