### PR TITLE
Introduce `dotnet format`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+    format:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup .NET Core
+              uses: actions/setup-dotnet@v1
+              with:
+                  dotnet-version: 6.0.*
+            - name: dotnet format
+              run: dotnet format --exclude Lib9c --exclude NineChronicles.RPC.Shared -v=d --no-restore --verify-no-changes

--- a/Libplanet.Headless.Tests/Hosting/LibplanetNodeServiceTest.cs
+++ b/Libplanet.Headless.Tests/Hosting/LibplanetNodeServiceTest.cs
@@ -35,7 +35,7 @@ namespace Libplanet.Headless.Tests.Hosting
                 renderers: null,
                 minerLoopAction: (chain, swarm, pk, ct) => Task.CompletedTask,
                 preloadProgress: null,
-                exceptionHandlerAction:  (code, msg) => throw new Exception($"{code}, {msg}"),
+                exceptionHandlerAction: (code, msg) => throw new Exception($"{code}, {msg}"),
                 preloadStatusHandlerAction: isPreloadStart => { }
             );
 
@@ -60,7 +60,7 @@ namespace Libplanet.Headless.Tests.Hosting
                     renderers: null,
                     minerLoopAction: (chain, swarm, pk, ct) => Task.CompletedTask,
                     preloadProgress: null,
-                    exceptionHandlerAction:  (code, msg) => throw new Exception($"{code}, {msg}"),
+                    exceptionHandlerAction: (code, msg) => throw new Exception($"{code}, {msg}"),
                     preloadStatusHandlerAction: isPreloadStart => { }
                 );
             });

--- a/Libplanet.Headless/Hosting/DevLibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/DevLibplanetNodeService.cs
@@ -69,7 +69,7 @@ namespace Libplanet.Headless.Hosting
 
             SubChain = new BlockChain<T>(
                 policy: hardPolicy,
-                stagePolicy : stagePolicy,
+                stagePolicy: stagePolicy,
                 store: SubStore,
                 stateStore: SubStateStore,
                 genesisBlock: genesisBlock);

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -331,7 +331,7 @@ namespace Libplanet.Headless.Hosting
             store ??= new DefaultStore(path, flush: false);
             if (!noReduceStore)
             {
-                store = new ReducedStore(store);   
+                store = new ReducedStore(store);
             }
 
             IKeyValueStore stateKeyValueStore = new RocksDBKeyValueStore(Path.Combine(path, "states"));

--- a/Libplanet.Headless/IceServerInvalidException.cs
+++ b/Libplanet.Headless/IceServerInvalidException.cs
@@ -3,7 +3,7 @@ using System;
 namespace Libplanet.Headless
 {
     [Serializable]
-    public class IceServerInvalidException: Exception
+    public class IceServerInvalidException : Exception
     {
         public IceServerInvalidException()
         {

--- a/Libplanet.Headless/NodeException.cs
+++ b/Libplanet.Headless/NodeException.cs
@@ -1,23 +1,23 @@
-﻿namespace Libplanet.Headless
+namespace Libplanet.Headless
 {
     public enum NodeExceptionType
     {
         NoAnyPeer = 0x01,
-        
+
         DemandTooHigh = 0x02,
-        
+
         TipNotChange = 0x03,
-        
+
         MessageNotReceived = 0x04,
-        
+
         ActionTimeout = 0x05,
     }
-    
+
     public class NodeException
     {
         public readonly int Code;
         public readonly string Message;
-        
+
         public NodeException(NodeExceptionType code, string message)
         {
             Code = (int)code;

--- a/Libplanet.Headless/PeerInvalidException.cs
+++ b/Libplanet.Headless/PeerInvalidException.cs
@@ -3,7 +3,7 @@ using System;
 namespace Libplanet.Headless
 {
     [Serializable]
-    public class PeerInvalidException: Exception
+    public class PeerInvalidException : Exception
     {
         public PeerInvalidException()
         {

--- a/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
@@ -35,7 +35,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState _) = ActivationKey.Create(privateKey, nonce);
-            string invitationCode =  invalid ? "invalid_code" : activationKey.Encode();
+            string invitationCode = invalid ? "invalid_code" : activationKey.Encode();
             var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
             var resultCode = _command.ActivateAccount(invitationCode, ByteUtil.Hex(nonce), filePath);
             Assert.Equal(expectedCode, resultCode);
@@ -116,7 +116,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             var recipientPrivateKey = new PrivateKey();
             var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
             var resultCode = _command.TransferAsset(
-                senderPrivateKey.ToAddress().ToHex(), 
+                senderPrivateKey.ToAddress().ToHex(),
                 recipientPrivateKey.ToAddress().ToHex(),
                 Convert.ToString(amount),
                 filePath,
@@ -184,7 +184,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
                 Assert.Contains("System.FormatException: Could not find any recognizable digits.", _console.Error.ToString());
             }
         }
-        
+
         [Theory]
         [InlineData("0xab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d", -1)]
         [InlineData("ab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d", 0)]

--- a/NineChronicles.Headless.Executable.Tests/Commands/KeyCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/KeyCommandTest.cs
@@ -31,7 +31,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         {
             PrivateKey privateKey = new PrivateKey();
             Guid keyId = _keyStore.Add(ProtectedPrivateKey.Protect(privateKey, passphrase));
-            
+
             Assert.Contains(keyId, _keyStore.ListIds());
             _keyCommand.Remove(keyId, passphrase: inputPassphrase, noPassphrase: true);
             Assert.DoesNotContain(keyId, _keyStore.ListIds());

--- a/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
@@ -78,7 +78,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
                 filePath);
             Assert_Tx(1, filePath);
         }
-        
+
         [Fact]
         public void Sign_Stake()
         {
@@ -97,7 +97,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             actionCommand.ClaimStakeReward(avatarAddress.ToHex(), filePath);
             Assert_Tx(1, filePath);
         }
-        
+
         [Fact]
         public void Sign_MigrateMonsterCollection()
         {

--- a/NineChronicles.Headless.Executable.Tests/KeyStore/InMemoryKeyStore.cs
+++ b/NineChronicles.Headless.Executable.Tests/KeyStore/InMemoryKeyStore.cs
@@ -13,7 +13,7 @@ namespace NineChronicles.Headless.Executable.Tests.KeyStore
         {
             _protectedPrivateKeys = new Dictionary<Guid, ProtectedPrivateKey>();
         }
-        
+
         public IEnumerable<Guid> ListIds()
         {
             return _protectedPrivateKeys.Keys;

--- a/NineChronicles.Headless.Executable/Commands/ActionCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ActionCommand.cs
@@ -52,7 +52,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
                 else
                 {
-                    File.WriteAllText(filePath, encoded);   
+                    File.WriteAllText(filePath, encoded);
                 }
 
                 return 0;
@@ -91,7 +91,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
                 else
                 {
-                    File.WriteAllText(filePath, encoded);   
+                    File.WriteAllText(filePath, encoded);
                 }
 
                 return 0;
@@ -131,7 +131,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
                 else
                 {
-                    File.WriteAllText(filePath, encoded);   
+                    File.WriteAllText(filePath, encoded);
                 }
 
                 return 0;
@@ -147,7 +147,7 @@ namespace NineChronicles.Headless.Executable.Commands
         public int TransferAsset(
             [Argument("SENDER-ADDRESS", Description = "A hex-encoded sender address.")] string senderAddress,
             [Argument("RECIPIENT-ADDRESS", Description = "A hex-encoded recipient address.")] string recipientAddress,
-            [Argument("AMOUNT", Description = "The amount of asset to transfer.")]  string amount,
+            [Argument("AMOUNT", Description = "The amount of asset to transfer.")] string amount,
             [Argument("PATH", Description = "A file path of base64 encoded action.")] string? filePath = null,
             [Argument("MEMO", Description = "A memo of asset transfer")] string? memo = null
         )
@@ -215,7 +215,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
                 else
                 {
-                    File.WriteAllText(filePath, encoded);   
+                    File.WriteAllText(filePath, encoded);
                 }
 
                 return 0;
@@ -252,7 +252,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
                 else
                 {
-                    File.WriteAllText(filePath, encoded);   
+                    File.WriteAllText(filePath, encoded);
                 }
 
                 return 0;
@@ -263,7 +263,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 return -1;
             }
         }
-        
+
         [Command(Description = "Create MigrateMonsterCollection action.")]
         public int MigrateMonsterCollection(
             [Argument("AVATAR-ADDRESS", Description = "A hex-encoded avatar address.")] string encodedAddress,
@@ -289,7 +289,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
                 else
                 {
-                    File.WriteAllText(filePath, encoded);   
+                    File.WriteAllText(filePath, encoded);
                 }
 
                 return 0;

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -93,7 +93,7 @@ namespace NineChronicles.Headless.Executable.Commands
         {
             if (storeType == StoreType.Memory)
             {
-                throw new CommandExitedException("Memory is volatile. "+
+                throw new CommandExitedException("Memory is volatile. " +
                                                  "Please use persistent StoreType like RocksDb.", -1);
             }
 

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -69,7 +69,7 @@ namespace NineChronicles.Headless.Executable.Commands
             {
                 throw Utils.Error("GoldDistributionPath is not set");
             }
-            
+
             if (string.IsNullOrEmpty(genesisConfig.AdminAddress))
             {
                 throw Utils.Error($"{nameof(genesisConfig.AdminAddress)} is not set");
@@ -103,9 +103,9 @@ namespace NineChronicles.Headless.Executable.Commands
                             a = File.ReadAllText(a);
                         }
 
-                        var decoded = (List) Codec.Decode(Convert.FromBase64String(a));
-                        string actionType = (Text) decoded[0];
-                        Dictionary plainValue = (Dictionary) decoded[1];
+                        var decoded = (List)Codec.Decode(Convert.FromBase64String(a));
+                        string actionType = (Text)decoded[0];
+                        Dictionary plainValue = (Dictionary)decoded[1];
                         Type type = typeof(ActionBase).Assembly
                             .GetTypes()
                             .First(type => type.Namespace is { } @namespace &&
@@ -113,7 +113,7 @@ namespace NineChronicles.Headless.Executable.Commands
                                            !type.IsAbstract &&
                                            typeof(ActionBase).IsAssignableFrom(type) &&
                                            type.Name == actionType);
-                        ActionBase action = (ActionBase) Activator.CreateInstance(type)!;
+                        ActionBase action = (ActionBase)Activator.CreateInstance(type)!;
                         action.LoadPlainValue(plainValue);
                         return action;
                     }).ToList();

--- a/NineChronicles.Headless.Executable/Commands/Key/ConversionCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/Key/ConversionCommand.cs
@@ -37,7 +37,7 @@ namespace NineChronicles.Headless.Executable.Commands.Key
 
             if (publicKey)
             {
-                _console.Out.WriteLine(ByteUtil.Hex(privateKey.PublicKey.Format(true)));   
+                _console.Out.WriteLine(ByteUtil.Hex(privateKey.PublicKey.Format(true)));
             }
         }
     }

--- a/NineChronicles.Headless.Executable/Commands/ValidationCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ValidationCommand.cs
@@ -32,7 +32,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 return -1;
             }
         }
-        
+
         [Command(Description = "Validate public key")]
         public int PublicKey(
             [Argument(

--- a/NineChronicles.Headless.Executable/LoggerConfigurationExtensions.cs
+++ b/NineChronicles.Headless.Executable/LoggerConfigurationExtensions.cs
@@ -13,19 +13,19 @@ namespace NineChronicles.Headless.Executable
             {
                 case "debug":
                     return loggerConfiguration.MinimumLevel.Debug();
-                
+
                 case "verbose":
                     return loggerConfiguration.MinimumLevel.Verbose();
 
                 case "info":
                     return loggerConfiguration.MinimumLevel.Information();
-                
+
                 case "error":
                     return loggerConfiguration.MinimumLevel.Error();
-                
+
                 default:
                     throw new CommandExitedException("Not supported log minimum level came.", -1);
             }
-        } 
+        }
     }
 }

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -236,7 +236,7 @@ namespace NineChronicles.Headless.Executable
                 Directory.Delete("_logs", true);
             }
 
-            if (useBasicAwsCredentials ^ useCognitoCredentials  && !(awsRegion is null))
+            if (useBasicAwsCredentials ^ useCognitoCredentials && !(awsRegion is null))
             {
                 RegionEndpoint regionEndpoint = RegionEndpoint.GetBySystemName(awsRegion);
                 AWSCredentials credentials = useCognitoCredentials

--- a/NineChronicles.Headless.Executable/Store/StoreType.cs
+++ b/NineChronicles.Headless.Executable/Store/StoreType.cs
@@ -2,8 +2,19 @@ namespace NineChronicles.Headless.Executable.Store
 {
     public enum StoreType
     {
+        /// <summary>
+        /// A store type corresponding to <see cref="Libplanet.RocksDBStore.RocksDBStore"/>.
+        /// </summary>
         RocksDb,
+
+        /// <summary>
+        /// A store type corresponding to <see cref="Libplanet.Store.MemoryStore"/>.
+        /// </summary>
         Memory,
+
+        /// <summary>
+        /// A store type corresponding to <see cref="Libplanet.Store.DefaultStore"/>.
+        /// </summary>
         Default,
     }
 }

--- a/NineChronicles.Headless.Tests/AccountStateGetterExtensionTest.cs
+++ b/NineChronicles.Headless.Tests/AccountStateGetterExtensionTest.cs
@@ -50,7 +50,7 @@ namespace NineChronicles.Headless.Tests
             IReadOnlyList<IValue?> GetStatesMock(IReadOnlyList<Address> addresses) =>
                 addresses.Select(GetStateMock).ToArray();
 
-            var getter = (AccountStateGetter) GetStatesMock;
+            var getter = (AccountStateGetter)GetStatesMock;
 
             if (exc)
             {

--- a/NineChronicles.Headless.Tests/Common/Fixtures.cs
+++ b/NineChronicles.Headless.Tests/Common/Fixtures.cs
@@ -21,7 +21,7 @@ namespace NineChronicles.Headless.Tests
         public static readonly Address UserAddress = UserPrivateKey.PublicKey.ToAddress();
 
         public static readonly Address AvatarAddress = new Address("983c3Fbfe8243a0e36D55C6C1aE26A7c8Bb6CBd4");
-        
+
         public static readonly Address StakeStateAddress = StakeState.DeriveAddress(UserAddress);
 
         public static readonly TableSheets TableSheetsFX =

--- a/NineChronicles.Headless.Tests/DumbTransferAction.cs
+++ b/NineChronicles.Headless.Tests/DumbTransferAction.cs
@@ -1,4 +1,4 @@
-﻿using Bencodex;
+using Bencodex;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Nekoyume.Action;
 
-namespace NineChronicles.Headless.Tests 
+namespace NineChronicles.Headless.Tests
 {
     [Serializable]
     [ActionType("dumb_transfer_action")]
@@ -27,7 +27,7 @@ namespace NineChronicles.Headless.Tests
         protected DumbTransferAction(SerializationInfo info, StreamingContext context)
         {
             var rawBytes = (byte[])info.GetValue("serialized", typeof(byte[]))!;
-            Dictionary pv = (Dictionary) new Codec().Decode(rawBytes);
+            Dictionary pv = (Dictionary)new Codec().Decode(rawBytes);
 
             LoadPlainValue(pv);
         }
@@ -62,7 +62,7 @@ namespace NineChronicles.Headless.Tests
 
         public override void LoadPlainValue(IValue plainValue)
         {
-            var asDict = (Dictionary) plainValue;
+            var asDict = (Dictionary)plainValue;
 
             Sender = asDict["sender"].ToAddress();
             Recipient = asDict["recipient"].ToAddress();

--- a/NineChronicles.Headless.Tests/GraphTypes/Abstractions/StakeRegularRewardsTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/Abstractions/StakeRegularRewardsTypeTest.cs
@@ -39,9 +39,9 @@ namespace NineChronicles.Headless.Tests.GraphTypes.Abstractions
             Assert.Single(bonusRewards);
             var queryResult = await ExecuteQueryAsync<StakeRegularRewardsType>(
                 query,
-                source: (rewardRow.Level, rewardRow.RequiredGold, rewards, bonusRewards) 
+                source: (rewardRow.Level, rewardRow.RequiredGold, rewards, bonusRewards)
             );
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var expected = new Dictionary<string, object>
             {
                 ["level"] = rewardRow.Level,

--- a/NineChronicles.Headless.Tests/GraphTypes/Abstractions/StakeRewardsTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/Abstractions/StakeRewardsTypeTest.cs
@@ -34,7 +34,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.Abstractions
                 source: (Fixtures.TableSheetsFX.StakeRegularRewardSheet,
                     Fixtures.TableSheetsFX.StakeRegularFixedRewardSheet)
             );
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.NotEmpty(data);
             Assert.Null(queryResult.Errors);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
@@ -86,7 +86,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }}";
 
             var queryResult = await ExecuteQueryAsync<ActionQuery>(query, standaloneContext: _standaloneContext);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             NCAction action = new Stake(amount);
             var expected = new Dictionary<string, object>()
             {
@@ -105,10 +105,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }}";
 
             var queryResult = await ExecuteQueryAsync<ActionQuery>(query, standaloneContext: _standaloneContext);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
-            var plainValue = _codec.Decode(ByteUtil.ParseHex((string) data["claimStakeReward"]));
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
+            var plainValue = _codec.Decode(ByteUtil.ParseHex((string)data["claimStakeReward"]));
             Assert.IsType<Dictionary>(plainValue);
-            var dictionary = (Dictionary) plainValue;
+            var dictionary = (Dictionary)plainValue;
             Assert.IsType<ClaimStakeReward>(DeserializeNCAction(dictionary).InnerAction);
         }
 
@@ -166,8 +166,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }}";
 
             var queryResult = await ExecuteQueryAsync<ActionQuery>(query, standaloneContext: _standaloneContext);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
