### PR TITLE
use explorer graphtype for txResult and txStatus

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/TransactionHeadlessQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/TransactionHeadlessQueryTest.cs
@@ -253,7 +253,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var queryFormat = @"query {{
                 transactionResult(txId: ""{0}"") {{
                     blockHash
-                    transactionStatus
+                    txStatus
                 }}
             }}";
             var result = await ExecuteAsync(string.Format(
@@ -262,8 +262,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.NotNull(result.Data);
             var transactionResult =
                 ((Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!)["transactionResult"];
-            var transactionStatus = (string)((Dictionary<string, object>)transactionResult)["transactionStatus"];
-            Assert.Equal("STAGING", transactionStatus);
+            var txStatus = (string)((Dictionary<string, object>)transactionResult)["txStatus"];
+            Assert.Equal("STAGING", txStatus);
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var queryFormat = @"query {{
                 transactionResult(txId: ""{0}"") {{
                     blockHash
-                    transactionStatus
+                    txStatus
                 }}
             }}";
             var result = await ExecuteAsync(string.Format(
@@ -287,8 +287,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.NotNull(result.Data);
             var transactionResult =
                 ((Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!)["transactionResult"];
-            var transactionStatus = (string)((Dictionary<string, object>)transactionResult)["transactionStatus"];
-            Assert.Equal("INVALID", transactionStatus);
+            var txStatus = (string)((Dictionary<string, object>)transactionResult)["txStatus"];
+            Assert.Equal("INVALID", txStatus);
         }
 
         [Fact]
@@ -301,7 +301,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var queryFormat = @"query {{
                 transactionResult(txId: ""{0}"") {{
                     blockHash
-                    transactionStatus
+                    txStatus
                 }}
             }}";
             var result = await ExecuteAsync(string.Format(
@@ -310,8 +310,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.NotNull(result.Data);
             var transactionResult =
                 ((Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!)["transactionResult"];
-            var transactionStatus = (string)((Dictionary<string, object>)transactionResult)["transactionStatus"];
-            Assert.Equal("SUCCESS", transactionStatus);
+            var txStatus = (string)((Dictionary<string, object>)transactionResult)["txStatus"];
+            Assert.Equal("SUCCESS", txStatus);
         }
 
         private Task<ExecutionResult> ExecuteAsync(string query)

--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -136,7 +136,7 @@ namespace NineChronicles.Headless.GraphTypes
                     return Convert.ToBase64String(signedTransaction.Serialize(true));
                 });
 
-            Field<NonNullGraphType<TransactionResultType>>(
+            Field<NonNullGraphType<TxResultType>>(
                 name: "transactionResult",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<TxIdType>>
@@ -160,8 +160,8 @@ namespace NineChronicles.Headless.GraphTypes
                     if (!(store.GetFirstTxIdBlockHashIndex(txId) is { } txExecutedBlockHash))
                     {
                         return blockChain.GetStagedTransactionIds().Contains(txId)
-                            ? new TransactionResult(TransactionStatus.STAGING, null, null, null, null)
-                            : new TransactionResult(TransactionStatus.INVALID, null, null, null, null);
+                            ? new TxResult(TxStatus.STAGING, null, null, null, null)
+                            : new TxResult(TxStatus.INVALID, null, null, null, null);
                     }
 
                     try
@@ -170,9 +170,9 @@ namespace NineChronicles.Headless.GraphTypes
                         Block<PolymorphicAction<ActionBase>> txExecutedBlock = blockChain[txExecutedBlockHash];
                         return execution switch
                         {
-                            TxSuccess txSuccess => new TransactionResult(TransactionStatus.SUCCESS, txExecutedBlock.Index,
+                            TxSuccess txSuccess => new TxResult(TxStatus.SUCCESS, txExecutedBlock.Index,
                                 txExecutedBlock.Hash.ToString(), null, null),
-                            TxFailure txFailure => new TransactionResult(TransactionStatus.FAILURE, txExecutedBlock.Index,
+                            TxFailure txFailure => new TxResult(TxStatus.FAILURE, txExecutedBlock.Index,
                                 txExecutedBlock.Hash.ToString(), txFailure.ExceptionName, txFailure.ExceptionMetadata),
                             _ => throw new NotImplementedException(
                                 $"{nameof(execution)} is not expected concrete class.")
@@ -180,7 +180,7 @@ namespace NineChronicles.Headless.GraphTypes
                     }
                     catch (Exception)
                     {
-                        return new TransactionResult(TransactionStatus.INVALID, null, null, null, null);
+                        return new TxResult(TxStatus.INVALID, null, null, null, null);
                     }
                 }
             );


### PR DESCRIPTION
This PR reverts the `transactionResult` query that was changed in https://github.com/planetarium/NineChronicles.Headless/pull/1492 to use the original query format. Therefore, services using this query won't have to make adjustments.

## Original Query Format Example

```
query{
  transaction{
    transactionResult(txId:"0b72e3a5ddedee0d65e42720da345b5475a5b1e6d6496dfa777233bc9fac885f"){
      txStatus
      exceptionName
    }
  }
}
```

P.S. https://github.com/planetarium/NineChronicles.Headless/blob/development/NineChronicles.Headless/GraphTypes/TxResultType.cs and https://github.com/planetarium/NineChronicles.Headless/blob/development/NineChronicles.Headless/GraphTypes/TxStatusType.cs should be deprecated or deleted so I'll create a separate issue.