### PR TITLE
Add `MemoryStore` to `--store-type` option

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -316,6 +316,10 @@ namespace Libplanet.Headless.Hosting
                     Log.Error("RocksDB is not available. DefaultStore will be used. {0}", e);
                 }
             }
+            else if (type == "memory")
+            {
+                store = new MemoryStore();
+            }
             else
             {
                 var message = type is null

--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -26,10 +26,8 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 {
     public class ChainCommandTest : IDisposable
     {
-        /// <summary>
-        /// `StoreType.Memory` will not be tested.
-        /// Because the purpose of ChainCommandTest is to store and read blockchain data.
-        /// </summary>
+        // `StoreType.Memory` will not be tested.
+        // Because the purpose of ChainCommandTest is to store and read blockchain data.
         private readonly StringIOConsole _console;
         private readonly ChainCommand _command;
 

--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Libplanet;
 using Libplanet.Action;
@@ -27,6 +26,10 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 {
     public class ChainCommandTest : IDisposable
     {
+        /// <summary>
+        /// `StoreType.Memory` will not be tested.
+        /// Because the purpose of ChainCommandTest is to store and read blockchain data.
+        /// </summary>
         private readonly StringIOConsole _console;
         private readonly ChainCommand _command;
 

--- a/NineChronicles.Headless.Executable.Tests/Store/IStoreExtensionsTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Store/IStoreExtensionsTest.cs
@@ -23,6 +23,7 @@ namespace NineChronicles.Headless.Executable.Tests.Store
         [Theory]
         [InlineData(StoreType.Default)]
         [InlineData(StoreType.RocksDb)]
+        [InlineData(StoreType.Memory)]
         public void GetGenesisBlock(StoreType storeType)
         {
             IStore store = storeType.CreateStore(_storePath);
@@ -41,6 +42,7 @@ namespace NineChronicles.Headless.Executable.Tests.Store
         [Theory]
         [InlineData(StoreType.Default)]
         [InlineData(StoreType.RocksDb)]
+        [InlineData(StoreType.Memory)]
         public void GetGenesisBlock_ThrowsInvalidOperationException_IfChainIdNotExist(StoreType storeType)
         {
             IStore store = storeType.CreateStore(_storePath);

--- a/NineChronicles.Headless.Executable.Tests/Store/StoreTypeExtensionsTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Store/StoreTypeExtensionsTest.cs
@@ -19,6 +19,7 @@ namespace NineChronicles.Headless.Executable.Tests.Store
         [Theory]
         [InlineData(StoreType.RocksDb, typeof(RocksDBStore))]
         [InlineData(StoreType.Default, typeof(DefaultStore))]
+        [InlineData(StoreType.Memory, typeof(MemoryStore))]
         public void ToStoreConstructor(StoreType storeType, Type expectedType)
         {
             IStore store = storeType.CreateStore(_storePath);

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -45,7 +45,7 @@ namespace NineChronicles.Headless.Executable.Commands
             [Argument("STORE-PATH")]
             string storePath)
         {
-            if (!Directory.Exists(storePath))
+            if (storeType != StoreType.Memory && !Directory.Exists(storePath))
             {
                 throw new CommandExitedException($"The given STORE-PATH, {storePath} seems not existed.", -1);
             }
@@ -71,7 +71,7 @@ namespace NineChronicles.Headless.Executable.Commands
                                "mimisbrunnr) of a given chain in csv format.")]
         public void Inspect(
             [Argument("STORE-TYPE",
-                Description = "Store type of RocksDb.")]
+                Description = "Store type of blockchain storage.")]
             StoreType storeType,
             [Argument("STORE-PATH",
                 Description = "Store path to inspect.")]
@@ -83,7 +83,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 Description = "Limit of block count.")]
             int? limit = null)
         {
-            if (!Directory.Exists(storePath))
+            if (storeType != StoreType.Memory && !Directory.Exists(storePath))
             {
                 throw new CommandExitedException($"The given STORE-PATH, {storePath} seems not existed.", -1);
             }
@@ -192,7 +192,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 Description = "Number of blocks to truncate from the tip")]
             int blocksBefore)
         {
-            if (!Directory.Exists(storePath))
+            if (storeType != StoreType.Memory && !Directory.Exists(storePath))
             {
                 throw new CommandExitedException(
                     $"The given STORE-PATH, {storePath} seems not existed.",

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -68,15 +68,14 @@ namespace NineChronicles.Headless.Executable.Commands
             }
 
             BlockHash tipHash = store.IndexBlockHash(chainId, -1)
-                                ?? throw new CommandExitedException("The given chain seems empty.", -1);
+                          ?? throw new CommandExitedException("The given chain seems empty.", -1);
             Block<NCAction> tip = store.GetBlock<NCAction>(blockPolicy.GetHashAlgorithm, tipHash);
             _console.Out.WriteLine(Utils.SerializeHumanReadable(tip.Header));
             (store as IDisposable)?.Dispose();
         }
 
-        [Command(Description =
-            "Print each block's mining time and tx stats (total tx, hack and slash, ranking battle, " +
-            "mimisbrunnr) of a given chain in csv format.")]
+        [Command(Description = "Print each block's mining time and tx stats (total tx, hack and slash, ranking battle, " +
+                               "mimisbrunnr) of a given chain in csv format.")]
         public void Inspect(
             [Argument("STORE-TYPE",
                 Description = "The storage type to store blockchain data. " +
@@ -142,7 +141,7 @@ namespace NineChronicles.Headless.Executable.Commands
 
             var typeOfActionTypeAttribute = typeof(ActionTypeAttribute);
             foreach (var item in
-                     store.IterateIndexes(chain.Id, offset + 1 ?? 1, limit).Select((value, i) => new { i, value }))
+                store.IterateIndexes(chain.Id, offset + 1 ?? 1, limit).Select((value, i) => new { i, value }))
             {
                 var block = store.GetBlock<NCAction>(blockPolicy.GetHashAlgorithm, item.value);
                 var previousBlock = store.GetBlock<NCAction>(
@@ -265,8 +264,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
 
                 snapshotTipHash = hash;
-            } while (!stateStore.ContainsStateRoot(store.GetBlock<NCAction>(hashAlgorithmGetter, snapshotTipHash)
-                         .StateRootHash));
+            } while (!stateStore.ContainsStateRoot(store.GetBlock<NCAction>(hashAlgorithmGetter, snapshotTipHash).StateRootHash));
 
             var forkedId = Guid.NewGuid();
 

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -83,6 +83,9 @@ namespace NineChronicles.Headless.Executable
                 Description = "The private key used for mining blocks. " +
                               "Must not be null if you want to turn on mining with libplanet-node.")]
             string? minerPrivateKeyString = null,
+            [Option(Description = "The type of storage to store blockchain data. " +
+                                  "If not provided, \"LiteDB\" will be used as default. " + 
+                                  "Available type: [\"rocksdb\", \"memory\"]")]
             string? storeType = null,
             string? storePath = null,
             bool noReduceStore = false,

--- a/NineChronicles.Headless.Executable/Store/StoreType.cs
+++ b/NineChronicles.Headless.Executable/Store/StoreType.cs
@@ -3,6 +3,7 @@ namespace NineChronicles.Headless.Executable.Store
     public enum StoreType
     {
         RocksDb,
+        Memory,
         Default,
     }
 }

