### PR TITLE
Championship arena GQL update

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -54,7 +54,8 @@ namespace NineChronicles.Headless.GraphTypes
 
                     return new StateContext(
                         chain.ToAccountStateGetter(blockHash),
-                        chain.ToAccountBalanceGetter(blockHash)
+                        chain.ToAccountBalanceGetter(blockHash),
+                        chain.Tip.Index
                     );
                 }
             );

--- a/NineChronicles.Headless/GraphTypes/States/AgentStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AgentStateType.cs
@@ -19,8 +19,8 @@ namespace NineChronicles.Headless.GraphTypes.States
     {
         public class AgentStateContext : StateContext
         {
-            public AgentStateContext(AgentState agentState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter)
-                : base(accountStateGetter, accountBalanceGetter)
+            public AgentStateContext(AgentState agentState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter, long chainTip)
+                : base(accountStateGetter, accountBalanceGetter, chainTip)
             {
                 AgentState = agentState;
             }

--- a/NineChronicles.Headless/GraphTypes/States/ChampionArenaInfo.cs
+++ b/NineChronicles.Headless/GraphTypes/States/ChampionArenaInfo.cs
@@ -1,0 +1,18 @@
+using Libplanet;
+
+namespace NineChronicles.Headless.GraphTypes.States
+{
+    public class ChampionArenaInfo
+    {
+        public Address AvatarAddress;
+        public Address AgentAddress;
+        public string? AvatarName;
+        public int Win { get; set; }
+        public int Lose { get; set; }
+        public int Ticket { get; set; }
+        public int TicketResetCount { get; set; }
+        public int PurchasedTicketCount { get; set; }
+        public int Score { get; set; }
+        public bool Active { get; set; }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/ChampionArenaInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/ChampionArenaInfoType.cs
@@ -1,0 +1,43 @@
+using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
+using Nekoyume.Model.State;
+
+namespace NineChronicles.Headless.GraphTypes.States
+{
+    internal class ChampionArenaInfoType : ObjectGraphType<ChampionArenaInfo>
+    {
+        public ChampionArenaInfoType()
+        {
+            Field<NonNullGraphType<AddressType>>(
+                nameof(ChampionArenaInfo.AgentAddress),
+                resolve: context => context.Source.AgentAddress);
+            Field<NonNullGraphType<AddressType>>(
+                nameof(ChampionArenaInfo.AvatarAddress),
+                resolve: context => context.Source.AvatarAddress);
+            Field<NonNullGraphType<StringGraphType>>(
+                nameof(ChampionArenaInfo.AvatarName),
+                resolve: context => context.Source.AvatarName);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(ChampionArenaInfo.Lose),
+                resolve: context => context.Source.Lose);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(ChampionArenaInfo.Win),
+                resolve: context => context.Source.Win);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(ChampionArenaInfo.PurchasedTicketCount),
+                resolve: context => context.Source.PurchasedTicketCount);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(ChampionArenaInfo.TicketResetCount),
+                resolve: context => context.Source.TicketResetCount);
+            Field<NonNullGraphType<BooleanGraphType>>(
+                nameof(ChampionArenaInfo.Active),
+                resolve: context => context.Source.Active);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(ChampionArenaInfo.Ticket),
+                resolve: context => context.Source.Ticket);
+            Field<NonNullGraphType<IntGraphType>>(
+                nameof(ChampionArenaInfo.Score),
+                resolve: context => context.Source.Score);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/ChampionshipArenaState.cs
+++ b/NineChronicles.Headless/GraphTypes/States/ChampionshipArenaState.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet;
+using Nekoyume.Action;
+using Nekoyume.TableData;
+
+namespace NineChronicles.Headless.GraphTypes.States
+{
+    public class ChampionshipArenaState
+    {
+        public Address Address;
+        public long StartIndex;
+        public long EndIndex;
+        public List<ChampionArenaInfo> OrderedArenaInfos { get; set; }
+
+        public ChampionshipArenaState()
+        {
+            OrderedArenaInfos = new List<ChampionArenaInfo>();
+        }
+
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/ChampionshipArenaStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/ChampionshipArenaStateType.cs
@@ -1,0 +1,25 @@
+using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
+using Nekoyume.Model.State;
+
+namespace NineChronicles.Headless.GraphTypes.States
+{
+    public class ChampionshipArenaStateType : ObjectGraphType<ChampionshipArenaState>
+    {
+        public ChampionshipArenaStateType()
+        {
+            Field<NonNullGraphType<AddressType>>(
+                    nameof(ChampionshipArenaState.Address),
+                    resolve: context => context.Source.Address);
+            Field<NonNullGraphType<IntGraphType>>(
+                    nameof(ChampionshipArenaState.EndIndex),
+                    resolve: context => context.Source.EndIndex);
+            Field<NonNullGraphType<IntGraphType>>(
+                    nameof(ChampionshipArenaState.StartIndex),
+                    resolve: context => context.Source.StartIndex);
+            Field<NonNullGraphType<ListGraphType<ChampionArenaInfoType>>>(
+                    nameof(ChampionshipArenaState.OrderedArenaInfos),
+                    resolve: context => context.Source.OrderedArenaInfos);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/States/StakeStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/StakeStateType.cs
@@ -16,8 +16,8 @@ namespace NineChronicles.Headless.GraphTypes.States
     {
         public class StakeStateContext : StateContext
         {
-            public StakeStateContext(StakeState stakeState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter)
-                : base(accountStateGetter, accountBalanceGetter)
+            public StakeStateContext(StakeState stakeState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter, long chainTip)
+                : base(accountStateGetter, accountBalanceGetter, chainTip)
             {
                 StakeState = stakeState;
             }

--- a/NineChronicles.Headless/GraphTypes/States/StateContext.cs
+++ b/NineChronicles.Headless/GraphTypes/States/StateContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
@@ -6,7 +7,7 @@ using Libplanet.Assets;
 
 namespace NineChronicles.Headless.GraphTypes.States
 {
-    public class StateContext
+    public class StateContext : IAccountStateDelta
     {
         public StateContext(AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter)
         {
@@ -17,6 +18,12 @@ namespace NineChronicles.Headless.GraphTypes.States
         public AccountStateGetter AccountStateGetter { get; }
         public AccountBalanceGetter AccountBalanceGetter { get; }
 
+        public IImmutableSet<Address> UpdatedAddresses => throw new System.NotImplementedException();
+
+        public IImmutableSet<Address> StateUpdatedAddresses => throw new System.NotImplementedException();
+
+        public IImmutableDictionary<Address, IImmutableSet<Currency>> UpdatedFungibleAssets => throw new System.NotImplementedException();
+
         public IValue? GetState(Address address) =>
             AccountStateGetter(new[] { address })[0];
 
@@ -25,5 +32,25 @@ namespace NineChronicles.Headless.GraphTypes.States
 
         public FungibleAssetValue GetBalance(Address address, Currency currency) =>
             AccountBalanceGetter(address, currency);
+
+        public IAccountStateDelta SetState(Address address, IValue state)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IAccountStateDelta TransferAsset(Address sender, Address recipient, FungibleAssetValue value, bool allowNegativeBalance = false)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
I added some additional models, added the chain tip index to the StateContext, and inherited from IAccountStateDelta to allow all of the extension methods to get the arena data.  The old weekly arena is still available to get data for older arena rounds.