### PR TITLE
Add `prune-states` command

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Libplanet;
 using Libplanet.Action;
@@ -11,16 +14,21 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Extensions.Cocona;
 using Libplanet.Crypto;
+using Libplanet.RocksDBStore;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
+using Nekoyume;
 using Nekoyume.Action;
 using Nekoyume.BlockChain.Policy;
+using Nekoyume.Model;
+using Nekoyume.Model.State;
 using NineChronicles.Headless.Executable.Commands;
 using NineChronicles.Headless.Executable.Store;
 using NineChronicles.Headless.Executable.Tests.IO;
 using Serilog.Core;
 using Xunit;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+using Lib9cUtils = Lib9c.DevExtensions.Utils;
 
 namespace NineChronicles.Headless.Executable.Tests.Commands
 {
@@ -80,7 +88,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             store.SetCanonicalChainId(chainId);
             store.PutBlock(genesisBlock);
             store.AppendIndex(chainId, genesisBlock.Hash);
-            var stateStore = new TrieStateStore(new DefaultKeyValueStore(null));
+            var stateStore = new TrieStateStore(new RocksDBKeyValueStore(Path.Combine(_storePath, "states")));
 
             IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
             IBlockPolicy<NCAction> blockPolicy = new BlockPolicySource(Logger.None).GetPolicy();
@@ -105,6 +113,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             chain.MakeTransaction(minerKey, new PolymorphicAction<ActionBase>[] { action });
             await chain.MineBlock(minerKey, DateTimeOffset.Now);
             store.Dispose();
+            stateStore.Dispose();
 
             _command.Inspect(storeType, _storePath);
             List<double> output = _console.Out.ToString().Split("\n")[1]
@@ -129,9 +138,9 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             store.SetCanonicalChainId(chainId);
             store.PutBlock(genesisBlock);
             store.AppendIndex(chainId, genesisBlock.Hash);
-            var stateStore = new TrieStateStore(new DefaultKeyValueStore(null));
+            var stateStore = new TrieStateStore(new RocksDBKeyValueStore(Path.Combine(_storePath, "states")));
 
-            IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
+            IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<NCAction>();
             IBlockPolicy<NCAction> blockPolicy = new BlockPolicySource(Logger.None).GetPolicy();
             BlockChain<NCAction> chain = new BlockChain<NCAction>(
                 blockPolicy,
@@ -153,12 +162,13 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             var minerKey = new PrivateKey();
             for (var i = 0; i < 2; i++)
             {
-                chain.MakeTransaction(minerKey, new PolymorphicAction<ActionBase>[] { action });
+                chain.MakeTransaction(minerKey, new NCAction[] { action });
                 await chain.MineBlock(minerKey, DateTimeOffset.Now);
             }
 
             var indexCountBeforeTruncate = store.CountIndex(chainId);
             store.Dispose();
+            stateStore.Dispose();
             _command.Truncate(storeType, _storePath, 1);
             IStore storeAfterTruncate = storeType.CreateStore(_storePath);
             chainId = storeAfterTruncate.GetCanonicalChainId() ?? new Guid();
@@ -167,6 +177,126 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 
             Assert.Equal(3, indexCountBeforeTruncate);
             Assert.Equal(2, indexCountAfterTruncate);
+        }
+
+        [Theory]
+        [InlineData(StoreType.Default)]
+        [InlineData(StoreType.RocksDb)]
+        public void PruneState(StoreType storeType)
+        {
+            IStore store = storeType.CreateStore(_storePath);
+            var statesPath = Path.Combine(_storePath, "states");
+            Guid chainId = Guid.NewGuid();
+            store.SetCanonicalChainId(chainId);
+            var genesisBlock = MineGenesisBlock();
+            store.PutBlock(genesisBlock);
+            store.AppendIndex(chainId, genesisBlock.Hash);
+            var stateKeyValueStore = new RocksDBKeyValueStore(statesPath);
+            var stateStore = new TrieStateStore(stateKeyValueStore);
+            IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<NCAction>();
+            IBlockPolicy<NCAction> blockPolicy = new BlockPolicySource(Logger.None).GetPolicy();
+            BlockChain<NCAction> chain = new BlockChain<NCAction>(
+                blockPolicy,
+                stagePolicy,
+                store,
+                stateStore,
+                genesisBlock);
+            chain.ExecuteActions(chain.Tip);
+            int prevStatesCount = stateKeyValueStore.ListKeys().Count();
+            stateKeyValueStore.Set(
+                new KeyBytes("alpha", Encoding.UTF8),
+                ByteUtil.ParseHex("00"));
+            stateKeyValueStore.Set(
+                new KeyBytes("beta", Encoding.UTF8),
+                ByteUtil.ParseHex("00"));
+            Assert.Equal(prevStatesCount + 2, stateKeyValueStore.ListKeys().Count());
+            store.Dispose();
+            stateStore.Dispose();
+            _command.PruneStates(storeType, _storePath);
+            IStore outputStore = storeType.CreateStore(_storePath);
+            var outputStateKeyValueStore = new RocksDBKeyValueStore(statesPath);
+            var outputStateStore = new TrieStateStore(outputStateKeyValueStore, true);
+            int outputStatesCount = outputStateKeyValueStore.ListKeys().Count();
+            outputStore.Dispose();
+            outputStateStore.Dispose();
+            Assert.Equal(prevStatesCount, outputStatesCount);
+        }
+
+        private Block<NCAction> MineGenesisBlock()
+        {
+            Dictionary<string, string> tableSheets = Lib9cUtils.ImportSheets("../../../../Lib9c/Lib9c/TableCSV");
+            var goldDistributionPath = Path.GetTempFileName();
+            File.WriteAllText(goldDistributionPath, @"Address,AmountPerBlock,StartBlock,EndBlock
+F9A15F870701268Bd7bBeA6502eB15F4997f32f9,1000000,0,0
+F9A15F870701268Bd7bBeA6502eB15F4997f32f9,100,1,100000
+Fb90278C67f9b266eA309E6AE8463042f5461449,3000,3600,13600
+Fb90278C67f9b266eA309E6AE8463042f5461449,100000000000,2,2
+");
+            var privateKey = new PrivateKey();
+            goldDistributionPath = goldDistributionPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var config = new Dictionary<string, object>
+            {
+                ["PrivateKey"] = ByteUtil.Hex(privateKey.ByteArray),
+                ["AdminAddress"] = "0000000000000000000000000000000000000005",
+                ["AuthorizedMinerConfig"] = new Dictionary<string, object>
+                {
+                    ["ValidUntil"] = 1500000,
+                    ["Interval"] = 50,
+                    ["Miners"] = new List<string>
+                    {
+                        "0000000000000000000000000000000000000001",
+                        "0000000000000000000000000000000000000002",
+                        "0000000000000000000000000000000000000003",
+                        "0000000000000000000000000000000000000004"
+                    }
+                }
+            };
+            string json = JsonSerializer.Serialize(config);
+            GenesisConfig genesisConfig = JsonSerializer.Deserialize<GenesisConfig>(json);
+
+            Lib9cUtils.CreateActivationKey(
+                out List<PendingActivationState> pendingActivationStates,
+                out List<ActivationKey> activationKeys,
+                (uint)config.Count);
+            var authorizedMinersState = new AuthorizedMinersState(
+                genesisConfig.AuthorizedMinerConfig.Miners.Select(a => new Address(a)),
+                genesisConfig.AuthorizedMinerConfig.Interval,
+                genesisConfig.AuthorizedMinerConfig.ValidUntil
+            );
+            GoldDistribution[] goldDistributions = GoldDistribution
+                .LoadInDescendingEndBlockOrder(goldDistributionPath);
+            AdminState adminState =
+                new AdminState(new Address(genesisConfig.AdminAddress), genesisConfig.AdminValidUntil);
+            Block<NCAction> genesisBlock = BlockHelper.MineGenesisBlock(
+                tableSheets,
+                goldDistributions,
+                pendingActivationStates.ToArray(),
+                adminState,
+                authorizedMinersState,
+                ImmutableHashSet<Address>.Empty,
+                genesisConfig.ActivationKeyCount != 0,
+                null,
+                new PrivateKey(ByteUtil.ParseHex(genesisConfig.PrivateKey))
+            );
+            return genesisBlock;
+        }
+
+        [Serializable]
+        private struct AuthorizedMinerConfig
+        {
+            public long Interval { get; set; }
+            public long ValidUntil { get; set; }
+            public List<string> Miners { get; set; }
+        }
+
+        [Serializable]
+        private struct GenesisConfig
+        {
+            public string PrivateKey { get; set; }
+            public uint ActivationKeyCount { get; set; }
+            public string AdminAddress { get; set; }
+            public long AdminValidUntil { get; set; }
+            public AuthorizedMinerConfig AuthorizedMinerConfig { get; set; }
         }
 
         public void Dispose()

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -304,7 +304,7 @@ namespace NineChronicles.Headless.Executable.Commands
             if (!(store.GetCanonicalChainId() is { } chainId))
             {
                 throw new CommandExitedException(
-                    $"There is no canonical chain: {storePath}", 
+                    $"There is no canonical chain: {storePath}",
                     -1);
             }
 


### PR DESCRIPTION
This PR adds a `chain command` that prunes the `states` of the 9c store (similar to `NineChronicles.Snapshot`).

With this command, downloading a new snapshot when the `states` size is too large is no longer needed.

One issue is that this command takes close to `30 mins` to complete in our current 9c store, which has an initial `states` size of about `4GB`. I'll add a more detailed issue on the `libplanet` repo.