### PR TITLE
Introduce `TxResultType.exception..` fields

### DIFF
--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -161,8 +161,8 @@ namespace NineChronicles.Headless.GraphTypes
                     if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } txExecutedBlockHash))
                     {
                         return blockChain.GetStagedTransactionIds().Contains(txId)
-                            ? new TxResult(TxStatus.STAGING, null, null)
-                            : new TxResult(TxStatus.INVALID, null, null);
+                            ? new TxResult(TxStatus.STAGING, null, null, null, null)
+                            : new TxResult(TxStatus.INVALID, null, null, null, null);
                     }
 
                     try
@@ -172,16 +172,16 @@ namespace NineChronicles.Headless.GraphTypes
                         return execution switch
                         {
                             TxSuccess txSuccess => new TxResult(TxStatus.SUCCESS, txExecutedBlock.Index,
-                                txExecutedBlock.Hash.ToString()),
+                                txExecutedBlock.Hash.ToString(), null, null),
                             TxFailure txFailure => new TxResult(TxStatus.FAILURE, txExecutedBlock.Index,
-                                txExecutedBlock.Hash.ToString()),
+                                txExecutedBlock.Hash.ToString(), txFailure.ExceptionName, txFailure.ExceptionMetadata),
                             _ => throw new NotImplementedException(
                                 $"{nameof(execution)} is not expected concrete class.")
                         };
                     }
                     catch(Exception)
                     {
-                        return new TxResult(TxStatus.INVALID, null, null);
+                        return new TxResult(TxStatus.INVALID, null, null, null, null);
                     }
                 }
             );

--- a/NineChronicles.Headless/GraphTypes/TxResult.cs
+++ b/NineChronicles.Headless/GraphTypes/TxResult.cs
@@ -1,16 +1,22 @@
-﻿namespace NineChronicles.Headless.GraphTypes
+﻿using Bencodex.Types;
+
+namespace NineChronicles.Headless.GraphTypes
 {
     public class TxResult
     {
         public readonly TxStatus TxStatus;
         public readonly long? BlockIndex;
         public readonly string? BlockHash;
+        public readonly string? ExceptionName;
+        public readonly IValue? ExceptionMetadata;
 
-        public TxResult(TxStatus status, long? blockIndex, string? blockHash)
+        public TxResult(TxStatus status, long? blockIndex, string? blockHash, string? exceptionName, IValue? exceptionMetadata)
         {
             TxStatus = status;
             BlockIndex = blockIndex;
             BlockHash = blockHash;
+            ExceptionName = exceptionName;
+            ExceptionMetadata = exceptionMetadata;
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/TxResultType.cs
+++ b/NineChronicles.Headless/GraphTypes/TxResultType.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel;
+using Bencodex;
 using GraphQL.Types;
+using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Tx;
@@ -8,6 +10,8 @@ namespace NineChronicles.Headless.GraphTypes
 {
     public class TxResultType : ObjectGraphType<TxResult>
     {
+        private static readonly Codec Codec = new Codec();
+
         public TxResultType()
         {
             Field<NonNullGraphType<TxStatusType>>(
@@ -26,6 +30,20 @@ namespace NineChronicles.Headless.GraphTypes
                 nameof(TxResult.BlockHash),
                 description: "The block hash which the target transaction executed.",
                 resolve: context => context.Source.BlockHash
+            );
+
+            Field<StringGraphType>(
+                nameof(TxResult.ExceptionName),
+                description: "The name of the exception when the transaction failed. "
+                    + "There will be a value when only the transaction fails.",
+                resolve: context => context.Source.ExceptionName
+            );
+
+            Field<StringGraphType>(
+                nameof(TxResult.ExceptionMetadata),
+                description: "A hexadecimal string to present the metadata of the exception when the transaction failed. "
+                    + "It is a Bencodex value. There will be a value when only the transaction fails.",
+                resolve: context => context.Source.ExceptionMetadata is {} metadata ? ByteUtil.Hex(Codec.Encode(metadata)) : null
             );
         }
     }


### PR DESCRIPTION
This pull request introduces new fields `exceptionName` and `exceptionMetadata` in `TxResultType`.

```graphql
type TxResultType {
  txStatus: TxStatus!
  blockIndex: Long
  blockHash: String
  + exceptionName: String
  + exceptionMetadata: String
}
```