-            var plainValue = _codec.Decode(ByteUtil.ParseHex((string) data["grinding"]));
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
+            var plainValue = _codec.Decode(ByteUtil.ParseHex((string)data["grinding"]));
             Assert.IsType<Dictionary>(plainValue);
             var polymorphicAction = DeserializeNCAction(plainValue);
             var action = Assert.IsType<Grinding>(polymorphicAction.InnerAction);
@@ -188,8 +188,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }}";
 
             var queryResult = await ExecuteQueryAsync<ActionQuery>(query, standaloneContext: _standaloneContext);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
-            var plainValue = _codec.Decode(ByteUtil.ParseHex((string) data["unlockEquipmentRecipe"]));
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
+            var plainValue = _codec.Decode(ByteUtil.ParseHex((string)data["unlockEquipmentRecipe"]));
             Assert.IsType<Dictionary>(plainValue);
             var polymorphicAction = DeserializeNCAction(plainValue);
             var action = Assert.IsType<UnlockEquipmentRecipe>(polymorphicAction.InnerAction);
@@ -215,8 +215,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }}";
 
             var queryResult = await ExecuteQueryAsync<ActionQuery>(query, standaloneContext: _standaloneContext);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
-            var plainValue = _codec.Decode(ByteUtil.ParseHex((string) data["unlockWorld"]));
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
+            var plainValue = _codec.Decode(ByteUtil.ParseHex((string)data["unlockWorld"]));
             Assert.IsType<Dictionary>(plainValue);
             var polymorphicAction = DeserializeNCAction(plainValue);
             var action = Assert.IsType<UnlockWorld>(polymorphicAction.InnerAction);
@@ -248,13 +248,13 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }
             var query = $"{{ transferAsset({args}) }}";
             var queryResult = await ExecuteQueryAsync<ActionQuery>(query, standaloneContext: _standaloneContext);
-            var data = (Dictionary<string, object>) ((ExecutionNode) queryResult.Data!).ToValue()!;
-            var plainValue = _codec.Decode(ByteUtil.ParseHex((string) data["transferAsset"]));
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
+            var plainValue = _codec.Decode(ByteUtil.ParseHex((string)data["transferAsset"]));
             Assert.IsType<Dictionary>(plainValue);
             var polymorphicAction = DeserializeNCAction(plainValue);
             var action = Assert.IsType<TransferAsset>(polymorphicAction.InnerAction);
             var rawState = _standaloneContext.BlockChain!.GetState(Addresses.GoldCurrency);
-            var goldCurrencyState = new GoldCurrencyState((Dictionary) rawState);
+            var goldCurrencyState = new GoldCurrencyState((Dictionary)rawState);
             Currency currency = currencyType == "NCG" ? goldCurrencyState.Currency : CrystalCalculator.CRYSTAL;
 
             Assert.Equal(recipient, action.Recipient);
@@ -295,8 +295,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             ";
             var query = $"{{ patchTableSheet(tableName: \"{tableName}\", tableCsv: \"\"\"{csv}\"\"\") }}";
             var queryResult = await ExecuteQueryAsync<ActionQuery>(query, standaloneContext: _standaloneContext);
-            var data = (Dictionary<string, object>) ((ExecutionNode) queryResult.Data!).ToValue()!;
-            var plainValue = _codec.Decode(ByteUtil.ParseHex((string) data["patchTableSheet"]));
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
+            var plainValue = _codec.Decode(ByteUtil.ParseHex((string)data["patchTableSheet"]));
             Assert.IsType<Dictionary>(plainValue);
             var polymorphicAction = DeserializeNCAction(plainValue);
             var action = Assert.IsType<PatchTableSheet>(polymorphicAction.InnerAction);

--- a/NineChronicles.Headless.Tests/GraphTypes/ScenarioTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ScenarioTest.cs
@@ -42,7 +42,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var args = $"recipient: \"{recipient}\", sender: \"{sender}\", amount: \"17.5\", currency: CRYSTAL";
             var actionQuery = $"{{ transferAsset({args}) }}";
             var actionQueryResult = await ExecuteQueryAsync<ActionQuery>(actionQuery, standaloneContext: StandaloneContextFx);
-            var actionData = (Dictionary<string, object>) ((ExecutionNode) actionQueryResult.Data!).ToValue()!;
+            var actionData = (Dictionary<string, object>)((ExecutionNode)actionQueryResult.Data!).ToValue()!;
             var plainValue = actionData["transferAsset"];
 
             // Get Nonce.
@@ -52,7 +52,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var nonceQueryResult =
                 await ExecuteQueryAsync<TransactionHeadlessQuery>(nonceQuery, standaloneContext: StandaloneContextFx);
             var nonce =
-                (long) ((Dictionary<string, object>) ((ExecutionNode) nonceQueryResult.Data!)
+                (long)((Dictionary<string, object>)((ExecutionNode)nonceQueryResult.Data!)
                     .ToValue()!)["nextTxNonce"];
 
             // Get PublicKey.
@@ -74,7 +74,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var unsignedQueryResult =
                 await ExecuteQueryAsync<TransactionHeadlessQuery>(unsignedQuery, standaloneContext: StandaloneContextFx);
             var unsignedData =
-                (string) ((Dictionary<string, object>) ((ExecutionNode) unsignedQueryResult.Data!).ToValue()!)[
+                (string)((Dictionary<string, object>)((ExecutionNode)unsignedQueryResult.Data!).ToValue()!)[
                     "unsignedTransaction"];
             var unsignedTxBytes = ByteUtil.ParseHex(unsignedData);
             Transaction<NCAction> unsignedTx = Transaction<NCAction>.Deserialize(unsignedTxBytes, false);
@@ -94,7 +94,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }}";
             var signQueryResult =
                 await ExecuteQueryAsync<TransactionHeadlessQuery>(signQuery, standaloneContext: StandaloneContextFx);