--- a/NineChronicles.Headless.Executable/Store/StoreTypeExtensions.cs
+++ b/NineChronicles.Headless.Executable/Store/StoreTypeExtensions.cs
@@ -9,6 +9,7 @@ namespace NineChronicles.Headless.Executable.Store
         public static IStore CreateStore(this StoreType storeType, string storePath) => storeType switch
         {
             StoreType.RocksDb => new RocksDBStore(storePath, dbConnectionCacheSize: 5),
+            StoreType.Memory => new MemoryStore(),
             StoreType.Default => new DefaultStore(storePath),
             _ => throw new ArgumentOutOfRangeException(nameof(storeType))
         };

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Options:
   -P, --port <Nullable`1>
   --swarm-private-key <String>                             The private key used for signing messages and to specify your node. If you leave this null, a randomly generated value will be used.
   --miner-private-key <String>                             The private key used for mining blocks. Must not be null if you want to turn on mining with libplanet-node.
-  --store-type <String>
+  --store-type <String>                                    The storage type to store blockchain data. If not provided, "LiteDB" will be used as default. Available type: ["rocksdb", "memory"]
   --store-path <String>
   -I, --ice-server <String>...
   --peer <String>...


### PR DESCRIPTION
resolves #1438 

---

### Description
Add `memory` type into `--store-type` option to use `MemoryStore` as blockchain data storage.

### Acknowledgement
- I did not add MemoryStore to `ChainCommandTest` type test because MemoryStore vanishes when it is disposed.
  - See comment in `ChainCommandTest.cs`