### PR TITLE
Bump lib9c

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -166,17 +166,6 @@ namespace Libplanet.Headless.Hosting
                 shuffledIceServers = iceServers.OrderBy(x => rand.Next());
             }
 
-            SwarmOptions.TransportType transportType = SwarmOptions.TransportType.TcpTransport;
-            switch (Properties.TransportType)
-            {
-                case "netmq":
-                    transportType = SwarmOptions.TransportType.NetMQTransport;
-                    break;
-                case "tcp":
-                    transportType = SwarmOptions.TransportType.TcpTransport;
-                    break;
-            }
-
             Swarm = new Swarm<T>(
                 BlockChain,
                 Properties.SwarmPrivateKey,
@@ -194,7 +183,6 @@ namespace Libplanet.Headless.Hosting
                     MinimumBroadcastTarget = Properties.MinimumBroadcastTarget,
                     BucketSize = Properties.BucketSize,
                     MaximumPollPeers = Properties.MaximumPollPeers,
-                    Type = transportType,
                     TimeoutOptions = new TimeoutOptions
                     {
                         MaxTimeout = TimeSpan.FromSeconds(50),

--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -71,7 +71,5 @@ namespace Libplanet.Headless.Hosting
         public string ChainTipStaleBehavior { get; set; } = "reboot";
 
         public int MaximumPollPeers { get; set; } = int.MaxValue;
-
-        public string TransportType { get; set; } = "tcp";
     }
 }

--- a/Libplanet.Headless/PropertyParser.cs
+++ b/Libplanet.Headless/PropertyParser.cs
@@ -11,10 +11,7 @@ namespace Libplanet.Headless
         {
             try
             {
-                var uri = new Uri(iceServerInfo);
-                string[] userInfo = uri.UserInfo.Split(':');
-
-                return new IceServer(uri, userInfo[0], userInfo[1]);
+                return new IceServer(new Uri(iceServerInfo));
             }
             catch (Exception e)
             {

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.7.0.5" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.8.24" />
-    <PackageReference Include="Cocona.Lite" Version="1.6.*" />
+    <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
     <PackageReference Include="HaemmerElectronics.SeppPenner.Serilog.Sinks.AmazonS3" Version="1.1.3" />
     <PackageReference Include="Sentry.Serilog" Version="2.1.*" />

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -44,7 +44,7 @@ namespace NineChronicles.Headless.Executable
 #if SENTRY || ! DEBUG
             using var _ = SentrySdk.Init(ConfigureSentryOptions);
 #endif
-            await CoconaLiteApp.Create()
+            await CoconaLiteApp.CreateHostBuilder()
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<IConsole, StandardConsole>();

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -184,10 +184,6 @@ namespace NineChronicles.Headless.Executable
             bool rpcHttpServer = false,
             [Option(Description = "The maximum number of peers to poll blocks.  int.MaxValue by default.")]
             int maximumPollPeers = int.MaxValue,
-            [Option(Description =
-                "Determines the type of transport.  \"netmq\" and \"tcp\" " +
-                "is available and \"tcp\" option is selected by default.")]
-            string transportType = "tcp",
             [Ignore]
             CancellationToken? cancellationToken = null
         )
@@ -325,8 +321,7 @@ namespace NineChronicles.Headless.Executable
                         minimumBroadcastTarget: minimumBroadcastTarget,
                         bucketSize: bucketSize,
                         chainTipStaleBehaviorType: chainTipStaleBehaviorType,
-                        maximumPollPeers: maximumPollPeers,
-                        transportType: transportType
+                        maximumPollPeers: maximumPollPeers
                     );
 
                 if (rpcServer)

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -70,8 +70,7 @@ namespace NineChronicles.Headless.Properties
                 int minimumBroadcastTarget = 10,
                 int bucketSize = 16,
                 string chainTipStaleBehaviorType = "reboot",