-            var hex = (string) ((Dictionary<string, object>) ((ExecutionNode) signQueryResult.Data!).ToValue()!)[
+            var hex = (string)((Dictionary<string, object>)((ExecutionNode)signQueryResult.Data!).ToValue()!)[
                 "signTransaction"];
             byte[] result = ByteUtil.ParseHex(hex);
             Transaction<NCAction> signedTx = Transaction<NCAction>.Deserialize(result);
@@ -116,7 +116,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var stageTxMutation = $"mutation {{ stageTransaction(payload: \"{hex}\") }}";
             var stageTxResult = await ExecuteQueryAsync(stageTxMutation);
             var txId =
-                (string) ((Dictionary<string, object>) ((ExecutionNode) stageTxResult.Data!).ToValue()!)["stageTransaction"];
+                (string)((Dictionary<string, object>)((ExecutionNode)stageTxResult.Data!).ToValue()!)["stageTransaction"];
             Assert.Equal(signedTx.Id.ToHex(), txId);
             Assert.Contains(signedTx.Id, StandaloneContextFx.BlockChain!.GetStagedTransactionIds());
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -49,7 +49,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             // FIXME: passphrase로 "passphrase" 대신 랜덤 문자열을 사용하면 좋을 것 같습니다.
             var result = await ExecuteQueryAsync(
                 "mutation { keyStore { createPrivateKey(passphrase: \"passphrase\") { publicKey { address } } } }");
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             var createdPrivateKeyAddress = (string)
                 ((Dictionary<string, object>)
                     ((Dictionary<string, object>)
@@ -68,11 +68,11 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var privateKeyHex = ByteUtil.Hex(privateKey.ByteArray);
             var result = await ExecuteQueryAsync(
                 $"mutation {{ keyStore {{ createPrivateKey(passphrase: \"passphrase\", privateKey: \"{privateKeyHex}\") {{ hex publicKey {{ address }} }} }} }}");
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             var privateKeyResult = (Dictionary<string, object>)
                 ((Dictionary<string, object>)
                     data["keyStore"])["createPrivateKey"];
-            var createdPrivateKeyHex = (string) privateKeyResult["hex"];
+            var createdPrivateKeyHex = (string)privateKeyResult["hex"];
             var createdPrivateKeyAddress = (string)((Dictionary<string, object>)privateKeyResult["publicKey"])["address"];
 
             Assert.Equal(privateKey, new PrivateKey(ByteUtil.ParseHex(createdPrivateKeyHex)));
@@ -93,7 +93,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             var result = await ExecuteQueryAsync(
                 $"mutation {{ keyStore {{ revokePrivateKey(address: \"{address.ToHex()}\") {{ address }} }} }}");
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             var revokedPrivateKeyAddress = (string)
                 ((Dictionary<string, object>)
                     ((Dictionary<string, object>)
@@ -118,11 +118,11 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var encodedActivationKey = activationKey.Encode();
             var queryResult = await ExecuteQueryAsync(
                 $"mutation {{ activationStatus {{ activateAccount(encodedActivationKey: \"{encodedActivationKey}\") }} }}");
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             await BlockChain.MineBlock(AdminPrivateKey);
 
-            var result = 
-                (bool) ((Dictionary<string, object>)
+            var result =
+                (bool)((Dictionary<string, object>)
                     data["activationStatus"])["activateAccount"];
             Assert.True(result);
 
@@ -168,7 +168,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             var query = $"mutation {{ transfer({args}) }}";
             ExecutionResult result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
 
             if (error)
             {
@@ -189,7 +189,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                     filtered: true);
                 Assert.NotNull(tx);
                 Assert.IsType<TransferAsset>(tx!.Actions.Single().InnerAction);
-                TransferAsset transferAsset = (TransferAsset) tx.Actions.Single().InnerAction;
+                TransferAsset transferAsset = (TransferAsset)tx.Actions.Single().InnerAction;
                 Assert.Equal(memo, transferAsset.Memo);
 
                 var expectedResult = new Dictionary<string, object>
@@ -239,7 +239,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Address recipient = recipientKey.ToAddress();
             var query = $"mutation {{ transferGold(recipient: \"{recipient}\", amount: \"17.5\") }}";
             ExecutionResult result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
 
             var stagedTxIds = BlockChain.GetStagedTransactionIds().ToImmutableList();
             Assert.Single(stagedTxIds);
@@ -282,7 +282,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                     }}
                 }}";
             ExecutionResult result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
 
             var txIds = BlockChain.GetStagedTransactionIds();
@@ -297,7 +297,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, data!);
             Assert.Single(tx.Actions);
-            var action = (CreateAvatar) tx.Actions.First().InnerAction;
+            var action = (CreateAvatar)tx.Actions.First().InnerAction;
             Assert.Equal(name, action.name);
             Assert.Equal(index, action.index);
             Assert.Equal(hair, action.hair);
@@ -369,7 +369,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }
             var query = @$"mutation {{ action {{ hackAndSlash({queryArgs}) }} }}";
             ExecutionResult result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
 
             var txIds = BlockChain.GetStagedTransactionIds();
@@ -384,7 +384,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, data);
             Assert.Single(tx.Actions);
-            var action = (HackAndSlash) tx.Actions.First().InnerAction;
+            var action = (HackAndSlash)tx.Actions.First().InnerAction;
             Assert.Equal(avatarAddress, action.avatarAddress);
             Assert.Equal(worldId, action.worldId);
             Assert.Equal(stageId, action.stageId);
@@ -464,7 +464,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                     }}
                 }}";
             ExecutionResult result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
 
             var txIds = BlockChain.GetStagedTransactionIds();
@@ -479,7 +479,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, data);
             Assert.Single(tx.Actions);
-            var action = (DailyReward) tx.Actions.First().InnerAction;
+            var action = (DailyReward)tx.Actions.First().InnerAction;
             Assert.Equal(avatarAddress, action.avatarAddress);
         }
 
@@ -530,7 +530,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }
             var query = @$"mutation {{ action {{ combinationEquipment({queryArgs}) }} }}";
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
 
             var txIds = BlockChain.GetStagedTransactionIds();
@@ -545,7 +545,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, data);
             Assert.Single(tx.Actions);
-            var action = (CombinationEquipment) tx.Actions.First().InnerAction;
+            var action = (CombinationEquipment)tx.Actions.First().InnerAction;
             Assert.Equal(avatarAddress, action.avatarAddress);
             Assert.Equal(recipeId, action.recipeId);
             Assert.Equal(slotIndex, action.slotIndex);
@@ -588,7 +588,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }}
             }}";
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
 
             var txIds = BlockChain.GetStagedTransactionIds();
@@ -603,7 +603,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, data);
             Assert.Single(tx.Actions);
-            var action = (ItemEnhancement) tx.Actions.First().InnerAction;
+            var action = (ItemEnhancement)tx.Actions.First().InnerAction;
             Assert.Equal(avatarAddress, action.avatarAddress);
             Assert.Equal(itemId, action.itemId);
             Assert.Equal(materialId, action.materialId);
@@ -640,7 +640,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }}
             }}";
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
 
             var txIds = BlockChain.GetStagedTransactionIds();
@@ -655,7 +655,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, data);
             Assert.Single(tx.Actions);
-            var action = (CombinationConsumable) tx.Actions.First().InnerAction;
+            var action = (CombinationConsumable)tx.Actions.First().InnerAction;
             Assert.Equal(avatarAddress, action.avatarAddress);
             Assert.Equal(recipeId, action.recipeId);
             Assert.Equal(slotIndex, action.slotIndex);
@@ -701,7 +701,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             Assert.NotNull(BlockChain.GetState(playerPrivateKey.ToAddress()));
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
 
             var txIds = BlockChain.GetStagedTransactionIds();
@@ -716,7 +716,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, data);
             Assert.Single(tx.Actions);
-            var action = (MonsterCollect) tx.Actions.First().InnerAction;
+            var action = (MonsterCollect)tx.Actions.First().InnerAction;
             Assert.Equal(1, action.level);
         }
 
@@ -746,7 +746,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.NotNull(BlockChain.GetState(playerPrivateKey.ToAddress()));
 
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
 
             var txIds = BlockChain.GetStagedTransactionIds();
@@ -761,7 +761,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, data);
             Assert.Single(tx.Actions);
-            var action = (ClaimMonsterCollectionReward) tx.Actions.First().InnerAction;
+            var action = (ClaimMonsterCollectionReward)tx.Actions.First().InnerAction;
             Assert.Equal(avatarAddress, action.avatarAddress);
         }
 
@@ -826,7 +826,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             // Error: empty payload
             var query = $"mutation {{ stageTx(payload: \"\") }}";
             ExecutionResult result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.NotNull(result.Errors);
             Assert.Equal(
                 new Dictionary<string, object>
@@ -846,7 +846,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             string base64Encoded = Convert.ToBase64String(tx.Serialize(true));
             query = $"mutation {{ stageTx(payload: \"{base64Encoded}\") }}";
             result = await ExecuteQueryAsync(query);
-            data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
             Assert.Equal(
                 new Dictionary<string, object>
@@ -889,7 +889,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             string base64Encoded = Convert.ToBase64String(tx.Serialize(true));
             query = $"mutation {{ stageTxV2(payload: \"{base64Encoded}\") }}";
             result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
             Assert.Equal(
                 new Dictionary<string, object>
@@ -920,12 +920,12 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var console = new StringIOConsole();
             var txCommand = new TxCommand(console);
             var timeStamp = DateTimeOffset.UtcNow;
-            txCommand.Sign(ByteUtil.Hex(privateKey.ByteArray), BlockChain.GetNextTxNonce(privateKey.ToAddress()), ByteUtil.Hex(BlockChain.Genesis.Hash.ByteArray), timeStamp.ToString(), new []{ filePath });
+            txCommand.Sign(ByteUtil.Hex(privateKey.ByteArray), BlockChain.GetNextTxNonce(privateKey.ToAddress()), ByteUtil.Hex(BlockChain.Genesis.Hash.ByteArray), timeStamp.ToString(), new[] { filePath });
             var output = console.Out.ToString();
             output = output.Trim();
             var queryResult = await ExecuteQueryAsync(
                 $"mutation {{ stageTx(payload: \"{output}\") }}");
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             await BlockChain.MineBlock(AdminPrivateKey);
 
             var result = (bool)data["stageTx"];

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -51,7 +51,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
         {
             Address adminStateAddress = AdminState.Address;
             var result = await ExecuteQueryAsync($"query {{ state(address: \"{adminStateAddress}\") }}");
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             IValue rawVal = new Codec().Decode(ByteUtil.ParseHex((string)data!["state"]));
             AdminState adminState = new AdminState((Dictionary)rawVal);
 
@@ -74,8 +74,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             var result = await ExecuteQueryAsync("query { keyStore { protectedPrivateKeys { address } } }");
 
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
-            var keyStoreResult = (Dictionary<string, object>) data["keyStore"];
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
+            var keyStoreResult = (Dictionary<string, object>)data["keyStore"];
             var protectedPrivateKeyAddresses = ((IList)keyStoreResult["protectedPrivateKeys"])
                 .Cast<Dictionary<string, object>>()
                 .Select(x => x["address"] as string)
@@ -99,9 +99,9 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             var result = await ExecuteQueryAsync($"query {{ keyStore {{ decryptedPrivateKey(address: \"{privateKey.ToAddress()}\", passphrase: \"{passphrase}\") }} }}");
 
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
-            var keyStoreResult = (Dictionary<string, object>) data["keyStore"];
-            var decryptedPrivateKeyResult = (string) keyStoreResult["decryptedPrivateKey"];
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
+            var keyStoreResult = (Dictionary<string, object>)data["keyStore"];
+            var decryptedPrivateKeyResult = (string)keyStoreResult["decryptedPrivateKey"];
 
             Assert.Equal(ByteUtil.Hex(privateKey.ByteArray), decryptedPrivateKeyResult);
         }
@@ -122,7 +122,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             // 1. 노드를 생성합니다.
             var seedNode = CreateLibplanetNodeService<EmptyAction>(genesisBlock, apv, apvPrivateKey.PublicKey);
             await StartAsync(seedNode.Swarm, cts.Token);
-            var service = CreateLibplanetNodeService<EmptyAction>(genesisBlock, apv, apvPrivateKey.PublicKey, peers: new [] { seedNode.Swarm.AsPeer });
+            var service = CreateLibplanetNodeService<EmptyAction>(genesisBlock, apv, apvPrivateKey.PublicKey, peers: new[] { seedNode.Swarm.AsPeer });
 
             // 2. NineChroniclesNodeService.ConfigureStandaloneContext(standaloneContext)를 호출합니다.
             // BlockChain 객체 공유 및 PreloadEnded, BootstrapEnded 이벤트 훅의 처리를 합니다.
@@ -138,8 +138,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             async Task<Dictionary<string, bool>> QueryNodeStatus()
             {
                 var result = await ExecuteQueryAsync("query { nodeStatus { bootstrapEnded preloadEnded } }");
-                var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
-                var nodeStatusData = (Dictionary<string, object>) data["nodeStatus"];
+                var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
+                var nodeStatusData = (Dictionary<string, object>)data["nodeStatus"];
                 return nodeStatusData.ToDictionary(pair => pair.Key, pair => (bool)pair.Value);
             }
 
@@ -168,7 +168,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var privateKey = new PrivateKey();
 
             var result = await ExecuteQueryAsync("query { nodeStatus { stagedTxIds } }");
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             var expectedResult = new Dictionary<string, object>()
             {
                 ["nodeStatus"] = new Dictionary<string, object>()
@@ -185,7 +185,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             );
 
             result = await ExecuteQueryAsync("query { nodeStatus { stagedTxIds } }");
-            data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             expectedResult = new Dictionary<string, object>()
             {
                 ["nodeStatus"] = new Dictionary<string, object>()
@@ -211,7 +211,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }}
             }}";
             result = await ExecuteQueryAsync(query);
