### PR TITLE
Make GenesisCommandTest passes: resolve #1487

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/GenesisCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/GenesisCommandTest.cs
@@ -6,6 +6,7 @@ using Cocona;
 using Libplanet;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
+using Nekoyume.Action;
 using NineChronicles.Headless.Executable.Commands;
 using NineChronicles.Headless.Executable.Tests.IO;
 using Xunit;
@@ -30,27 +31,90 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         [Theory]
         [InlineData(true, true, false, false)]
         [InlineData(true, true, true, false)]
-        [InlineData(true, false, false, true)]
+        [InlineData(true, false, false, false)]
         [InlineData(false, true, false, true)]
         [InlineData(false, false, false, true)]
-        public void Mine(bool tablePathExist, bool goldDistributionPathExist, bool actionsExist, bool exc)
+        public void Mine(bool tablePathExist, bool goldDistributionExist, bool actionsExist, bool exc)
         {
+            var config = new Dictionary<string, object>();
+
+            // DataConfig: tablePath
             var tablePath = tablePathExist
                 ? Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Lib9c", "Lib9c", "TableCSV"))
                 : "";
 
-            var goldDistributionPath = "";
-            if (goldDistributionPathExist)
+            // Avoid JsonException in Windows
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                goldDistributionPath = Path.GetTempFileName();
-                File.WriteAllText(goldDistributionPath, @"Address,AmountPerBlock,StartBlock,EndBlock
-F9A15F870701268Bd7bBeA6502eB15F4997f32f9,1000000,0,0
-F9A15F870701268Bd7bBeA6502eB15F4997f32f9,100,1,100000
-Fb90278C67f9b266eA309E6AE8463042f5461449,3000,3600,13600
-Fb90278C67f9b266eA309E6AE8463042f5461449,100000000000,2,2
-");
+                if (tablePathExist)
+                {
+                    tablePath = tablePath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                }
             }
 
+            config["data"] = new Dictionary<string, object>
+            {
+                ["tablePath"] = tablePath,
+            };
+
+            // CurrencyConfig: initialMinter, initialCurrencyDeposit
+            List<GoldDistribution>? goldDistribution = null;
+            if (goldDistributionExist)
+            {
+                goldDistribution = new List<GoldDistribution>
+                {
+                    new GoldDistribution
+                    {
+                        Address = new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9"),
+                        AmountPerBlock = 1000000,
+                        StartBlock = 0,
+                        EndBlock = 0,
+                    },
+                    new GoldDistribution
+                    {
+                        Address = new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9"),
+                        AmountPerBlock = 100,
+                        StartBlock = 1,
+                        EndBlock = 100000,
+                    },
+                    new GoldDistribution
+                    {
+                        Address = new Address("Fb90278C67f9b266eA309E6AE8463042f5461449"),
+                        AmountPerBlock = 3000,
+                        StartBlock = 3600,
+                        EndBlock = 13600,
+                    },
+                    new GoldDistribution
+                    {
+                        Address = new Address("Fb90278C67f9b266eA309E6AE8463042f5461449"),
+                        AmountPerBlock = 100000000000,
+                        StartBlock = 2,
+                        EndBlock = 2,
+                    },
+                };
+            }
+
+            if (!(goldDistribution is null))
+            {
+                config["currency"] = new Dictionary<string, object>
+                {
+                    ["initialMinter"] = ByteUtil.Hex(_privateKey.ByteArray),
+                    ["initialCurrencyDeposit"] = goldDistribution
+                };
+            }
+
+            // AdminConfig: activate, address, validUntil
+            var adminConfig = new Dictionary<string, object>
+            {
+                ["activate"] = true,
+                ["address"] = "0000000000000000000000000000000000000005",
+                ["validUntil"] = 1500000,
+            };
+            config["admin"] = adminConfig;
+
+            // ExtraConfig: pendingActivationStatePath
+
+            // Deprecated: actions
             var actions = new List<string>();
             if (actionsExist)
             {
@@ -62,43 +126,25 @@ Fb90278C67f9b266eA309E6AE8463042f5461449,100000000000,2,2
                     actions.Add(path);
                 }
             }
