### PR TITLE
feat(graphql): introduce `CrystalMonsterCollectionMultiplierSheet` type

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierRowTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierRowTypeTest.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using NineChronicles.Headless.GraphTypes.States.Models.Table;
+using Xunit;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
+
+namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
+{
+    public class CrystalMonsterCollectionMultiplierRowTypeTest
+    {
+        [Fact]
+        public async Task Query()
+        {
+            const string query = @"
+            {
+                level
+                multiplier
+            }";
+            var queryResult = await ExecuteQueryAsync<CrystalMonsterCollectionMultiplierRowType>(
+                query,
+                source: Fixtures.TableSheetsFX.CrystalMonsterCollectionMultiplierSheet.OrderedList.First()
+            );
+            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            Assert.NotEmpty(data);
+            Assert.Null(queryResult.Errors);
+            Assert.Equal(new Dictionary<string, object>
+            {
+                ["level"] = 0,
+                ["multiplier"] = 0,
+            }, data);
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierSheetTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierSheetTypeTest.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using NineChronicles.Headless.GraphTypes.States.Models.Table;
+using Xunit;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
+
+namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
+{
+    public class CrystalMonsterCollectionMultiplierSheetTypeTest
+    {
+        [Fact]
+        public async Task Query()
+        {
+            const string query = @"
+            {
+                orderedList {
+                    level
+                    multiplier
+                }
+            }";
+            var queryResult = await ExecuteQueryAsync<CrystalMonsterCollectionMultiplierSheetType>(
+                query,
+                source: Fixtures.TableSheetsFX.CrystalMonsterCollectionMultiplierSheet
+            );
+            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            Assert.NotEmpty(data);
+            Assert.Null(queryResult.Errors);
+            Assert.Equal(new Dictionary<string, object>
+            {
+                ["orderedList"] = new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["level"] = 0,
+                        ["multiplier"] = 0,
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["level"] = 1,
+                        ["multiplier"] = 20,
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["level"] = 2,
+                        ["multiplier"] = 100,
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["level"] = 3,
+                        ["multiplier"] = 200,
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["level"] = 4,
+                        ["multiplier"] = 500,
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["level"] = 5,
+                        ["multiplier"] = 2000,
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["level"] = 6,
+                        ["multiplier"] = 2000,
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["level"] = 7,
+                        ["multiplier"] = 2000,
+                    },
+                }
+            }, data);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/StateQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StateQuery.cs
@@ -11,6 +11,7 @@ using Nekoyume.Action;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Nekoyume.TableData.Crystal;
 using NineChronicles.Headless.GraphTypes.Abstractions;
 using NineChronicles.Headless.GraphTypes.States;
 using NineChronicles.Headless.GraphTypes.States.Models.Item.Enum;
@@ -259,6 +260,22 @@ namespace NineChronicles.Headless.GraphTypes
                     return null;
                 }
             );
+
+            Field<CrystalMonsterCollectionMultiplierSheetType>(
+                name: nameof(CrystalMonsterCollectionMultiplierSheet),
+                resolve: context =>
+                {
+                    var sheetAddress = Addresses.GetSheetAddress<CrystalMonsterCollectionMultiplierSheet>();
+                    IValue? sheetValue = context.Source.GetState(sheetAddress);
+                    if (sheetValue is Text sv)
+                    {
+                        var crystalMonsterCollectionMultiplierSheet = new CrystalMonsterCollectionMultiplierSheet();
+                        crystalMonsterCollectionMultiplierSheet.Set(sv);
+                        return crystalMonsterCollectionMultiplierSheet;
+                    }
+
+                    return null;
+                });
 
             Field<ListGraphType<IntGraphType>>(
                 "unlockedRecipeIds",

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/CrystalMonsterCollectionMultiplierRowType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/CrystalMonsterCollectionMultiplierRowType.cs
@@ -1,0 +1,21 @@
+using GraphQL.Types;
+using Nekoyume.TableData.Crystal;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Table
+{
+    public class CrystalMonsterCollectionMultiplierRowType : ObjectGraphType<CrystalMonsterCollectionMultiplierSheet.Row>
+    {
+        public CrystalMonsterCollectionMultiplierRowType()
+        {
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(CrystalMonsterCollectionMultiplierSheet.Row.Level),
+                resolve: context => context.Source.Level
+            );
+            
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(CrystalMonsterCollectionMultiplierSheet.Row.Multiplier),
+                resolve: context => context.Source.Multiplier
+            );
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/CrystalMonsterCollectionMultiplierSheetType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/CrystalMonsterCollectionMultiplierSheetType.cs
@@ -1,0 +1,16 @@
+using GraphQL.Types;
+using Nekoyume.TableData.Crystal;
+
+namespace NineChronicles.Headless.GraphTypes.States.Models.Table
+{
+    public class CrystalMonsterCollectionMultiplierSheetType : ObjectGraphType<CrystalMonsterCollectionMultiplierSheet>
+    {
+        public CrystalMonsterCollectionMultiplierSheetType()
+        {
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<CrystalMonsterCollectionMultiplierRowType>>>>(
+                nameof(CrystalMonsterCollectionMultiplierSheet.OrderedList),
+                resolve: context => context.Source.OrderedList
+            );
+        }
+    }
+}


### PR DESCRIPTION
It introduces `query.stateQuery.crystalMonsterCollectionMultiplierSheet`.

```graphql
query {
  stateQuery {
    crystalMonsterCollectionMultiplierSheet {
      orderedList {
        level
        multiplier
      }
    }
  }
}


```