-            data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             expectedResult = new Dictionary<string, object>()
             {
                 ["nodeStatus"] = new Dictionary<string, object>()
@@ -258,7 +258,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }";
 
             var queryResult = await ExecuteQueryAsync(queryWithoutOffset);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var actualResult = ((Dictionary<string, object>)data["nodeStatus"])["topmostBlocks"];
             var expectedResult = new List<object>
             {
@@ -270,7 +270,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.Equal(expectedResult, actualResult);
 
             queryResult = await ExecuteQueryAsync(queryWithOffset);
-            data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             actualResult = ((Dictionary<string, object>)data["nodeStatus"])["topmostBlocks"];
             expectedResult = new List<object>
             {
@@ -303,7 +303,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }}";
 
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
 
             var validationResult =
                 ((Dictionary<string, object>)data["validation"])["metadata"];
@@ -328,7 +328,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }}";
 
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             var validationResult =
                 ((Dictionary<string, object>)data["validation"])["privateKey"];
             Assert.IsType<bool>(validationResult);
@@ -374,7 +374,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }}";
 
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
 
             var validationResult =
                 ((Dictionary<string, object>)data["validation"])["publicKey"];
@@ -404,7 +404,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             ";
 
             var result = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             var privateKeyResult = (Dictionary<string, object>)
                 ((Dictionary<string, object>)data["keyStore"])["privateKey"];
             Assert.Equal(privateKeyHex, privateKeyResult["hex"]);
@@ -476,28 +476,28 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             var blockChain = StandaloneContextFx.BlockChain!;
 
-            var queryResult = await ExecuteQueryAsync( "query { activationStatus { activated } }");
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var queryResult = await ExecuteQueryAsync("query { activationStatus { activated } }");
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var result = (bool)
                 ((Dictionary<string, object>)data["activationStatus"])["activated"];
 
             // If we don't use activated accounts, bypass check (always true).
             Assert.Equal(!existsActivatedAccounts, result);
 
-            var nonce = new byte[] {0x00, 0x01, 0x02, 0x03};
+            var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
             PolymorphicAction<ActionBase> action = new CreatePendingActivation(pendingActivation);
-            blockChain.MakeTransaction(adminPrivateKey, new[] {action});
+            blockChain.MakeTransaction(adminPrivateKey, new[] { action });
             await blockChain.MineBlock(adminPrivateKey);
 
             action = activationKey.CreateActivateAccount(nonce);
             blockChain.MakeTransaction(userPrivateKey, new[] { action });
             await blockChain.MineBlock(adminPrivateKey);
 
-            queryResult = await ExecuteQueryAsync( "query { activationStatus { activated } }");
-            data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            queryResult = await ExecuteQueryAsync("query { activationStatus { activated } }");
+            data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             result = (bool)
                 ((Dictionary<string, object>)data["activationStatus"])["activated"];
 
@@ -516,7 +516,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var blockChain = StandaloneContextFx.BlockChain;
             var query = $"query {{ goldBalance(address: \"{userAddress}\") }}";
             var queryResult = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(
                 new Dictionary<string, object>
                 {
@@ -528,7 +528,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             await blockChain!.MineBlock(userPrivateKey);
 
             queryResult = await ExecuteQueryAsync(query);
-            data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(
                 new Dictionary<string, object>
                 {
@@ -550,9 +550,9 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             await BlockChain.MineBlock(senderKey);
             await BlockChain.MineBlock(recipientKey);
 
-            var currency = new GoldCurrencyState((Dictionary) BlockChain.GetState(Addresses.GoldCurrency)).Currency;
+            var currency = new GoldCurrencyState((Dictionary)BlockChain.GetState(Addresses.GoldCurrency)).Currency;
             var transferAsset = new TransferAsset(sender, recipient, new FungibleAssetValue(currency, 10, 0), memo);
-            var tx = BlockChain.MakeTransaction(minerPrivateKey, new PolymorphicAction<ActionBase>[] {transferAsset});
+            var tx = BlockChain.MakeTransaction(minerPrivateKey, new PolymorphicAction<ActionBase>[] { transferAsset });
             var block = await BlockChain.MineBlock(minerPrivateKey, append: false);
             BlockChain.Append(block);
             Assert.NotNull(StandaloneContextFx.Store?.GetTxExecution(block.Hash, tx.Id));
@@ -561,7 +561,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var result =
                 await ExecuteQueryAsync(
                     $"{{ transferNCGHistories(blockHash: \"{blockHashHex}\") {{ blockHash txId sender recipient amount memo }} }}");
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Null(result.Errors);
             Assert.Equal(new List<object>
             {
@@ -589,7 +589,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 minerAddress
             }";
             var queryResult = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object?>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object?>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(
                 new Dictionary<string, object?>
                 {
@@ -736,7 +736,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var adminPrivateKey = new PrivateKey();
             var adminAddress = adminPrivateKey.ToAddress();
             var activatedAccounts = ImmutableHashSet<Address>.Empty;
-            var nonce = new byte[] {0x00, 0x01, 0x02, 0x03};
+            var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
@@ -798,7 +798,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             }
             var query = $"query {{ activationKeyNonce(invitationCode: \"{code}\") }}";
             var queryResult = await ExecuteQueryAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var result = (string)data["activationKeyNonce"];
             Assert.Equal(nonce, ByteUtil.ParseHex(result));
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -46,19 +46,19 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 await BlockChain.MineBlock(miner);
 
                 var result = await ExecuteSubscriptionQueryAsync("subscription { tipChanged { index hash } }");
-                
+
                 // var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
                 Assert.IsType<SubscriptionExecutionResult>(result);
-                var subscribeResult = (SubscriptionExecutionResult) result;
+                var subscribeResult = (SubscriptionExecutionResult)result;
                 Assert.Equal(index, BlockChain.Tip.Index);
                 var stream = subscribeResult.Streams!.Values.FirstOrDefault();
                 var rawEvents = await stream.Take((int)index);
                 Assert.NotNull(rawEvents);
 
-                var events = (Dictionary<string, object>)((ExecutionNode) rawEvents.Data!).ToValue()!;
-                var tipChangedEvent = (Dictionary<string, object>) events["tipChanged"];
+                var events = (Dictionary<string, object>)((ExecutionNode)rawEvents.Data!).ToValue()!;
+                var tipChangedEvent = (Dictionary<string, object>)events["tipChanged"];
                 Assert.Equal(index, tipChangedEvent["index"]);
-                Assert.Equal(BlockChain[index].Hash.ToByteArray(), ByteUtil.ParseHex((string) tipChangedEvent["hash"]));
+                Assert.Equal(BlockChain[index].Hash.ToByteArray(), ByteUtil.ParseHex((string)tipChangedEvent["hash"]));
             }
         }
 
@@ -88,7 +88,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 {
                     StandaloneContextFx.PreloadStateSubject.OnNext(state);
                 }),
-                new [] { seedNode.Swarm.AsPeer });
+                new[] { seedNode.Swarm.AsPeer });
 
             var miner = new PrivateKey();
             await seedNode.BlockChain.MineBlock(miner);
@@ -99,7 +99,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             await service.PreloadEnded.WaitAsync(cts.Token);
 
-            var subscribeResult = (SubscriptionExecutionResult) result;
+            var subscribeResult = (SubscriptionExecutionResult)result;
             var stream = subscribeResult.Streams!.Values.FirstOrDefault();
 
             // BlockHashDownloadState  : 2
@@ -120,7 +120,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             foreach (var index in Enumerable.Range(1, preloadStatesCount))
             {
                 var rawEvents = await stream.Take(index);
-                var events = (Dictionary<string, object>)((ExecutionNode) rawEvents.Data!).ToValue()!;
+                var events = (Dictionary<string, object>)((ExecutionNode)rawEvents.Data!).ToValue()!;
                 var preloadProgress = (Dictionary<string, object>)events["preloadProgress"];
                 var preloadProgressExtra = (Dictionary<string, object>)preloadProgress["extra"];
 
@@ -160,7 +160,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                     }
                 }
             ");
-            var subscribeResult = (SubscriptionExecutionResult) result;
+            var subscribeResult = (SubscriptionExecutionResult)result;
             var stream = subscribeResult.Streams!.Values.FirstOrDefault();
             Assert.NotNull(stream);
 
@@ -177,7 +177,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 new DifferentAppProtocolVersionEncounter(peer, apv1, apv2)
             );
             var rawEvents = await stream.Take(1);
-            var rawEvent = (Dictionary<string, object>)((ExecutionNode) rawEvents.Data!).ToValue()!;
+            var rawEvent = (Dictionary<string, object>)((ExecutionNode)rawEvents.Data!).ToValue()!;
             var differentAppProtocolVersionEncounter =
                 (Dictionary<string, object>)rawEvent["differentAppProtocolVersionEncounter"];
             Assert.Equal(
@@ -209,7 +209,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                     }
                 }
             ");
-            var subscribeResult = (SubscriptionExecutionResult) result;
+            var subscribeResult = (SubscriptionExecutionResult)result;
             var stream = subscribeResult.Streams!.Values.FirstOrDefault();
             Assert.NotNull(stream);
 
@@ -218,11 +218,11 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 await stream.Take(1).Timeout(TimeSpan.FromMilliseconds(5000)).FirstAsync();
             });
 
-            const Libplanet.Headless.NodeExceptionType code = (Libplanet.Headless.NodeExceptionType) 0x01;
+            const Libplanet.Headless.NodeExceptionType code = (Libplanet.Headless.NodeExceptionType)0x01;
             const string message = "This is test message.";
             StandaloneContextFx.NodeExceptionSubject.OnNext(new NodeException(code, message));
             var rawEvents = await stream.Take(1);
-            var rawEvent = (Dictionary<string, object>)((ExecutionNode) rawEvents.Data!).ToValue()!;
+            var rawEvent = (Dictionary<string, object>)((ExecutionNode)rawEvents.Data!).ToValue()!;
             var nodeException =
                 (Dictionary<string, object>)rawEvent["nodeException"];
             Assert.Equal((int)code, nodeException["code"]);
@@ -245,14 +245,14 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }"
             );
             Assert.IsType<SubscriptionExecutionResult>(result);
-            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult) result;
+            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult)result;
             IObservable<ExecutionResult> stream = subscribeResult.Streams!.Values.First();
             Assert.NotNull(stream);
 
             MonsterCollectionState monsterCollectionState = new MonsterCollectionState(default, 1, 2, Fixtures.TableSheetsFX.MonsterCollectionRewardSheet);
             StandaloneContextFx.MonsterCollectionStateSubject.OnNext(monsterCollectionState);
             ExecutionResult rawEvents = await stream.Take(1);
-            var rawEvent = (Dictionary<string, object>)((ExecutionNode) rawEvents.Data!).ToValue()!;
+            var rawEvent = (Dictionary<string, object>)((ExecutionNode)rawEvents.Data!).ToValue()!;
             Dictionary<string, object> subject =
                 (Dictionary<string, object>)rawEvent["monsterCollectionState"];
             Dictionary<string, object> expected = new Dictionary<string, object>
@@ -290,7 +290,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }"
             );
             Assert.IsType<SubscriptionExecutionResult>(result);
-            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult) result;
+            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult)result;
             IObservable<ExecutionResult> stream = subscribeResult.Streams!.Values.First();
             Assert.NotNull(stream);
 
@@ -308,7 +308,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 )
             );
             ExecutionResult rawEvents = await stream.Take(1);
-            var data = (MonsterCollectionStatus)((RootExecutionNode) rawEvents.Data.GetValue()).SubFields![0].Result!;
+            var data = (MonsterCollectionStatus)((RootExecutionNode)rawEvents.Data.GetValue()).SubFields![0].Result!;
             Dictionary<string, object> expected = new Dictionary<string, object>
             {
                 ["fungibleAssetValue"] = new Dictionary<string, object>
@@ -332,7 +332,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.Equal(((Dictionary<string, object>)
                 expected["fungibleAssetValue"])["quantity"],
                 (decimal)data.FungibleAssetValue.MajorUnit +
-                (decimal)data.FungibleAssetValue.MinorUnit/
+                (decimal)data.FungibleAssetValue.MinorUnit /
                 ((decimal)Math.Pow(10, Convert.ToInt32(data.FungibleAssetValue.Currency.DecimalPlaces.ToString()))));
             Assert.Equal(((Dictionary<string, object>)
                 ((List<object>)expected["rewardInfos"])[0])["quantity"], data.RewardInfos[0].Quantity);
@@ -360,7 +360,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }}"
             );
             Assert.IsType<SubscriptionExecutionResult>(result);
-            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult) result;
+            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult)result;
             IObservable<ExecutionResult> stream = subscribeResult.Streams!.Values.First();
             Assert.NotNull(stream);
             Assert.NotEmpty(StandaloneContextFx.AgentAddresses);