-                int maximumPollPeers = int.MaxValue,
-                string transportType = "tcp")
+                int maximumPollPeers = int.MaxValue)
         {
             var swarmPrivateKey = string.IsNullOrEmpty(swarmPrivateKeyString)
                 ? new PrivateKey()
@@ -114,8 +113,7 @@ namespace NineChronicles.Headless.Properties
                 MinimumBroadcastTarget = minimumBroadcastTarget,
                 BucketSize = bucketSize,
                 ChainTipStaleBehavior = chainTipStaleBehaviorType,
-                MaximumPollPeers = maximumPollPeers,
-                TransportType = transportType
+                MaximumPollPeers = maximumPollPeers
             };
         }
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 $ dotnet run --project ./NineChronicles.Headless.Executable/ -- --help
 
 Usage: NineChronicles.Headless.Executable [command]
-Usage: NineChronicles.Headless.Executable [--app-protocol-version <String>] [--genesis-block-path <String>] [--no-miner] [--host <String>] [--port <Nullable`1>] [--swarm-private-key <String>] [--miner-private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--graphql-secret-token-path <String>] [--no-cors] [--workers <Int32>] [--confirmations <Int32>] [--nonblock-renderer] [--nonblock-renderer-queue <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-action-renders] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--static-peer <String>...] [--miner-count <Int32>] [--skip-preload] [--minimum-broadcast-target <Int32>] [--bucket-size <Int32>] [--chain-tip-stale-behavior-type <String>] [--tx-quota-per-signer <Int32>] [--rpc-remote-server] [--maximum-poll-peers <Int32>] [--transport-type <String>] [--completion] [--help] [--version]
+Usage: NineChronicles.Headless.Executable [--app-protocol-version <String>] [--genesis-block-path <String>] [--no-miner] [--host <String>] [--port <Nullable`1>] [--swarm-private-key <String>] [--miner-private-key <String>] [--store-type <String>] [--store-path <String>] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Nullable`1>] [--graphql-server] [--graphql-host <String>] [--graphql-port <Nullable`1>] [--graphql-secret-token-path <String>] [--no-cors] [--workers <Int32>] [--confirmations <Int32>] [--nonblock-renderer] [--nonblock-renderer-queue <Int32>] [--strict-rendering] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--log-action-renders] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--static-peer <String>...] [--miner-count <Int32>] [--skip-preload] [--minimum-broadcast-target <Int32>] [--bucket-size <Int32>] [--chain-tip-stale-behavior-type <String>] [--tx-quota-per-signer <Int32>] [--rpc-remote-server] [--maximum-poll-peers <Int32>] [--completion] [--help] [--version]
 
 NineChronicles.Headless.Executable
 
@@ -74,7 +74,6 @@ Options:
   --chain-tip-stale-behavior-type <String>                 Determines behavior when the chain's tip is stale. "reboot" and "preload" is available and "reboot" option is selected by default. (Default: reboot)
   --tx-quota-per-signer <Int32>                            The number of maximum transactions can be included in stage per signer. (Default: 10)
   --rpc-remote-server
-  --transport-type <String>                                Determines the type of transport.  "netmq" and "tcp" is available and "tcp" option is selected by default. (Default: tcp)
   --maximum-poll-peers <Int32>                             The maximum number of peers to poll blocks.  int.MaxValue by default. (Default: 2147483647)
   --completion                                             Generate a shell completion code
   -h, --help                                               Show help message
@@ -127,7 +126,6 @@ $ docker build . -t <IMAGE_TAG> --build-arg COMMIT=<VERSION_SUFFIX>
 - `--bucket-size`: Specifies the number of the peers can be stored in each bucket.
 - `--tx-quota-per-signer`: Specifies the number of maximum transactions can be included in stage per signer.
 - `--poll-interval`: Specifies the interval between block polling.
-- `--transport-type`: Specifies the type of transport to use.  Either `netmq` or `tcp` is available.  `tcp` by default.
 - `--maximum-poll-peers`: Specifies the maximum number of peers to poll blocks.
 
 ### Format


### PR DESCRIPTION
Argument `--transport-type` has been removed. Should also update [k8s-config]. Also [Cocona.Lite] has been upgraded to 2.0.*.

[k8s-config]: https://github.com/planetarium/k8s-config
[Cocona.Lite]: https://www.nuget.org/packages/Cocona.Lite