### PR TITLE
Rebuild genesis command

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -75,7 +75,7 @@ namespace NineChronicles.Headless.Executable.Commands
             }
 
             initialDepositList = new List<GoldDistribution>();
-            if (config.Value.InitialCurrencyDeposit.Count == 0)
+            if (config.Value.InitialCurrencyDeposit is null || config.Value.InitialCurrencyDeposit.Count == 0)
             {
                 Log.Information("Initial currency deposit list not provided. " +
                                 $"Give initial ${DefaultCurrencyValue} currency to InitialMinter");
@@ -196,7 +196,8 @@ namespace NineChronicles.Headless.Executable.Commands
                     }
                 }
 
-                if (genesisConfig.Currency?.InitialCurrencyDeposit.Count == 0)
+                if (genesisConfig.Currency?.InitialCurrencyDeposit is null ||
+                    genesisConfig.Currency.Value.InitialCurrencyDeposit.Count == 0)
                 {
                     if (string.IsNullOrEmpty(genesisConfig.Currency?.InitialMinter))
                     {
@@ -232,8 +233,8 @@ namespace NineChronicles.Headless.Executable.Commands
         [Serializable]
         private struct CurrencyConfig
         {
-            public string InitialMinter { get; set; } // PrivateKey, not Address
-            public List<GoldDistribution> InitialCurrencyDeposit { get; set; }
+            public string? InitialMinter { get; set; } // PrivateKey, not Address
+            public List<GoldDistribution>? InitialCurrencyDeposit { get; set; }
         }
 
         [Serializable]

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -2,18 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Numerics;
-using System.Security.AccessControl;
 using System.Text.Json;
 using Bencodex;
 using Bencodex.Types;
 using Cocona;
-using CsvHelper.Configuration.Attributes;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
-using Libplanet.Explorer.GraphTypes;
 using Libplanet.Extensions.Cocona;
 using Nekoyume;
 using Nekoyume.Action;
@@ -182,6 +178,38 @@ namespace NineChronicles.Headless.Executable.Commands
                 );
 
                 Lib9cUtils.ExportBlock(block, "genesis-block");
+                if (genesisConfig.Admin?.Activate == true)
+                {
+                    if (string.IsNullOrEmpty(genesisConfig.Admin.Value.Address))
+                    {
+                        Console.WriteLine("Initial minter has admin privilege. Keep this account in secret.");
+                    }
+                    else
+                    {
+                        Console.WriteLine("Admin privilege has been granted to given admin address. " +
+                                          "Keep this account in secret.");
+                    }
+                }
+
+                if (genesisConfig.Currency?.InitialCurrencyDeposit.Count == 0)
+                {
+                    if (string.IsNullOrEmpty(genesisConfig.Currency?.InitialMinter))
+                    {
+                        Console.WriteLine("No currency data provided. Initial minter gets initial deposition.\n" +
+                                          "Please check `initial_deposit.csv` file to get detailed info.");
+                        File.WriteAllText("initial_deposit.csv",
+                            "Address,PrivateKey,AmountPerBlock,StartBlock,EndBlock\n");
+                        File.AppendAllText("initial_deposit.csv",
+                            $"{initialMinter.ToAddress()},{ByteUtil.Hex(initialMinter.ByteArray)},{DefaultCurrencyValue},0,0");
+                    }
+                    else
+                    {
+                        Console.WriteLine("No initial deposit data provided. " +
+                                          "Initial minter you provided gets initial deposition.");
+                    }
+                }
+
+                Console.WriteLine("\nGenesis block created.");
             }
             catch (Exception e)
             {

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -33,7 +33,7 @@ namespace NineChronicles.Headless.Executable.Commands
 
         private void ProcessData(DataConfig config, out Dictionary<string, string> tableSheets)
         {
-            Console.WriteLine("Processing data for genesis...");
+            _console.Out.WriteLine("\nProcessing data for genesis...");
             if (string.IsNullOrEmpty(config.TablePath))
             {
                 throw Utils.Error("TablePath is not set.");
@@ -48,10 +48,10 @@ namespace NineChronicles.Headless.Executable.Commands
             out List<GoldDistribution> initialDepositList
         )
         {
-            Console.WriteLine("Processing currency for genesis...");
+            _console.Out.WriteLine("\nProcessing currency for genesis...");
             if (config is null)
             {
-                Log.Information("CurrencyConfig not provided. Skip setting...");
+                _console.Out.WriteLine("CurrencyConfig not provided. Skip setting...");
                 initialMinter = new PrivateKey();
                 initialDepositList = new List<GoldDistribution>
                 {
@@ -66,7 +66,7 @@ namespace NineChronicles.Headless.Executable.Commands
 
             if (string.IsNullOrEmpty(config.Value.InitialMinter))
             {
-                Log.Information("Private Key not provided. Create random one...");
+                _console.Out.WriteLine("Private Key not provided. Create random one...");
                 initialMinter = new PrivateKey();
             }
             else
@@ -77,8 +77,8 @@ namespace NineChronicles.Headless.Executable.Commands
             initialDepositList = new List<GoldDistribution>();
             if (config.Value.InitialCurrencyDeposit is null || config.Value.InitialCurrencyDeposit.Count == 0)
             {
-                Log.Information("Initial currency deposit list not provided. " +
-                                $"Give initial ${DefaultCurrencyValue} currency to InitialMinter");
+                _console.Out.WriteLine("Initial currency deposit list not provided. " +
+                                $"Give initial {DefaultCurrencyValue} currency to InitialMinter");
                 initialDepositList.Add(new GoldDistribution
                 {
                     Address = initialMinter.ToAddress(),
@@ -97,11 +97,11 @@ namespace NineChronicles.Headless.Executable.Commands
         {
             // FIXME: If the `adminState` is not required inside `MineGenesisBlock`,
             //        this logic will be much lighter.
-            Console.WriteLine("Processing admin for genesis...");
+            _console.Out.WriteLine("\nProcessing admin for genesis...");
             adminState = new AdminState(new Address(), 0);
             if (config is null)
             {
-                Log.Information("AdminConfig not provided. Skip admin setting...");
+                _console.Out.WriteLine("AdminConfig not provided. Skip admin setting...");
                 return;
             }
 
@@ -109,28 +109,28 @@ namespace NineChronicles.Headless.Executable.Commands
             {
                 if (string.IsNullOrEmpty(config.Value.Address))
                 {
-                    Log.Information("Admin address not provided. Give admin privilege to initialMinter");
+                    _console.Out.WriteLine("Admin address not provided. Give admin privilege to initialMinter");
                     adminState = new AdminState(initialMinter.ToAddress(), config.Value.ValidUntil);
                 }
             }
             else
             {
-                Log.Information("Inactivate Admin. Skip admin setting...");
+                _console.Out.WriteLine("Inactivate Admin. Skip admin setting...");
             }
 
-            Log.Information("Admin config done");
+            _console.Out.WriteLine("Admin config done");
         }
 
         private void ProcessExtra(ExtraConfig? config,
             out List<PendingActivationState> pendingActivationStates
         )
         {
-            Console.WriteLine("Processing extra data for genesis...");
+            _console.Out.WriteLine("\nProcessing extra data for genesis...");
             pendingActivationStates = new List<PendingActivationState>();
 
             if (config is null)
             {
-                Log.Information("Extra config not provided");
+                _console.Out.WriteLine("Extra config not provided");
                 return;
             }
 
@@ -151,9 +151,6 @@ namespace NineChronicles.Headless.Executable.Commands
             [Argument("CONFIG", Description = "JSON config path to mine genesis block")]
             string configPath)
         {
-            var loggerConf = new LoggerConfiguration();
-            Log.Logger = loggerConf.CreateLogger();
-
             var options = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
@@ -173,7 +170,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 ProcessExtra(genesisConfig.Extra, out List<PendingActivationState> pendingActivationStates);
 
                 // Mine genesis block
-                Console.WriteLine("\nMining genesis block...\n");
+                _console.Out.WriteLine("\nMining genesis block...\n");
                 Block<PolymorphicAction<ActionBase>> block = BlockHelper.MineGenesisBlock(
                     tableSheets: tableSheets,
                     goldDistributions: initialDepositList.ToArray(),
@@ -187,11 +184,11 @@ namespace NineChronicles.Headless.Executable.Commands
                 {
                     if (string.IsNullOrEmpty(genesisConfig.Admin.Value.Address))
                     {
-                        Console.WriteLine("Initial minter has admin privilege. Keep this account in secret.");
+                        _console.Out.WriteLine("Initial minter has admin privilege. Keep this account in secret.");
                     }
                     else
                     {
-                        Console.WriteLine("Admin privilege has been granted to given admin address. " +
+                        _console.Out.WriteLine("Admin privilege has been granted to given admin address. " +
                                           "Keep this account in secret.");
                     }
                 }
@@ -201,7 +198,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 {
                     if (string.IsNullOrEmpty(genesisConfig.Currency?.InitialMinter))
                     {
-                        Console.WriteLine("No currency data provided. Initial minter gets initial deposition.\n" +
+                        _console.Out.WriteLine("No currency data provided. Initial minter gets initial deposition.\n" +
                                           "Please check `initial_deposit.csv` file to get detailed info.");
                         File.WriteAllText("initial_deposit.csv",
                             "Address,PrivateKey,AmountPerBlock,StartBlock,EndBlock\n");
@@ -210,12 +207,12 @@ namespace NineChronicles.Headless.Executable.Commands
                     }
                     else
                     {
-                        Console.WriteLine("No initial deposit data provided. " +
+                        _console.Out.WriteLine("No initial deposit data provided. " +
                                           "Initial minter you provided gets initial deposition.");
                     }
                 }
 
-                Console.WriteLine("\nGenesis block created.");
+                _console.Out.WriteLine("\nGenesis block created.");
             }
             catch (Exception e)
             {

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -1,32 +1,33 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Reflection;
+using System.Numerics;
+using System.Security.AccessControl;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Bencodex;
 using Bencodex.Types;
 using Cocona;
+using CsvHelper.Configuration.Attributes;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
+using Libplanet.Explorer.GraphTypes;
 using Libplanet.Extensions.Cocona;
-using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Nekoyume;
 using Nekoyume.Action;
-using Nekoyume.Model;
 using Nekoyume.Model.State;
 using NineChronicles.Headless.Executable.IO;
+using Serilog;
 using Lib9cUtils = Lib9c.DevExtensions.Utils;
 
 namespace NineChronicles.Headless.Executable.Commands
 {
     public class GenesisCommand : CoconaLiteConsoleAppBase
     {
-        private static readonly Codec Codec = new Codec();
+        private const int DefaultCurrencyValue = 10000;
+        private static readonly Codec _codec = new Codec();
         private readonly IConsole _console;
 
         public GenesisCommand(IConsole console)
@@ -34,105 +35,153 @@ namespace NineChronicles.Headless.Executable.Commands
             _console = console;
         }
 
-        [Command(Description = "Mine a new genesis block.")]
-        public void Mine(
-            [Argument("CONFIG", Description = "JSON config path to mine genesis block.")]
-            string configPath
+        private void ProcessData(DataConfig config, out Dictionary<string, string> tableSheets)
+        {
+            if (string.IsNullOrEmpty(config.TablePath))
+            {
+                throw Utils.Error("TablePath is not set.");
+            }
+
+            tableSheets = Lib9cUtils.ImportSheets(config.TablePath);
+        }
+
+        private void ProcessCurrency(
+            CurrencyConfig? config,
+            out PrivateKey initialMinter,
+            out List<GoldDistribution> initialDepositList
         )
         {
+            if (config is null)
+            {
+                Log.Information("CurrencyConfig not provided. Skip setting...");
+                initialMinter = new PrivateKey();
+                initialDepositList = new List<GoldDistribution>
+                {
+                    new()
+                    {
+                        Address = initialMinter.ToAddress(), AmountPerBlock = DefaultCurrencyValue,
+                        StartBlock = 0, EndBlock = 0
+                    }
+                };
+                return;
+            }
+
+            if (string.IsNullOrEmpty(config.Value.InitialMinter))
+            {
+                Log.Information("Private Key not provided. Create random one...");
+                initialMinter = new PrivateKey();
+            }
+            else
+            {
+                initialMinter = new PrivateKey(config.Value.InitialMinter);
+            }
+
+            initialDepositList = new List<GoldDistribution>();
+            if (config.Value.InitialCurrencyDeposit.Count == 0)
+            {
+                Log.Information("Initial currency deposit list not provided. " +
+                                $"Give initial ${DefaultCurrencyValue} currency to InitialMinter");
+                initialDepositList.Add(new GoldDistribution
+                {
+                    Address = initialMinter.ToAddress(),
+                    AmountPerBlock = DefaultCurrencyValue,
+                    StartBlock = 0,
+                    EndBlock = 0
+                });
+            }
+            else
+            {
+                initialDepositList = config.Value.InitialCurrencyDeposit;
+            }
+        }
+
+        private void ProcessAdmin(AdminConfig? config, PrivateKey initialMinter, out AdminState adminState)
+        {
+            // FIXME: If the `adminState` is not required inside `MineGenesisBlock`,
+            //        this logic will be much lighter.
+            adminState = new AdminState(new PrivateKey().ToAddress(), 0);
+            if (config is null)
+            {
+                Log.Information("AdminConfig not provided. Skip admin setting...");
+                return;
+            }
+
+            if (config.Value.Activate)
+            {
+                if (string.IsNullOrEmpty(config.Value.Address))
+                {
+                    Log.Information("Admin address not provided. Give admin privilege to initialMinter");
+                    adminState = new AdminState(initialMinter.ToAddress(), config.Value.ValidUntil);
+                }
+            }
+            else
+            {
+                Log.Information("Inactivate Admin. Skip admin setting...");
+            }
+
+            Log.Information("Admin config done");
+        }
+
+        private void ProcessExtra(ExtraConfig? config,
+            out List<PendingActivationState> pendingActivationStates
+        )
+        {
+            pendingActivationStates = new List<PendingActivationState>();
+
+            if (config is null)
+            {
+                Log.Information("Extra config not provided");
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(config.Value.PendingActivationStatePath))
+            {
+                string hex = File.ReadAllText(config.Value.PendingActivationStatePath).Trim();
+                List decoded = (List)_codec.Decode(ByteUtil.ParseHex(hex));
+                CreatePendingActivations action = new();
+                action.LoadPlainValue(decoded[1]);
+                pendingActivationStates = action.PendingActivations.Select(
+                    pa => new PendingActivationState(pa.Nonce, new PublicKey(pa.PublicKey))
+                ).ToList();
+            }
+        }
+
+        [Command(Description = "Mine a new genesis block")]
+        public void Mine(
+            [Argument("CONFIG", Description = "JSON config path to mine genesis block")]
+            string configPath)
+        {
+            var loggerConf = new LoggerConfiguration();
+            Log.Logger = loggerConf.CreateLogger();
+
             var options = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
-
             string json = File.ReadAllText(configPath);
             GenesisConfig genesisConfig = JsonSerializer.Deserialize<GenesisConfig>(json, options);
-            if (string.IsNullOrEmpty(genesisConfig.TablePath))
-            {
-                throw Utils.Error("TablePath is not set.");
-            }
-
-            Dictionary<string, string> tableSheets = Lib9cUtils.ImportSheets(genesisConfig.TablePath);
-
-            Lib9cUtils.CreateActivationKey(
-                out List<PendingActivationState> pendingActivationStates,
-                out List<ActivationKey> activationKeys,
-                genesisConfig.ActivationKeyCount);
-
-            if (string.IsNullOrEmpty(genesisConfig.PrivateKey))
-            {
-                throw Utils.Error("PrivateKey is not set");
-            }
-
-            if (string.IsNullOrEmpty(genesisConfig.GoldDistributionPath))
-            {
-                throw Utils.Error("GoldDistributionPath is not set");
-            }
-
-            if (string.IsNullOrEmpty(genesisConfig.AdminAddress))
-            {
-                throw Utils.Error($"{nameof(genesisConfig.AdminAddress)} is not set");
-            }
 
             try
             {
-                GoldDistribution[] goldDistributions = GoldDistribution
-                    .LoadInDescendingEndBlockOrder(genesisConfig.GoldDistributionPath);
+                ProcessData(genesisConfig.Data, out var tableSheets);
 
-                AdminState adminState =
-                    new AdminState(new Address(genesisConfig.AdminAddress), genesisConfig.AdminValidUntil);
+                ProcessCurrency(genesisConfig.Currency, out var initialMinter, out var initialDepositList);
 
-                AuthorizedMinersState? authorizedMinersState = null;
-                if (genesisConfig.AuthorizedMinerConfig.Miners is { } miners && miners.Any())
-                {
-                    authorizedMinersState = new AuthorizedMinersState(
-                        miners: genesisConfig.AuthorizedMinerConfig.Miners.Select(a => new Address(a)),
-                        interval: genesisConfig.AuthorizedMinerConfig.Interval,
-                        validUntil: genesisConfig.AuthorizedMinerConfig.ValidUntil
-                    );
-                }
+                ProcessAdmin(genesisConfig.Admin, initialMinter, out var adminState);
 
-                List<ActionBase>? actions = null;
-                if (!(genesisConfig.Actions is null))
-                {
-                    actions = genesisConfig.Actions.Select(a =>
-                    {
-                        if (File.Exists(a))
-                        {
-                            a = File.ReadAllText(a);
-                        }
+                ProcessExtra(genesisConfig.Extra, out List<PendingActivationState> pendingActivationStates);
 
-                        var decoded = (List)Codec.Decode(Convert.FromBase64String(a));
-                        string actionType = (Text)decoded[0];
-                        Dictionary plainValue = (Dictionary)decoded[1];
-                        Type type = typeof(ActionBase).Assembly
-                            .GetTypes()
-                            .First(type => type.Namespace is { } @namespace &&
-                                           @namespace.StartsWith($"{nameof(Nekoyume)}.{nameof(Nekoyume.Action)}") &&
-                                           !type.IsAbstract &&
-                                           typeof(ActionBase).IsAssignableFrom(type) &&
-                                           type.Name == actionType);
-                        ActionBase action = (ActionBase)Activator.CreateInstance(type)!;
-                        action.LoadPlainValue(plainValue);
-                        return action;
-                    }).ToList();
-                }
-
+                // Mine genesis block
                 Block<PolymorphicAction<ActionBase>> block = BlockHelper.MineGenesisBlock(
-                    tableSheets,
-                    goldDistributions,
-                    pendingActivationStates.ToArray(),
-                    adminState,
-                    authorizedMinersState,
-                    ImmutableHashSet<Address>.Empty,
-                    genesisConfig.ActivationKeyCount != 0,
-                    null,
-                    new PrivateKey(ByteUtil.ParseHex(genesisConfig.PrivateKey))
+                    tableSheets: tableSheets,
+                    goldDistributions: initialDepositList.ToArray(),
+                    pendingActivationStates: pendingActivationStates.ToArray(),
+                    adminState: adminState,
+                    privateKey: initialMinter
                 );
 
                 Lib9cUtils.ExportBlock(block, "genesis-block");
-                Lib9cUtils.ExportKeys(activationKeys, "keys");
             }
             catch (Exception e)
             {
@@ -142,25 +191,41 @@ namespace NineChronicles.Headless.Executable.Commands
 
 #pragma warning disable S3459
         [Serializable]
-        private struct AuthorizedMinerConfig
+        private struct DataConfig
         {
-            public long Interval { get; set; }
-            public long ValidUntil { get; set; }
-            public List<string> Miners { get; set; }
+            public string TablePath { get; set; }
         }
 
         [Serializable]
+        private struct CurrencyConfig
+        {
+            public string InitialMinter { get; set; }
+            public List<GoldDistribution> InitialCurrencyDeposit { get; set; }
+        }
+
+        [Serializable]
+        private struct AdminConfig
+        {
+            public bool Activate { get; set; }
+            public string Address { get; set; }
+            public long ValidUntil { get; set; }
+        }
+
+        [Serializable]
+        private struct ExtraConfig
+        {
+            public string? PendingActivationStatePath { get; set; }
+        }
+
+        // Config to mine new genesis block.
+        [Serializable]
         private struct GenesisConfig
         {
-            public string PrivateKey { get; set; }
-            public string TablePath { get; set; }
-            public string GoldDistributionPath { get; set; }
-            public uint ActivationKeyCount { get; set; }
-            public string AdminAddress { get; set; }
-            public long AdminValidUntil { get; set; }
-            public AuthorizedMinerConfig AuthorizedMinerConfig { get; set; }
-            public List<string> ActivatedAccounts { get; set; }
-            public List<string> Actions { get; set; }
+            public DataConfig Data { get; set; }
+            public CurrencyConfig? Currency { get; set; }
+            public AdminConfig? Admin { get; set; }
+
+            public ExtraConfig? Extra { get; set; }
         }
 #pragma warning restore S3459
     }

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -224,41 +224,107 @@ namespace NineChronicles.Headless.Executable.Commands
         }
 
 #pragma warning disable S3459
+        /// <summary>
+        /// Game data to set into genesis block.
+        /// </summary>
+        /// <seealso cref="GenesisConfig"/>
         [Serializable]
         private struct DataConfig
         {
+            /// <value>A path of game data table directory.</value>
             public string TablePath { get; set; }
         }
 
+        /// <summary>
+        /// Currency related configurations.<br/>
+        /// Set initial minter(Tx signer) and/or initial currency depositions.<br/>
+        /// If not provided, default values will set.
+        /// </summary>
         [Serializable]
         private struct CurrencyConfig
         {
+            /// <value>
+            /// Private Key of initial currency minter.<br/>
+            /// If not provided, a new private key will be created and used.<br/>
+            /// </value>
             public string? InitialMinter { get; set; } // PrivateKey, not Address
+
+            /// <value>
+            /// Initial currency deposition list.<br/>
+            /// If you leave it to empty list or even not provide, the `InitialMinter` will get 10000 currency.<br.>
+            /// You can see newly created deposition info in <c>initial_deposit.csv</c> file.
+            /// </value>
             public List<GoldDistribution>? InitialCurrencyDeposit { get; set; }
         }
 
+        /// <summary>
+        /// Admin related configurations.<br/>
+        /// If not provided, no admin will be set.
+        /// </summary>
         [Serializable]
         private struct AdminConfig
         {
+            /// <value>Whether active admin address or not.</value>
             public bool Activate { get; set; }
+
+            /// <value>
+            /// Address to give admin privilege.<br/>
+            /// If <c>Activate</c> is <c>true</c> and no <c>Address</c> provided, the <see cref="CurrencyConfig.InitialMinter"/> will get admin privilege.
+            /// </value>
             public string Address { get; set; }
+
+            /// <value>
+            /// The block count to persist admin privilege.<br/>
+            /// After this block, admin will no longer be admin.
+            /// </value>
             public long ValidUntil { get; set; }
         }
 
+        /// <summary>
+        /// Extra configurations.
+        /// </summary>
         [Serializable]
         private struct ExtraConfig
         {
+            /// <value>
+            /// Dump file path of pending activation state created using <c>9c-tools</c><br/>
+            /// This will set activation codes that can be used to genesis block. <br/>
+            /// See <a href="https://github.com/planetarium/lib9c/blob/development/.Lib9c.Tools/SubCommand/Tx.cs">Tx.cs</a> to create activation key.
+            /// </value>
             public string? PendingActivationStatePath { get; set; }
         }
 
-        // Config to mine new genesis block.
+        /// <summary>
+        /// Config to mine new genesis block.
+        /// </summary>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Config</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term><see cref="DataConfig">Data</see></term>
+        /// <description>Required. Sets game data to genesis block.</description>
+        /// </item>
+        /// <item>
+        /// <term><see cref="CurrencyConfig">Currency</see></term>
+        /// <description>Optional. Sets initial currency mint/deposition data to genesis block.</description>
+        /// </item>
+        /// <item>
+        /// <term><see cref="AdminConfig">Admin</see></term>
+        /// <description>Optional. Sets game admin and lifespan to genesis block.</description>
+        /// </item>
+        /// <item>
+        /// <term><see cref="ExtraConfig">Extra</see></term>
+        /// <description>Optional. Sets extra data (e.g. activation keys) to genesis block.</description>
+        /// </item>
+        /// </list>
         [Serializable]
         private struct GenesisConfig
         {
             public DataConfig Data { get; set; } // Required
             public CurrencyConfig? Currency { get; set; }
             public AdminConfig? Admin { get; set; }
-
             public ExtraConfig? Extra { get; set; }
         }
 #pragma warning restore S3459

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -95,10 +95,10 @@ namespace NineChronicles.Headless.Executable.Commands
 
         private void ProcessAdmin(AdminConfig? config, PrivateKey initialMinter, out AdminState adminState)
         {
-            Console.WriteLine("Processing admin for genesis...");
             // FIXME: If the `adminState` is not required inside `MineGenesisBlock`,
             //        this logic will be much lighter.
-            adminState = new AdminState(new PrivateKey().ToAddress(), 0);
+            Console.WriteLine("Processing admin for genesis...");
+            adminState = new AdminState(new Address(), 0);
             if (config is null)
             {
                 Log.Information("AdminConfig not provided. Skip admin setting...");

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -33,6 +33,7 @@ namespace NineChronicles.Headless.Executable.Commands
 
         private void ProcessData(DataConfig config, out Dictionary<string, string> tableSheets)
         {
+            Console.WriteLine("Processing data for genesis...");
             if (string.IsNullOrEmpty(config.TablePath))
             {
                 throw Utils.Error("TablePath is not set.");
@@ -47,6 +48,7 @@ namespace NineChronicles.Headless.Executable.Commands
             out List<GoldDistribution> initialDepositList
         )
         {
+            Console.WriteLine("Processing currency for genesis...");
             if (config is null)
             {
                 Log.Information("CurrencyConfig not provided. Skip setting...");
@@ -93,6 +95,7 @@ namespace NineChronicles.Headless.Executable.Commands
 
         private void ProcessAdmin(AdminConfig? config, PrivateKey initialMinter, out AdminState adminState)
         {
+            Console.WriteLine("Processing admin for genesis...");
             // FIXME: If the `adminState` is not required inside `MineGenesisBlock`,
             //        this logic will be much lighter.
             adminState = new AdminState(new PrivateKey().ToAddress(), 0);
@@ -122,6 +125,7 @@ namespace NineChronicles.Headless.Executable.Commands
             out List<PendingActivationState> pendingActivationStates
         )
         {
+            Console.WriteLine("Processing extra data for genesis...");
             pendingActivationStates = new List<PendingActivationState>();
 
             if (config is null)
@@ -169,6 +173,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 ProcessExtra(genesisConfig.Extra, out List<PendingActivationState> pendingActivationStates);
 
                 // Mine genesis block
+                Console.WriteLine("\nMining genesis block...\n");
                 Block<PolymorphicAction<ActionBase>> block = BlockHelper.MineGenesisBlock(
                     tableSheets: tableSheets,
                     goldDistributions: initialDepositList.ToArray(),
@@ -227,7 +232,7 @@ namespace NineChronicles.Headless.Executable.Commands
         [Serializable]
         private struct CurrencyConfig
         {
-            public string InitialMinter { get; set; }
+            public string InitialMinter { get; set; } // PrivateKey, not Address
             public List<GoldDistribution> InitialCurrencyDeposit { get; set; }
         }
 
@@ -249,7 +254,7 @@ namespace NineChronicles.Headless.Executable.Commands
         [Serializable]
         private struct GenesisConfig
         {
-            public DataConfig Data { get; set; }
+            public DataConfig Data { get; set; } // Required
             public CurrencyConfig? Currency { get; set; }
             public AdminConfig? Admin { get; set; }
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ Activation key is the code for 9c account to register/activate into NineChronicl
 You can create activation key whenever you want later, so you can just skip this step.
 
 ```shell
-$ dotnet run --project ./.Lib9c.Tools tx create-activation-keys [Key count] > ActivationKeys.csv // Change [Key count to number of new activation keys]
-$ dotnet run --project ./.Lib9c.Tools tx create-pending-activations ActivationKeys.csv > PendingActivation
+dotnet run --project ./.Lib9c.Tools tx create-activation-keys 10 > ActivationKeys.csv  # Change [10] to your number of new activation keys
+dotnet run --project ./.Lib9c.Tools tx create-pending-activations ActivationKeys.csv > PendingActivation
 ```
 
 ### 2. Create config file for genesis block
@@ -276,13 +276,13 @@ $ dotnet run --project ./.Lib9c.Tools tx create-pending-activations ActivationKe
 
 ### 3. Create genesis block
 ```shell
-$ dotnet run --project ./NineChronicles.Headless.Executable/ genesis ./config.json
+dotnet run --project ./NineChronicles.Headless.Executable/ genesis ./config.json
 ```
 After this step, you will get `genesis-block` file as output and another info in addition.
 
 ### 4. Run Headless node with genesis block
 ```shell
-$ dotnet run --project ./NineChronicles.Headless.Executable/ \
+dotnet run --project ./NineChronicles.Headless.Executable/ \
     -V=100260/6ec8E598962F1f475504F82fD5bF3410eAE58B9B/MEUCIQCG2yQNyXu3ovuUBNMEQiqx1vdo.FCMet9FoayFiIL89QIgXGRTU84nrcmLL4ud2j9ogrGt7ScmqaD97N.4rrtraXE=/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTU2Omh0dHBzOi8vZG93bmxvYWQubmluZS1jaHJvbmljbGVzLmNvbS92MTAwMjYwL1dpbmRvd3MuemlwdTk6dGltZXN0YW1wdTEwOjIwMjItMDctMjhl \ 
     -G=[PATH/TO/GENESIS/BLOCK] \
     --store-type=memory \

--- a/config.json.example
+++ b/config.json.example
@@ -19,6 +19,6 @@
         "validUntil": 10000
     },
     "extra": {
-        "pendingActivationStatePath": "pendingActivation.csv"
+        "pendingActivationStatePath": "pendingActivation"
     }
 }

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,24 @@
+{
+    "data": {
+        "tablePath": "Lib9c/Lib9c/TableCSV"
+    },
+    "currency": {
+        "initialMinter": "",
+        "initialCurrencyDeposit": [
+            {
+                "address": "",
+                "amount": 100000,
+                "start": 0,
+                "end": 0
+            }
+        ]
+    },
+    "admin": {
+        "activate": false,
+        "address": "",
+        "validUntil": 10000
+    },
+    "extra": {
+        "pendingActivationStatePath": "pendingActivation.csv"
+    }
+}

--- a/config.json.example
+++ b/config.json.example
@@ -19,6 +19,6 @@
         "validUntil": 10000
     },
     "extra": {
-        "pendingActivationStatePath": "pendingActivation"
+        "pendingActivationStatePath": "PendingActivation"
     }
 }


### PR DESCRIPTION
The old genesis command needs bunch of outdated configs and files.

This PR enhances genesis command.
- Removes unused configs and restruct `config.json`.
- Write genesis instruction in `README`