@@ -368,7 +368,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             MonsterCollectionState monsterCollectionState = new MonsterCollectionState(default, 1, 2, Fixtures.TableSheetsFX.MonsterCollectionRewardSheet);
             StandaloneContextFx.AgentAddresses[address].stateSubject.OnNext(monsterCollectionState);
             ExecutionResult rawEvents = await stream.Take(1);
-            var rawEvent = (Dictionary<string, object>)((ExecutionNode) rawEvents.Data!).ToValue()!;
+            var rawEvent = (Dictionary<string, object>)((ExecutionNode)rawEvents.Data!).ToValue()!;
             Dictionary<string, object> subject =
                 (Dictionary<string, object>)rawEvent["monsterCollectionStateByAgent"];
             Dictionary<string, object> expected = new Dictionary<string, object>
@@ -382,7 +382,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             Assert.Equal(expected, subject);
         }
-        
+
         [Theory]
         [InlineData(100, 0, "100.00", 10, true)]
         [InlineData(0, 2, "0.02", 100, false)]
@@ -408,7 +408,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }}"
             );
             Assert.IsType<SubscriptionExecutionResult>(result);
-            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult) result;
+            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult)result;
             IObservable<ExecutionResult> stream = subscribeResult.Streams!.Values.First();
             Assert.NotNull(stream);
             Assert.NotEmpty(StandaloneContextFx.AgentAddresses);
@@ -427,7 +427,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 )
             );
             ExecutionResult rawEvents = await stream.Take(1);
-            var data = (MonsterCollectionStatus)((RootExecutionNode) rawEvents.Data.GetValue()).SubFields![0].Result!;
+            var data = (MonsterCollectionStatus)((RootExecutionNode)rawEvents.Data.GetValue()).SubFields![0].Result!;
             Dictionary<string, object> expected = new Dictionary<string, object>
             {
                 ["fungibleAssetValue"] = new Dictionary<string, object>
@@ -451,7 +451,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.Equal(((Dictionary<string, object>)
                     expected["fungibleAssetValue"])["quantity"],
                 (decimal)data.FungibleAssetValue.MajorUnit +
-                (decimal)data.FungibleAssetValue.MinorUnit/
+                (decimal)data.FungibleAssetValue.MinorUnit /
                 ((decimal)Math.Pow(10, Convert.ToInt32(data.FungibleAssetValue.Currency.DecimalPlaces.ToString()))));
             Assert.Equal(((Dictionary<string, object>)
                 ((List<object>)expected["rewardInfos"])[0])["quantity"], data.RewardInfos[0].Quantity);
@@ -475,7 +475,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }}"
             );
             Assert.IsType<SubscriptionExecutionResult>(result);
-            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult) result;
+            SubscriptionExecutionResult subscribeResult = (SubscriptionExecutionResult)result;
             IObservable<ExecutionResult> stream = subscribeResult.Streams!.Values.First();
             Assert.NotNull(stream);
             Assert.NotEmpty(StandaloneContextFx.AgentAddresses);
@@ -484,7 +484,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             FungibleAssetValue fungibleAssetValue = new FungibleAssetValue(currency, major, minor);
             StandaloneContextFx.AgentAddresses[address].balanceSubject.OnNext(fungibleAssetValue.GetQuantityString(true));
             ExecutionResult rawEvents = await stream.Take(1);
-            var data = ((RootExecutionNode) rawEvents.Data.GetValue()).SubFields![0].Result!;
+            var data = ((RootExecutionNode)rawEvents.Data.GetValue()).SubFields![0].Result!;
             Assert.Equal(decimalString, data);
         }
     }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AgentStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AgentStateTypeTest.cs
@@ -87,7 +87,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 query,
                 source: new AgentStateType.AgentStateContext(agentState, GetStatesMock, GetBalanceMock)
             );
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var expected = new Dictionary<string, object>()
             {
                 ["address"] = agentState.address.ToString(),

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/ArenaInfoTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/ArenaInfoTypeTest.cs
@@ -30,7 +30,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
 
             var arenaInfo = new ArenaInfo(Fixtures.AvatarStateFX, Fixtures.TableSheetsFX.CharacterSheet, active);
             var queryResult = await ExecuteQueryAsync<ArenaInfoType>(query, source: arenaInfo);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
 
             Assert.Equal(
                 new Dictionary<string, object>

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
@@ -38,7 +38,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                             {
                                 arr[i] = Fixtures.AvatarStateFX.Serialize();
                             }
-                            
+
                             if (addresses[i].Equals(Fixtures.UserAddress))
                             {
                                 arr[i] = Fixtures.AgentStateFx.Serialize();
@@ -48,7 +48,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                         return arr;
                     },
                     (_, _) => new FungibleAssetValue()));
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(expected, data);
         }
 

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CollectionMapTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CollectionMapTypeTest.cs
@@ -24,7 +24,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             var result = await ExecuteQueryAsync<CollectionMapType>(
                 "{ count pairs }",
                 source: collectionMap);
-            var resultData = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var resultData = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Equal(pairs.Length, resultData["count"]);
             Assert.Equal(pairs, resultData["pairs"]);
         }
@@ -33,7 +33,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
         {
             new[]
             {
-               new int[][] {}, 
+               new int[][] {},
             },
             new[]
             {

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CombinationSlotStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CombinationSlotStateTypeTest.cs
@@ -25,7 +25,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             Address address = default;
             CombinationSlotState combinationSlotState = new CombinationSlotState(address, 1);
             var queryResult = await ExecuteQueryAsync<CombinationSlotStateType>(query, source: combinationSlotState);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var expected = new Dictionary<string, object>()
             {
                 ["address"] = address.ToString(),

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierRowTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierRowTypeTest.cs
@@ -22,7 +22,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 query,
                 source: Fixtures.TableSheetsFX.CrystalMonsterCollectionMultiplierSheet.OrderedList.First()
             );
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.NotEmpty(data);
             Assert.Null(queryResult.Errors);
             Assert.Equal(new Dictionary<string, object>

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierSheetTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierSheetTypeTest.cs
@@ -23,7 +23,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 query,
                 source: Fixtures.TableSheetsFX.CrystalMonsterCollectionMultiplierSheet
             );
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.NotEmpty(data);
             Assert.Null(queryResult.Errors);
 

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/FungibleAssetValueTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/FungibleAssetValueTypeTest.cs
@@ -24,7 +24,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             var goldCurrency = new Currency("NCG", 2, minter: null);
             var fav = new FungibleAssetValue(goldCurrency, major, minor);
             var queryResult = await ExecuteQueryAsync<FungibleAssetValueType>(query, source: fav);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(new Dictionary<string, object>
             {
                 ["currency"] = "NCG",

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/InventoryTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/InventoryTypeTest.cs
@@ -26,12 +26,12 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                     itemType
                 }}
             }}";
-            
+
             var row = Fixtures.TableSheetsFX.MaterialItemSheet.Values.Single(r => r.Id == inventoryItemId);
             var item = ItemFactory.CreateMaterial(row);
             Inventory inventory = Fixtures.AvatarStateFX.inventory;
             inventory.AddFungibleItem(item);
-            
+
             ExecutionResult queryResult = await ExecuteQueryAsync<InventoryType>(query, source: inventory);
             Assert.Null(queryResult.Errors);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/MonsterCollectionResultTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/MonsterCollectionResultTypeTest.cs
@@ -32,7 +32,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 query,
                 source: result
             );
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var expected = new Dictionary<string, object>
             {
                 ["avatarAddress"] = result.avatarAddress.ToString(),

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/MonsterCollectionRowTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/MonsterCollectionRowTypeTest.cs
@@ -30,7 +30,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 query,
                 source: (row, Fixtures.TableSheetsFX.MonsterCollectionRewardSheet)
             );
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var expected = new Dictionary<string, object>
             {
                 ["level"] = row.Level,

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/MonsterCollectionSheetTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/MonsterCollectionSheetTypeTest.cs
@@ -28,7 +28,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 query,
                 source: (Fixtures.TableSheetsFX.MonsterCollectionSheet, Fixtures.TableSheetsFX.MonsterCollectionRewardSheet)
             );
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.NotEmpty(data);
             Assert.Null(queryResult.Errors);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/MonsterCollectionStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/MonsterCollectionStateTypeTest.cs
@@ -28,7 +28,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 Fixtures.TableSheetsFX.MonsterCollectionRewardSheet
             );
             var queryResult = await ExecuteQueryAsync<MonsterCollectionStateType>(query, source: state);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var expected = new Dictionary<string, object>
             {
                 ["address"] = state.address.ToString(),

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/RankingInfoTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/RankingInfoTypeTest.cs
@@ -20,7 +20,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 agentAddress
             }";
             var queryResult = await ExecuteQueryAsync<RankingInfoType>(query, source: rankingInfo);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(expected, data);
         }
 

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/RankingMapStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/RankingMapStateTypeTest.cs
@@ -25,7 +25,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             }";
 
             var queryResult = await ExecuteQueryAsync<RankingMapStateType>(query, source: rankingMapState);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(expected, data);
         }
 

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/ShardedShopStateV2TypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/ShardedShopStateV2TypeTest.cs
@@ -38,7 +38,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 }
             }";
             var queryResult = await ExecuteQueryAsync<ShardedShopStateV2Type>(query, source: _state);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(
                 new Dictionary<string, object>
                 {
@@ -68,7 +68,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 }}
             }}";
             var queryResult = await ExecuteQueryAsync<ShardedShopStateV2Type>(query, source: Fixtures.ShardedWeapon0ShopStateV2FX());
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var orderDigestList = (IList)data["orderDigestList"];
             Assert.Equal(expected, orderDigestList.Count!);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/ShopItemTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/ShopItemTypeTest.cs
@@ -62,7 +62,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             };
 
             var queryResult = await ExecuteQueryAsync<ShopItemType>(query, source: shopItem);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var expectedItemUsable = (Dictionary<string, object>)expected["itemUsable"];
             var dataItemUsable = (Dictionary<string, object>)data["itemUsable"];
             var expectedCostume = (Dictionary<string, object>)expected["costume"];

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/ShopStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/ShopStateTypeTest.cs
@@ -37,7 +37,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             }";
             var shopState = new ShopState();
             var queryResult = await ExecuteQueryAsync<ShopStateType>(query, source: shopState);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(
                 new Dictionary<string, object>
                 {
@@ -80,7 +80,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 }}
             }}";
             var queryResult = await ExecuteQueryAsync<ShopStateType>(query, source: Fixtures.ShopStateFX());
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var products = (IList)data["products"];
             Assert.Equal(expected, products.Count!);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/SkillTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/SkillTypeTest.cs