-            // Avoid JsonException in Windows
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                if (tablePathExist)
-                {
-                    tablePath = tablePath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                }
+            // if (actionsExist)
+            // {
+            //     config["actions"] = actions;
+            // }
 
-                if (goldDistributionPathExist)
-                {
-                    goldDistributionPath = goldDistributionPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                }
-            }
-
-            var config = new Dictionary<string, object>
+            // Deprecated: authorizedMinerConfig
+            var authorizedMinerConfig = new Dictionary<string, object>
             {
-                ["privateKey"] = ByteUtil.Hex(_privateKey.ByteArray),
-                ["tablePath"] = tablePath,
-                ["goldDistributionPath"] = goldDistributionPath,
-                ["adminAddress"] = "0000000000000000000000000000000000000005",
-                ["authorizedMinerConfig"] = new Dictionary<string, object>
+                ["validUntil"] = 1500000,
+                ["interval"] = 50,
+                ["miners"] = new List<string>
                 {
-                    ["validUntil"] = 1500000,
-                    ["interval"] = 50,
-                    ["miners"] = new List<string>
-                    {
-                        "0000000000000000000000000000000000000001",
-                        "0000000000000000000000000000000000000002",
-                        "0000000000000000000000000000000000000003",
-                        "0000000000000000000000000000000000000004"
-                    }
+                    "0000000000000000000000000000000000000001",
+                    "0000000000000000000000000000000000000002",
+                    "0000000000000000000000000000000000000003",
+                    "0000000000000000000000000000000000000004"
                 }
             };
-            if (actionsExist)
-            {
-                config["actions"] = actions;
-            }
+
             string json = JsonSerializer.Serialize(config);
             var configPath = Path.GetTempFileName();
             File.WriteAllText(configPath, json);

--- a/NineChronicles.Headless.Executable.Tests/Commands/GenesisCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/GenesisCommandTest.cs
@@ -114,37 +114,6 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 
             // ExtraConfig: pendingActivationStatePath
 
-            // Deprecated: actions
-            var actions = new List<string>();
-            if (actionsExist)
-            {
-                var actionCommand = new ActionCommand(_console);
-                for (int i = 0; i < 2; i++)
-                {
-                    var path = Path.GetTempFileName();
-                    actionCommand.MonsterCollect(i, path);
-                    actions.Add(path);
-                }
-            }
-            // if (actionsExist)
-            // {
-            //     config["actions"] = actions;
-            // }
-
-            // Deprecated: authorizedMinerConfig
-            var authorizedMinerConfig = new Dictionary<string, object>
-            {
-                ["validUntil"] = 1500000,
-                ["interval"] = 50,
-                ["miners"] = new List<string>
-                {
-                    "0000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000002",
-                    "0000000000000000000000000000000000000003",
-                    "0000000000000000000000000000000000000004"
-                }
-            };
-
             string json = JsonSerializer.Serialize(config);
             var configPath = Path.GetTempFileName();
             File.WriteAllText(configPath, json);

--- a/NineChronicles.Headless.Executable.Tests/Commands/GenesisCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/GenesisCommandTest.cs
@@ -114,6 +114,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 
             // ExtraConfig: pendingActivationStatePath
 
+            // Serialize and write config file
             string json = JsonSerializer.Serialize(config);
             var configPath = Path.GetTempFileName();
             File.WriteAllText(configPath, json);


### PR DESCRIPTION
This PR makes `GenesisCommandTest` passes.

### Changelist
- Apply new genesis config structure to unittest
- Only `DataConfig` is required, so change expected exception result of one testcase.

Sorry for breaking integrities 🙏 