@@ -26,7 +26,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             var row = Fixtures.TableSheetsFX.SkillSheet.OrderedList.First();
             var skill = SkillFactory.Get(row, power, chance);
             var queryResult = await ExecuteQueryAsync<Headless.GraphTypes.States.Models.SkillType>(query, source: skill);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(new Dictionary<string, object>
             {
                 ["id"] = row.Id,

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/WeeklyArenaStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/WeeklyArenaStateTypeTest.cs
@@ -39,7 +39,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 weeklyArenaState.End();
             }
             var queryResult = await ExecuteQueryAsync<WeeklyArenaStateType>(query, source: weeklyArenaState);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
 
             Assert.Equal(
                 new Dictionary<string, object>

--- a/NineChronicles.Headless.Tests/GraphTypes/TransactionHeadlessQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/TransactionHeadlessQueryTest.cs
@@ -51,7 +51,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var userAddress = userPrivateKey.ToAddress();
             string query = $"{{ nextTxNonce(address: \"{userAddress}\") }}";
             var queryResult = await ExecuteAsync(query);
-            var data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(
                 new Dictionary<string, object>
                 {
@@ -62,7 +62,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             _blockChain.MakeTransaction(userPrivateKey, new PolymorphicAction<ActionBase>[] { });
             queryResult = await ExecuteAsync(query);
-            data = (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(
                 new Dictionary<string, object>
                 {
@@ -90,7 +90,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 }}
             }}";
             var queryResult = await ExecuteAsync(string.Format(queryFormat, new TxId()));
-            var data = (Dictionary<string, object?>)((ExecutionNode) queryResult.Data!).ToValue()!;
+            var data = (Dictionary<string, object?>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(
                 new Dictionary<string, object?>
                 {
@@ -112,7 +112,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             _blockChain.StageTransaction(transaction);
             await _blockChain.MineBlock(new PrivateKey());
             queryResult = await ExecuteAsync(string.Format(queryFormat, transaction.Id.ToString()));
-            var tx = (Transaction<PolymorphicAction<ActionBase>>)((RootExecutionNode) queryResult.Data.GetValue()).SubFields![0].Result!;
+            var tx = (Transaction<PolymorphicAction<ActionBase>>)((RootExecutionNode)queryResult.Data.GetValue()).SubFields![0].Result!;
 
             Assert.Equal(tx.Id, transaction.Id);
             Assert.Equal(tx.Nonce, transaction.Nonce);
@@ -124,7 +124,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var plainValue = tx.Actions.First().PlainValue.Inspect(true);
             Assert.Equal(transaction.Actions.First().PlainValue.Inspect(true), plainValue);
         }
-        
+
         [Theory]
         [InlineData(null)]
         [InlineData(0)]
@@ -155,7 +155,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Convert.ToBase64String(codec.Encode(action.PlainValue)),
                 expectedNonce.ToString()));
             var base64EncodedUnsignedTx = (string)(
-                (Dictionary<string, object>)((ExecutionNode) queryResult.Data!).ToValue()!)["createUnsignedTx"];
+                (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!)["createUnsignedTx"];
             Transaction<NCAction> unsignedTx =
                 Transaction<NCAction>.Deserialize(Convert.FromBase64String(base64EncodedUnsignedTx), validate: false);
             Assert.Empty(unsignedTx.Signature);
@@ -164,7 +164,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.Equal(expectedNonce, unsignedTx.Nonce);
             Assert.Contains(signer, unsignedTx.UpdatedAddresses);
         }
-        
+
         [Theory]
         [InlineData("", "")]  // Empty String
         [InlineData(
@@ -182,7 +182,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var result = await ExecuteAsync(string.Format(queryFormat, publicKey, plainValue));
             Assert.NotNull(result.Errors);
         }
-        
+
         [Fact]
         public async Task AttachSignature()
         {
@@ -209,7 +209,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Convert.ToBase64String(signature)));
             Assert.Null(result.Errors);
             var base64EncodedSignedTx = (string)(
-                (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!)["attachSignature"];
+                (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!)["attachSignature"];
             Transaction<NCAction> signedTx =
                 Transaction<NCAction>.Deserialize(Convert.FromBase64String(base64EncodedSignedTx));
             Assert.Equal(signature, signedTx.Signature);
@@ -246,8 +246,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var privateKey = new PrivateKey();
             Transaction<NCAction> tx = Transaction<NCAction>.Create(
                 0,
-                privateKey, 
-                _blockChain.Genesis.Hash, 
+                privateKey,
+                _blockChain.Genesis.Hash,
                 ImmutableArray<NCAction>.Empty);
             _blockChain.StageTransaction(tx);
             var queryFormat = @"query {{
@@ -261,19 +261,19 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 tx.Id.ToString()));
             Assert.NotNull(result.Data);
             var transactionResult =
-                ((Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!)["transactionResult"];
-            var txStatus = (string) ((Dictionary<string, object>)transactionResult)["txStatus"];
+                ((Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!)["transactionResult"];
+            var txStatus = (string)((Dictionary<string, object>)transactionResult)["txStatus"];
             Assert.Equal("STAGING", txStatus);
         }
-        
+
         [Fact]
         public async Task TransactionResultIsInvalid()
         {
             var privateKey = new PrivateKey();
             Transaction<NCAction> tx = Transaction<NCAction>.Create(
                 0,
-                privateKey, 
-                _blockChain.Genesis.Hash, 
+                privateKey,
+                _blockChain.Genesis.Hash,
                 ImmutableArray<NCAction>.Empty);
             var queryFormat = @"query {{
                 transactionResult(txId: ""{0}"") {{
@@ -286,17 +286,17 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 tx.Id.ToString()));
             Assert.NotNull(result.Data);
             var transactionResult =
-                ((Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!)["transactionResult"];
-            var txStatus = (string) ((Dictionary<string, object>)transactionResult)["txStatus"];
+                ((Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!)["transactionResult"];
+            var txStatus = (string)((Dictionary<string, object>)transactionResult)["txStatus"];
             Assert.Equal("INVALID", txStatus);
         }
-        
+
         [Fact]
         public async Task TransactionResultIsSuccess()
         {
             var privateKey = new PrivateKey();
             var action = new DumbTransferAction(new Address(), new Address());
-            Transaction<NCAction> tx = _blockChain.MakeTransaction(privateKey, new NCAction[]{action});
+            Transaction<NCAction> tx = _blockChain.MakeTransaction(privateKey, new NCAction[] { action });
             await _blockChain.MineBlock(new PrivateKey());
             var queryFormat = @"query {{
                 transactionResult(txId: ""{0}"") {{
@@ -309,11 +309,11 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 tx.Id.ToString()));
             Assert.NotNull(result.Data);
             var transactionResult =
-                ((Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!)["transactionResult"];
-            var txStatus = (string) ((Dictionary<string, object>)transactionResult)["txStatus"];
+                ((Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!)["transactionResult"];
+            var txStatus = (string)((Dictionary<string, object>)transactionResult)["txStatus"];
             Assert.Equal("SUCCESS", txStatus);
         }
-        
+
         private Task<ExecutionResult> ExecuteAsync(string query)
         {
             return GraphQLTestUtils.ExecuteQueryAsync<TransactionHeadlessQuery>(query, standaloneContext: new StandaloneContext

--- a/NineChronicles.Headless.Tests/GraphTypes/TransferNCGHistoryTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/TransferNCGHistoryTypeTest.cs
@@ -34,7 +34,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var result = await GraphQLTestUtils.ExecuteQueryAsync<TransferNCGHistoryType>(
                 "{ blockHash txId sender recipient amount }",
                 source: new TransferNCGHistory(blockHash, txId, sender, recipient, amount, memo));
-            var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
             Assert.Equal(new Dictionary<string, object>
             {
                 ["blockHash"] = blockHash.ToString(),

--- a/NineChronicles.Headless.Tests/Middleware/LocalAuthenticationMiddlewareTest.cs
+++ b/NineChronicles.Headless.Tests/Middleware/LocalAuthenticationMiddlewareTest.cs
@@ -40,7 +40,7 @@ namespace NineChronicles.Headless.Tests.Middleware
 
             Assert.True(_httpContext.User.HasClaim("role", "Admin"));
         }
-        
+
         [Theory]
         [MemberData(nameof(IncorrectHeaders))]
         public async Task AuthorizeWithIncorrectSecretToken(string incorrectHeader)
@@ -56,8 +56,8 @@ namespace NineChronicles.Headless.Tests.Middleware
 
             Assert.False(_httpContext.User.HasClaim("role", "Admin"));
         }
-        
-        public static IEnumerable<object[]> IncorrectHeaders => new []
+
+        public static IEnumerable<object[]> IncorrectHeaders => new[]
         {
             new [] { "" },
             new [] { "Basic" },

--- a/NineChronicles.Headless/ActionEvaluationHub.cs
+++ b/NineChronicles.Headless/ActionEvaluationHub.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Threading.Tasks;
 using MagicOnion.Server.Hubs;
@@ -44,13 +44,13 @@ namespace NineChronicles.Headless
             Broadcast(_addressGroup).OnRenderBlock(oldTip, newTip);
             await Task.CompletedTask;
         }
-        
+
         public async Task ReportReorgAsync(byte[] oldTip, byte[] newTip, byte[] branchpoint)
         {
             Broadcast(_addressGroup).OnReorged(oldTip, newTip, branchpoint);
             await Task.CompletedTask;
         }
-        
+
         public async Task ReportReorgEndAsync(byte[] oldTip, byte[] newTip, byte[] branchpoint)
         {
             Broadcast(_addressGroup).OnReorgEnd(oldTip, newTip, branchpoint);

--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -167,12 +167,12 @@ namespace NineChronicles.Headless
                                 {
                                     extra[nameof(BattleArena.ExtraMyArenaPlayerDigest)] = myDigest.Serialize();
                                 }
-                                
+
                                 if (ba.ExtraEnemyArenaPlayerDigest is { } enemyDigest)
                                 {
                                     extra[nameof(BattleArena.ExtraEnemyArenaPlayerDigest)] = enemyDigest.Serialize();
                                 }
-                                
+
                                 if (ba.ExtraPreviousMyScore is { } myScore)
                                 {
                                     extra[nameof(BattleArena.ExtraPreviousMyScore)] = myScore.Serialize();

--- a/NineChronicles.Headless/BlockChainInitializeException.cs
+++ b/NineChronicles.Headless/BlockChainInitializeException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NineChronicles.Headless
 {

--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -70,7 +70,7 @@ namespace NineChronicles.Headless
                     Log.Debug("PutTransaction: (nonce: {nonce}, id: {id})", tx.Nonce, tx.Id);
                     Log.Debug("StagedTransactions: {txIds}", string.Join(", ", _blockChain.GetStagedTransactionIds()));
                     _blockChain.StageTransaction(tx);
-                    _swarm.BroadcastTxs(new[] {tx});
+                    _swarm.BroadcastTxs(new[] { tx });
 
                     return UnaryResult(true);
                 }

--- a/NineChronicles.Headless/Controllers/GraphQLController.cs
+++ b/NineChronicles.Headless/Controllers/GraphQLController.cs
@@ -129,7 +129,7 @@ namespace NineChronicles.Headless.Controllers
                 {
                     return Ok($"Found peer {request.AddressString}.");
                 }
-                
+
                 return BadRequest($"No such peer {request.AddressString}");
             }
             catch (Exception e)
@@ -187,12 +187,12 @@ namespace NineChronicles.Headless.Controllers
             }
 
             var agentStates =
-                states.Select(state => new AgentState((Bencodex.Types.Dictionary) state));
+                states.Select(state => new AgentState((Bencodex.Types.Dictionary)state));
             var avatarStates = agentStates.SelectMany(agentState =>
                 agentState.avatarAddresses.Values.Select(address =>
-                    new AvatarState((Bencodex.Types.Dictionary) chain.GetState(address))));
+                    new AvatarState((Bencodex.Types.Dictionary)chain.GetState(address))));
             var gameConfigState =
-                new GameConfigState((Bencodex.Types.Dictionary) chain.GetState(Addresses.GameConfig));
+                new GameConfigState((Bencodex.Types.Dictionary)chain.GetState(Addresses.GameConfig));
 
             bool IsDailyRewardRefilled(long dailyRewardReceivedIndex)
             {

--- a/NineChronicles.Headless/ExceptionRenderer.cs
+++ b/NineChronicles.Headless/ExceptionRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using NineChronicles.RPC.Shared.Exceptions;

--- a/NineChronicles.Headless/GraphQLServiceExtensions.cs
+++ b/NineChronicles.Headless/GraphQLServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace NineChronicles.Headless
         public static IServiceCollection AddGraphTypes(this IServiceCollection services)
         {
             var graphTypes = Assembly.GetAssembly(typeof(GraphQLServiceExtensions))!.GetTypes().Where(
-                type => type.Namespace is {} @namespace &&
+                type => type.Namespace is { } @namespace &&
                         @namespace.StartsWith($"{nameof(NineChronicles)}.{nameof(Headless)}.{nameof(GraphTypes)}") &&
                         (typeof(IGraphType).IsAssignableFrom(type) || typeof(ISchema).IsAssignableFrom(type)) &&
                         !type.IsAbstract);

--- a/NineChronicles.Headless/GraphTypes/ActionMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionMutation.cs
@@ -188,7 +188,7 @@ namespace NineChronicles.Headless.GraphTypes
                     new QueryArgument<NonNullGraphType<IntGraphType>>
                     {
                         Name = "slotIndex",
-                        Description =  "The empty combination slot index to combine equipment. 0 ~ 3"
+                        Description = "The empty combination slot index to combine equipment. 0 ~ 3"
                     },
                     new QueryArgument<IntGraphType>
                     {
@@ -253,7 +253,7 @@ namespace NineChronicles.Headless.GraphTypes
                     new QueryArgument<NonNullGraphType<IntGraphType>>
                     {
                         Name = "slotIndex",
-                        Description =  "The empty combination slot index to upgrade equipment. 0 ~ 3"
+                        Description = "The empty combination slot index to upgrade equipment. 0 ~ 3"
                     }
                 ),
                 resolve: context =>
@@ -397,7 +397,7 @@ namespace NineChronicles.Headless.GraphTypes
                     new QueryArgument<NonNullGraphType<IntGraphType>>
                     {
                         Name = "slotIndex",
-                        Description =  "The empty combination slot index to combine consumable. 0 ~ 3"
+                        Description = "The empty combination slot index to combine consumable. 0 ~ 3"
                     }
                 ),
                 resolve: context =>
@@ -504,7 +504,7 @@ namespace NineChronicles.Headless.GraphTypes
 
                         Address avatarAddress = context.GetArgument<Address>("avatarAddress");
                         Address agentAddress = service.MinerPrivateKey.ToAddress();
-                        AgentState agentState = new AgentState((Dictionary) service.BlockChain.GetState(agentAddress));
+                        AgentState agentState = new AgentState((Dictionary)service.BlockChain.GetState(agentAddress));
 
                         var action = new ClaimMonsterCollectionReward
                         {

--- a/NineChronicles.Headless/GraphTypes/AppProtocolVersionType.cs
+++ b/NineChronicles.Headless/GraphTypes/AppProtocolVersionType.cs
@@ -24,5 +24,5 @@ namespace NineChronicles.Headless.GraphTypes
                 name: "extra",
                 resolve: context => _codec.Encode(context.Source.Extra));
         }
-    }   
+    }
 }

--- a/NineChronicles.Headless/GraphTypes/CurrencyType.cs
+++ b/NineChronicles.Headless/GraphTypes/CurrencyType.cs
@@ -10,7 +10,7 @@ namespace NineChronicles.Headless.GraphTypes
         NCG,
     }
 
-    public class CurrencyType: EnumerationGraphType<CurrencyEnum>
+    public class CurrencyType : EnumerationGraphType<CurrencyEnum>
     {
     }
 }

--- a/NineChronicles.Headless/GraphTypes/DifferentAppProtocolVersionEncounterType.cs
+++ b/NineChronicles.Headless/GraphTypes/DifferentAppProtocolVersionEncounterType.cs
@@ -12,10 +12,10 @@ namespace NineChronicles.Headless.GraphTypes
                 resolve: context => context.Source.Peer.ToString());
             Field<NonNullGraphType<AppProtocolVersionType>>(
                 name: "peerVersion",
-                resolve: context => context.Source.PeerVersion);   
+                resolve: context => context.Source.PeerVersion);
             Field<NonNullGraphType<AppProtocolVersionType>>(
                 name: "localVersion",
                 resolve: context => context.Source.LocalVersion);
         }
-    }   
+    }
 }

--- a/NineChronicles.Headless/GraphTypes/NodeExceptionType.cs
+++ b/NineChronicles.Headless/GraphTypes/NodeExceptionType.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Types;
+using GraphQL.Types;
 using Libplanet.Headless;
 
 namespace NineChronicles.Headless.GraphTypes

--- a/NineChronicles.Headless/GraphTypes/NodeStatus.cs
+++ b/NineChronicles.Headless/GraphTypes/NodeStatus.cs
@@ -19,7 +19,7 @@ namespace NineChronicles.Headless.GraphTypes
         public bool BootstrapEnded { get; set; }
 
         public bool PreloadEnded { get; set; }
-        
+
         public bool IsMining { get; set; }
 
         public NodeStatusType(StandaloneContext context)

--- a/NineChronicles.Headless/GraphTypes/Notification.cs
+++ b/NineChronicles.Headless/GraphTypes/Notification.cs
@@ -7,7 +7,7 @@ namespace NineChronicles.Headless.GraphTypes
 
         public Notification(NotificationEnum type, string msg = "")
         {
-            Type = type;   
+            Type = type;
             Message = msg;
         }
     }

--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -130,7 +130,7 @@ namespace NineChronicles.Headless.GraphTypes
                         }
 
                         throw new ExecutionError(
-                            $"The given transaction is invalid. (due to: {validationExc.Message})", 
+                            $"The given transaction is invalid. (due to: {validationExc.Message})",
                             validationExc
                         );
                     }

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -141,7 +141,7 @@ namespace NineChronicles.Headless.GraphTypes
                     }
 
                     var histories = filteredTransactions.Select(tx =>
-                        ToTransferNCGHistory((TxSuccess) store.GetTxExecution(blockHash, tx.Id),
+                        ToTransferNCGHistory((TxSuccess)store.GetTxExecution(blockHash, tx.Id),
                             ((TransferAsset)tx.Actions.Single().InnerAction).Memo));
 
                     return histories;
@@ -235,7 +235,7 @@ namespace NineChronicles.Headless.GraphTypes
                                    "Use transaction.getTx()",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<TxIdType>>
-                        {Name = "txId", Description = "transaction id."}
+                    { Name = "txId", Description = "transaction id." }
                 ),
                 resolve: context =>
                 {
@@ -307,7 +307,7 @@ namespace NineChronicles.Headless.GraphTypes
                         AgentState agentState = new AgentState(agentDict);
                         Address deriveAddress = MonsterCollectionState.DeriveAddress(agentAddress, agentState.MonsterCollectionRound);
                         Currency currency = new GoldCurrencyState(
-                            (Dictionary) blockChain.GetState(Addresses.GoldCurrency, offset)
+                            (Dictionary)blockChain.GetState(Addresses.GoldCurrency, offset)
                             ).Currency;
 
                         FungibleAssetValue balance = blockChain.GetBalance(agentAddress, currency, offset);

--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -109,13 +109,15 @@ namespace NineChronicles.Headless.GraphTypes
         public StandaloneSubscription(StandaloneContext standaloneContext)
         {
             StandaloneContext = standaloneContext;
-            AddField(new EventStreamFieldType {
+            AddField(new EventStreamFieldType
+            {
                 Name = "tipChanged",
                 Type = typeof(TipChanged),
                 Resolver = new FuncFieldResolver<TipChanged>(ResolveTipChanged),
                 Subscriber = new EventStreamResolver<TipChanged>(SubscribeTipChanged),
             });
-            AddField(new EventStreamFieldType {
+            AddField(new EventStreamFieldType
+            {
                 Name = "preloadProgress",
                 Type = typeof(PreloadStateType),
                 Resolver = new FuncFieldResolver<PreloadState>(context => (context.Source as PreloadState)!),
@@ -265,10 +267,10 @@ namespace NineChronicles.Headless.GraphTypes
         private void RenderBlock((Block<PolymorphicAction<ActionBase>> OldTip, Block<PolymorphicAction<ActionBase>> NewTip) pair)
         {
             _subject.OnNext(new TipChanged
-                {
-                    Index = pair.NewTip.Index,
-                    Hash = pair.NewTip.Hash,
-                }
+            {
+                Index = pair.NewTip.Index,
+                Hash = pair.NewTip.Hash,
+            }
             );
             if (StandaloneContext.NineChroniclesNodeService is null)
             {
@@ -281,7 +283,7 @@ namespace NineChronicles.Headless.GraphTypes
             BlockHash? offset = delayedRenderer?.Tip?.Hash;
             Currency currency =
                 new GoldCurrencyState(
-                    (Dictionary) blockChain.GetState(Addresses.GoldCurrency, offset)
+                    (Dictionary)blockChain.GetState(Addresses.GoldCurrency, offset)
                 ).Currency;
             var rewardSheet = new MonsterCollectionRewardSheet();
             var csv = blockChain.GetState(

--- a/NineChronicles.Headless/GraphTypes/StateQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StateQuery.cs
@@ -61,7 +61,7 @@ namespace NineChronicles.Headless.GraphTypes
                     var index = context.GetArgument<int>("index");
                     if (context.Source.GetState(RankingState.Derive(index)) is { } state)
                     {
-                        return new RankingMapState((Dictionary) state);
+                        return new RankingMapState((Dictionary)state);
                     }
 
                     return null;
@@ -71,7 +71,7 @@ namespace NineChronicles.Headless.GraphTypes
                 description: "State for shop.",
                 deprecationReason: "Shop is migrated to ShardedShop and not using now. Use shardedShop() instead.",
                 resolve: context => context.Source.GetState(Addresses.Shop) is { } state
-                    ? new ShopState((Dictionary) state)
+                    ? new ShopState((Dictionary)state)
                     : null);
             Field<ShardedShopStateV2Type>(
                 name: "shardedShop",
@@ -94,7 +94,7 @@ namespace NineChronicles.Headless.GraphTypes
 
                     if (context.Source.GetState(ShardedShopStateV2.DeriveAddress(subType, nonce)) is { } state)
                     {
-                        return new ShardedShopStateV2((Dictionary) state);
+                        return new ShardedShopStateV2((Dictionary)state);
                     }
 
                     return null;
@@ -132,7 +132,7 @@ namespace NineChronicles.Headless.GraphTypes
                                     }
                                 }
 #pragma warning disable CS0618 // Type or member is obsolete
-                                arenastate.OrderedArenaInfos.AddRange(arenaInfos.OrderByDescending(a => a.Score).ThenBy(a=>a.CombatPoint));
+                                arenastate.OrderedArenaInfos.AddRange(arenaInfos.OrderByDescending(a => a.Score).ThenBy(a => a.CombatPoint));
 #pragma warning restore CS0618 // Type or member is obsolete
                             }
                         }
@@ -164,9 +164,9 @@ namespace NineChronicles.Headless.GraphTypes
                     return null;
                 }
             );
-            
+
             Field<StakeStateType>(
-                name:  nameof(StakeState),
+                name: nameof(StakeState),
                 description: "State for staking.",
                 arguments: new QueryArguments(new QueryArgument<NonNullGraphType<AddressType>>
                 {
@@ -241,7 +241,7 @@ namespace NineChronicles.Headless.GraphTypes
                     return null;
                 }
             );
-            
+
             Field<StakeRewardsType>(
                 "stakeRewards",
                 resolve: context =>
@@ -292,7 +292,7 @@ namespace NineChronicles.Headless.GraphTypes
                 {
                     var avatarAddress = context.GetArgument<Address>("avatarAddress");
                     var address = avatarAddress.Derive("recipe_ids");
-                    IReadOnlyList<IValue?> values = context.Source.AccountStateGetter(new[] {address});
+                    IReadOnlyList<IValue?> values = context.Source.AccountStateGetter(new[] { address });
                     if (values[0] is List rawRecipeIds)
                     {
                         return rawRecipeIds.ToList(StateExtensions.ToInteger);
@@ -314,7 +314,7 @@ namespace NineChronicles.Headless.GraphTypes
                 {
                     var avatarAddress = context.GetArgument<Address>("avatarAddress");
                     var address = avatarAddress.Derive("world_ids");
-                    IReadOnlyList<IValue?> values = context.Source.AccountStateGetter(new[] {address});
+                    IReadOnlyList<IValue?> values = context.Source.AccountStateGetter(new[] { address });
                     if (values[0] is List rawWorldIds)
                     {
                         return rawWorldIds.ToList(StateExtensions.ToInteger);

--- a/NineChronicles.Headless/GraphTypes/States/AgentStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AgentStateType.cs
@@ -81,7 +81,7 @@ namespace NineChronicles.Headless.GraphTypes.States
                     );
                     if (context.Source.GetState(monsterCollectionAddress) is { } state)
                     {
-                        return new MonsterCollectionState((Dictionary) state).Level;
+                        return new MonsterCollectionState((Dictionary)state).Level;
                     }
 
                     return 0;
@@ -113,7 +113,7 @@ namespace NineChronicles.Headless.GraphTypes.States
                         }
                         else if (values[avatarAddresses.Count + i] is { } state)
                         {
-                            var avatarState = new AvatarState((Dictionary) state);
+                            var avatarState = new AvatarState((Dictionary)state);
                             var traded = IsTradeQuestCompleted(avatarState.questList);
                             if (traded)
                             {

--- a/NineChronicles.Headless/GraphTypes/States/CombinationSlotStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/CombinationSlotStateType.cs
@@ -4,7 +4,7 @@ using Nekoyume.Model.State;
 
 namespace NineChronicles.Headless.GraphTypes.States
 {
-    public class CombinationSlotStateType: ObjectGraphType<CombinationSlotState>
+    public class CombinationSlotStateType : ObjectGraphType<CombinationSlotState>
     {
         public CombinationSlotStateType()
         {

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/ItemBaseType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/ItemBaseType.cs
@@ -17,7 +17,7 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
                 nameof(ItemBase.Id),
                 description: "ID from ItemSheet."
             );
-            
+
             Field<NonNullGraphType<ItemTypeEnumType>>(
                 nameof(ItemBase.ItemType),
                 description: "Item category.",

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/CrystalMonsterCollectionMultiplierRowType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/CrystalMonsterCollectionMultiplierRowType.cs
@@ -11,7 +11,7 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Table
                 nameof(CrystalMonsterCollectionMultiplierSheet.Row.Level),
                 resolve: context => context.Source.Level
             );
-            
+
             Field<NonNullGraphType<IntGraphType>>(
                 nameof(CrystalMonsterCollectionMultiplierSheet.Row.Multiplier),
                 resolve: context => context.Source.Multiplier

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/MonsterCollectionRewardInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/MonsterCollectionRewardInfoType.cs
@@ -3,7 +3,7 @@ using Nekoyume.TableData;
 
 namespace NineChronicles.Headless.GraphTypes.States.Models.Table
 {
-    public class MonsterCollectionRewardInfoType: ObjectGraphType<MonsterCollectionRewardSheet.RewardInfo>
+    public class MonsterCollectionRewardInfoType : ObjectGraphType<MonsterCollectionRewardSheet.RewardInfo>
     {
         public MonsterCollectionRewardInfoType()
         {

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularFixedRewardInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularFixedRewardInfoType.cs
@@ -3,7 +3,7 @@ using Nekoyume.TableData;
 
 namespace NineChronicles.Headless.GraphTypes.States.Models.Table
 {
-    public class StakeRegularFixedRewardInfoType: ObjectGraphType<StakeRegularFixedRewardSheet.RewardInfo>
+    public class StakeRegularFixedRewardInfoType : ObjectGraphType<StakeRegularFixedRewardSheet.RewardInfo>
     {
         public StakeRegularFixedRewardInfoType()
         {

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardInfoType.cs
@@ -3,7 +3,7 @@ using Nekoyume.TableData;
 
 namespace NineChronicles.Headless.GraphTypes.States.Models.Table
 {
-    public class StakeRegularRewardInfoType: ObjectGraphType<StakeRegularRewardSheet.RewardInfo>
+    public class StakeRegularRewardInfoType : ObjectGraphType<StakeRegularRewardSheet.RewardInfo>
     {
         public StakeRegularRewardInfoType()
         {

--- a/NineChronicles.Headless/GraphTypes/States/StakeAchievementsType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/StakeAchievementsType.cs
@@ -19,6 +19,6 @@ namespace NineChronicles.Headless.GraphTypes.States
                 resolve: context =>
                     Enumerable.Range(0, int.MaxValue)
                         .SkipWhile(x => context.Source.Check(context.GetArgument<int>("level"), x)).First() - 1);
-        }    
+        }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -97,7 +97,7 @@ namespace NineChronicles.Headless.GraphTypes
                         Transaction<NCAction>.CreateUnsigned(nonce, publicKey, blockChain.Genesis.Hash, new[] { action });
                     return Convert.ToBase64String(unsignedTransaction.Serialize(false));
                 });
-            
+
             Field<NonNullGraphType<StringGraphType>>(
                 name: "attachSignature",
                 deprecationReason: "Use signTransaction",
@@ -118,7 +118,7 @@ namespace NineChronicles.Headless.GraphTypes
                     byte[] signature = Convert.FromBase64String(context.GetArgument<string>("signature"));
                     Transaction<NCAction> unsignedTransaction =
                         Transaction<NCAction>.Deserialize(
-                            Convert.FromBase64String(context.GetArgument<string>("unsignedTransaction")), 
+                            Convert.FromBase64String(context.GetArgument<string>("unsignedTransaction")),
                             false);
                     Transaction<NCAction> signedTransaction = new Transaction<NCAction>(
                         unsignedTransaction.Nonce,
@@ -132,12 +132,12 @@ namespace NineChronicles.Headless.GraphTypes
 
                     return Convert.ToBase64String(signedTransaction.Serialize(true));
                 });
-            
+
             Field<NonNullGraphType<TxResultType>>(
                 name: "transactionResult",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<TxIdType>>
-                        {Name = "txId", Description = "transaction id."}
+                    { Name = "txId", Description = "transaction id." }
                 ),
                 resolve: context =>
                 {
@@ -152,7 +152,7 @@ namespace NineChronicles.Headless.GraphTypes
                         throw new ExecutionError(
                             $"{nameof(StandaloneContext)}.{nameof(StandaloneContext.Store)} was not set yet!");
                     }
-                    
+
                     TxId txId = context.GetArgument<TxId>("txId");
                     if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } txExecutedBlockHash))
                     {
@@ -175,7 +175,7 @@ namespace NineChronicles.Headless.GraphTypes
                                 $"{nameof(execution)} is not expected concrete class.")
                         };
                     }
-                    catch(Exception)
+                    catch (Exception)
                     {
                         return new TxResult(TxStatus.INVALID, null, null, null, null);
                     }

--- a/NineChronicles.Headless/GraphTypes/TxResult.cs
+++ b/NineChronicles.Headless/GraphTypes/TxResult.cs
@@ -1,4 +1,4 @@
-﻿using Bencodex.Types;
+using Bencodex.Types;
 
 namespace NineChronicles.Headless.GraphTypes
 {

--- a/NineChronicles.Headless/GraphTypes/TxResultType.cs
+++ b/NineChronicles.Headless/GraphTypes/TxResultType.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Bencodex;
 using GraphQL.Types;
 using Libplanet;
@@ -43,7 +43,7 @@ namespace NineChronicles.Headless.GraphTypes
                 nameof(TxResult.ExceptionMetadata),
                 description: "A hexadecimal string to present the metadata of the exception when the transaction failed. "
                     + "It is a Bencodex value. There will be a value when only the transaction fails.",
-                resolve: context => context.Source.ExceptionMetadata is {} metadata ? ByteUtil.Hex(Codec.Encode(metadata)) : null
+                resolve: context => context.Source.ExceptionMetadata is { } metadata ? ByteUtil.Hex(Codec.Encode(metadata)) : null
             );
         }
     }

--- a/NineChronicles.Headless/GraphTypes/TxStatusType.cs
+++ b/NineChronicles.Headless/GraphTypes/TxStatusType.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using GraphQL.Types;
 
 namespace NineChronicles.Headless.GraphTypes
@@ -8,19 +8,19 @@ namespace NineChronicles.Headless.GraphTypes
     {
         [Description("The Transaction doesn't staged or invalid.")]
         INVALID,
-        
+
         [Description("The Transaction do not executed yet.")]
         STAGING,
-        
+
         [Description("The Transaction is success.")]
         SUCCESS,
-        
+
         [Description("The Transaction is failure.")]
         FAILURE,
     }
 
     public class TxStatusType : EnumerationGraphType<TxStatus>
     {
-        
+
     }
 }

--- a/NineChronicles.Headless/NodeStatusRenderer.cs
+++ b/NineChronicles.Headless/NodeStatusRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using NineChronicles.RPC.Shared.Exceptions;

--- a/NineChronicles.Headless/Properties/GraphQLNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/GraphQLNodeServiceProperties.cs
@@ -7,7 +7,7 @@ namespace NineChronicles.Headless.Properties
         public string? GraphQLListenHost { get; set; }
 
         public int? GraphQLListenPort { get; set; }
-        
+
         public string? SecretToken { get; set; }
 
         public bool NoCors { get; set; }

--- a/NineChronicles.Headless/Properties/NetworkType.cs
+++ b/NineChronicles.Headless/Properties/NetworkType.cs
@@ -1,4 +1,4 @@
-﻿namespace NineChronicles.Headless.Properties
+namespace NineChronicles.Headless.Properties
 {
     public enum NetworkType
     {

--- a/NineChronicles.Headless/RPCContext.cs
+++ b/NineChronicles.Headless/RPCContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using Libplanet;
 
 namespace NineChronicles.Headless

--- a/NineChronicles.Headless/Requests/AddressRequest.cs
+++ b/NineChronicles.Headless/Requests/AddressRequest.cs
@@ -1,7 +1,7 @@
-﻿namespace NineChronicles.Headless.Requests
+namespace NineChronicles.Headless.Requests
 {
-  public struct AddressRequest
-  {
-    public string AddressString { get; set; }
-  }
+    public struct AddressRequest
+    {
+        public string AddressString { get; set; }
+    }
 }

--- a/NineChronicles.Headless/Requests/SetMiningRequest.cs
+++ b/NineChronicles.Headless/Requests/SetMiningRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace NineChronicles.Headless.Requests
+namespace NineChronicles.Headless.Requests
 {
     public struct SetMiningRequest
     {

--- a/NineChronicles.Headless/StandaloneContext.cs
+++ b/NineChronicles.Headless/StandaloneContext.cs
@@ -32,7 +32,8 @@ namespace NineChronicles.Headless
 
         public ConcurrentDictionary<Address,
                 (ReplaySubject<MonsterCollectionStatus> statusSubject, ReplaySubject<MonsterCollectionState> stateSubject, ReplaySubject<string> balanceSubject)>
-            AgentAddresses { get; } = new ConcurrentDictionary<Address,
+            AgentAddresses
+        { get; } = new ConcurrentDictionary<Address,
                 (ReplaySubject<MonsterCollectionStatus>, ReplaySubject<MonsterCollectionState>, ReplaySubject<string>)>();
 
         public NodeStatusType NodeStatus => new NodeStatusType(this)

--- a/NineChronicles.Headless/TransferNCGHistory.cs
+++ b/NineChronicles.Headless/TransferNCGHistory.cs
@@ -8,15 +8,15 @@ namespace NineChronicles.Headless
     public class TransferNCGHistory
     {
         public BlockHash BlockHash { get; }
-        
+
         public TxId TxId { get; }
 
         public Address Sender { get; }
-        
+
         public Address Recipient { get; }
 
         public FungibleAssetValue Amount { get; }
-        
+
         public string? Memo { get; }
 
         public TransferNCGHistory(

--- a/NineChronicles.Headless/UserContextBuilder.cs
+++ b/NineChronicles.Headless/UserContextBuilder.cs
@@ -15,7 +15,7 @@ namespace NineChronicles.Headless
         {
             _standaloneContext = standaloneContext;
         }
-        
+
         public Task<IDictionary<string, object?>> BuildUserContext(HttpContext httpContext)
         {
             return new ValueTask<IDictionary<string, object?>>(new Dictionary<string, object?>

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+dotnet format \
+    --exclude Lib9c \
+    --exclude NineChronicles.RPC.Shared


### PR DESCRIPTION
Resolves #1328.

------

## Description

The `dotnet format` is a new tool introduced at .NET Core SDK 6.x version. I hope the code stay consistent code style by applying it.

- You can register a new git `pre-commit` hook with the `git config core.hooksPath hooks` on the root of this project.
- Since this pull request, the GitHub Actions workflow will check the code is formatted well.

## For reviewers

There are 9 commits and the changes are too big to review. I split them by its purpose and described them at the below lines:

- Apply `dotnet format`
  -  [Add documents for StoreType](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/1c94d62d9d7edd27a625797f4f6bd85b0c90e933) [1c94d62](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/1c94d62d9d7edd27a625797f4f6bd85b0c90e933)
  - [Apply dotnet format at NineChronicles.Headless.Executable](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/6f8e328f290f725a881f07cb11bbe6df4fc7b03d) [6f8e328](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/6f8e328f290f725a881f07cb11bbe6df4fc7b03d)
  - [Apply dotnet format at NineChronicles.Headless](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/95c6a397feae58c8f40d37a1a6a6cb66ad13b056) [95c6a39](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/95c6a397feae58c8f40d37a1a6a6cb66ad13b056)
  - [Apply dotnet format for Libplanet.Headless](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/625146bb2adac7761491fb27021fda1b8df9ea26) [625146b](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/625146bb2adac7761491fb27021fda1b8df9ea26)
  - [Apply dotnet format for NineChronicles.Headless.Tests](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/fa2cc5ecdd11749111a403e8f3705ab6133fc95c) [fa2cc5e](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/fa2cc5ecdd11749111a403e8f3705ab6133fc95c)
  - [Apply dotnet format for NineChronicles.Headless.Executable.Tests](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/692bc9465cc05f09c18fae0b6b4572eeaab8914a) [692bc94](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/692bc9465cc05f09c18fae0b6b4572eeaab8914a)
  - [Apply dotnet format for Libplanet.Headless.Tests](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/dcab0070e18fb888e3e262e5093b608318910c6d) [dcab007](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/dcab0070e18fb888e3e262e5093b608318910c6d)
- Help checking formatting
  - [Introduce a new GitHub Actions workflow for dontet format](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/2008fc2e9ebc11830c85a56f216d0116d9a2f8b5) [2008fc2](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/2008fc2e9ebc11830c85a56f216d0116d9a2f8b5)
  - [Provide pre-commit git hook script](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/ea834da2cd8e68f97f8574848a0c18718dc905b7) [ea834da](https://github.com/planetarium/NineChronicles.Headless/pull/1443/commits/ea834da2cd8e68f97f8574848a0c18718dc905b7)