### PR TITLE
Bump lib9c and incorporate `Currency` API changes

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Headless.Hosting
 
         public Block<T> GenesisBlock { get; set; }
 
-        public IEnumerable<Peer> Peers { get; set; }
+        public IEnumerable<BoundPeer> Peers { get; set; }
 
         public bool NoMiner { get; set; }
 

--- a/Libplanet.Headless/ReducedStore.cs
+++ b/Libplanet.Headless/ReducedStore.cs
@@ -41,17 +41,11 @@ namespace Libplanet.Headless
         public long CountIndex(Guid chainId) =>
             InternalStore.CountIndex(chainId);
 
-        public long CountTransactions() =>
-            InternalStore.CountTransactions();
-
         public bool DeleteBlock(BlockHash blockHash) =>
             InternalStore.DeleteBlock(blockHash);
 
         public void DeleteChainId(Guid chainId) =>
             InternalStore.DeleteChainId(chainId);
-
-        public bool DeleteTransaction(TxId txid) =>
-            InternalStore.DeleteTransaction(txid);
 
         public void ForkBlockIndexes(
             Guid sourceChainId,
@@ -103,9 +97,6 @@ namespace Libplanet.Headless
             int? limit = null
         ) =>
             InternalStore.IterateIndexes(chainId, offset, limit);
-
-        public IEnumerable<TxId> IterateTransactionIds() =>
-            InternalStore.IterateTransactionIds();
 
         public IEnumerable<Guid> ListChainIds() =>
             InternalStore.ListChainIds();

--- a/NineChronicles.Headless.Executable/Commands/ActionCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ActionCommand.cs
@@ -155,7 +155,10 @@ namespace NineChronicles.Headless.Executable.Commands
             try
             {
                 // Minter for 9c-mainnet
-                var currency = new Currency("NCG", 2, minter: new Address("47d082a115c63e7b58b1532d20e631538eafadde"));
+#pragma warning disable CS0618
+                // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                var currency = Currency.Legacy("NCG", 2, minter: new Address("47d082a115c63e7b58b1532d20e631538eafadde"));
+#pragma warning restore CS0618
                 FungibleAssetValue amountFungibleAssetValue =
                     FungibleAssetValue.Parse(currency, amount);
                 Address sender = new Address(ByteUtil.ParseHex(senderAddress));

--- a/NineChronicles.Headless.Tests/Common/Fixtures.cs
+++ b/NineChronicles.Headless.Tests/Common/Fixtures.cs
@@ -44,7 +44,10 @@ namespace NineChronicles.Headless.Tests
             avatarAddresses = { [2] = AvatarAddress },
         };
 
-        public static readonly Currency CurrencyFX = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+        // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+        public static readonly Currency CurrencyFX = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
 
         public static ShopState ShopStateFX()
         {
@@ -78,7 +81,10 @@ namespace NineChronicles.Headless.Tests
                 3,
                 new Guid("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4"),
                 new Guid("45082f35-699c-41f0-9332-9143966933a3"),
-                new FungibleAssetValue(new Currency("NCG", 2, minter: null), 1, 0),
+#pragma warning disable CS0618
+                // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                new FungibleAssetValue(Currency.Legacy("NCG", 2, null), 1, 0),
+#pragma warning restore CS0618
                 0,
                 0,
                 10110000,
@@ -90,7 +96,10 @@ namespace NineChronicles.Headless.Tests
                 4,
                 new Guid("936DA01F-9ABD-4d9d-80C7-02AF85C822A8"),
                 new Guid("dae32f1b-6b43-4bdb-933e-fd51d003283e"),
-                new FungibleAssetValue(new Currency("NCG", 2, minter: null), 2, 0),
+#pragma warning disable CS0618
+                // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                new FungibleAssetValue(Currency.Legacy("NCG", 2, null), 2, 0),
+#pragma warning restore CS0618
                 0,
                 0,
                 10110000,

--- a/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
+++ b/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
@@ -39,7 +39,7 @@ namespace NineChronicles.Headless.Tests.Common
                 NoMiner = true,
                 Render = false,
                 LogActionRenders = false,
-                Peers = ImmutableHashSet<Peer>.Empty,
+                Peers = ImmutableHashSet<BoundPeer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
                 MessageTimeout = TimeSpan.FromMinutes(1),
                 TipTimeout = TimeSpan.FromMinutes(1),

--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
@@ -54,7 +54,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                         ),
                         adminAddressState: new AdminState(new PrivateKey().ToAddress(), 1500000),
                         activatedAccountsState: new ActivatedAccountsState(),
-                        goldCurrencyState: new GoldCurrencyState(new Currency("NCG", 2, minerPrivateKey.ToAddress())),
+#pragma warning disable CS0618
+                        // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                        goldCurrencyState: new GoldCurrencyState(Currency.Legacy("NCG", 2, minerPrivateKey.ToAddress())),
+#pragma warning restore CS0618
                         goldDistributions: Array.Empty<GoldDistribution>(),
                         tableSheets: new Dictionary<string, string>(),
                         pendingActivationStates: new PendingActivationState[]{ }

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -96,8 +96,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             services.AddSingleton<IConfiguration>(configuration);
             services.AddGraphTypes();
             services.AddLibplanetExplorer<NCAction>();
-            services.AddSingleton<StateQuery>();
             services.AddSingleton(ncService);
+            services.AddSingleton(ncService.Store);
             ServiceProvider serviceProvider = services.BuildServiceProvider();
             Schema = new StandaloneSchema(serviceProvider);
 

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -40,7 +40,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             _output = output;
 
-            var goldCurrency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
 
             var sheets =
                 TableSheetsImporter.ImportSheets(Path.Join("..", "..", "..", "..", "Lib9c", "Lib9c", "TableCSV"));

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -159,7 +159,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             AppProtocolVersion appProtocolVersion,
             PublicKey appProtocolVersionSigner,
             Progress<PreloadState>? preloadProgress = null,
-            IEnumerable<Peer>? peers = null,
+            IEnumerable<BoundPeer>? peers = null,
             ImmutableHashSet<BoundPeer>? staticPeers = null)
             where T : IAction, new()
         {
@@ -174,7 +174,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Port = null,
                 NoMiner = true,
                 Render = false,
-                Peers = peers ?? ImmutableHashSet<Peer>.Empty,
+                Peers = peers ?? ImmutableHashSet<BoundPeer>.Empty,
                 TrustedAppProtocolVersionSigners = ImmutableHashSet<PublicKey>.Empty.Add(appProtocolVersionSigner),
                 StaticPeers = staticPeers ?? ImmutableHashSet<BoundPeer>.Empty,
             };

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -815,7 +815,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Block<PolymorphicAction<ActionBase>> genesis =
                 MakeGenesisBlock(
                     default,
-                    new Currency("NCG", 2, minters: null),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("NCG", 2, null),
+#pragma warning restore CS0618
                     ImmutableHashSet<Address>.Empty
                 );
             NineChroniclesNodeService service = ServiceBuilder.CreateNineChroniclesNodeService(genesis, new PrivateKey());
@@ -866,7 +869,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Block<PolymorphicAction<ActionBase>> genesis =
                 MakeGenesisBlock(
                     default,
-                    new Currency("NCG", 2, minters: null),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("NCG", 2, null),
+#pragma warning restore CS0618
                     ImmutableHashSet<Address>.Empty
                 );
             NineChroniclesNodeService service = ServiceBuilder.CreateNineChroniclesNodeService(genesis, new PrivateKey());

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -465,7 +465,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Port = null,
                 NoMiner = true,
                 Render = false,
-                Peers = ImmutableHashSet<Peer>.Empty,
+                Peers = ImmutableHashSet<BoundPeer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
                 StaticPeers = ImmutableHashSet<BoundPeer>.Empty
             };
@@ -785,7 +785,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Port = null,
                 NoMiner = true,
                 Render = false,
-                Peers = ImmutableHashSet<Peer>.Empty,
+                Peers = ImmutableHashSet<BoundPeer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
                 StaticPeers = ImmutableHashSet<BoundPeer>.Empty
             };
@@ -859,7 +859,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Port = null,
                 NoMiner = true,
                 Render = false,
-                Peers = ImmutableHashSet<Peer>.Empty,
+                Peers = ImmutableHashSet<BoundPeer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
                 StaticPeers = ImmutableHashSet<BoundPeer>.Empty
             };
@@ -916,7 +916,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 Port = null,
                 NoMiner = true,
                 Render = false,
-                Peers = ImmutableHashSet<Peer>.Empty,
+                Peers = ImmutableHashSet<BoundPeer>.Empty,
                 TrustedAppProtocolVersionSigners = null,
                 StaticPeers = ImmutableHashSet<BoundPeer>.Empty,
             };

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -439,7 +439,11 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                             ),
                             adminAddressState: new AdminState(adminAddress, 1500000),
                             activatedAccountsState: new ActivatedAccountsState(activatedAccounts),
-                            goldCurrencyState: new GoldCurrencyState(new Currency("NCG", 2, minter: null)),
+#pragma warning disable CS0618
+                            // Use of obsolete method Currency.Legacy():
+                            // https://github.com/planetarium/lib9c/discussions/1319
+                            goldCurrencyState: new GoldCurrencyState(Currency.Legacy("NCG", 2, null)),
+#pragma warning restore CS0618
                             goldDistributions: new GoldDistribution[0],
                             tableSheets: _sheets,
                             pendingActivationStates: new PendingActivationState[]{ }
@@ -755,7 +759,11 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                             ),
                             adminAddressState: new AdminState(adminAddress, 1500000),
                             activatedAccountsState: new ActivatedAccountsState(activatedAccounts),
-                            goldCurrencyState: new GoldCurrencyState(new Currency("NCG", 2, minter: null)),
+#pragma warning disable CS0618
+                            // Use of obsolete method Currency.Legacy():
+                            // https://github.com/planetarium/lib9c/discussions/1319
+                            goldCurrencyState: new GoldCurrencyState(Currency.Legacy("NCG", 2, null)),
+#pragma warning restore CS0618
                             goldDistributions: new GoldDistribution[0],
                             tableSheets: _sheets,
                             pendingActivationStates: pendingActivationStates.ToArray()
@@ -824,7 +832,11 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                             ),
                             adminAddressState: new AdminState(adminAddress, 1500000),
                             activatedAccountsState: new ActivatedAccountsState(activatedAccounts),
-                            goldCurrencyState: new GoldCurrencyState(new Currency("NCG", 2, minter: null)),
+#pragma warning disable CS0618
+                            // Use of obsolete method Currency.Legacy():
+                            // https://github.com/planetarium/lib9c/discussions/1319
+                            goldCurrencyState: new GoldCurrencyState(Currency.Legacy("NCG", 2, null)),
+#pragma warning restore CS0618
                             goldDistributions: new GoldDistribution[0],
                             tableSheets: _sheets,
                             pendingActivationStates: pendingActivationStates.ToArray()
@@ -866,7 +878,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
         }
         private NineChroniclesNodeService MakeMineChroniclesNodeService(PrivateKey privateKey)
         {
-            var goldCurrency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
 
             var blockPolicy = NineChroniclesNodeService.GetTestBlockPolicy();
             Block<PolymorphicAction<ActionBase>> genesis =

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Net;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Security.Cryptography;
@@ -170,7 +171,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var apvPrivateKey = new PrivateKey();
             var apv1 = AppProtocolVersion.Sign(apvPrivateKey, 1);
             var apv2 = AppProtocolVersion.Sign(apvPrivateKey, 0);
-            var peer = new Peer(apvPrivateKey.PublicKey);
+            var peer = new BoundPeer(apvPrivateKey.PublicKey, new DnsEndPoint("0.0.0.0", 0));
             StandaloneContextFx.DifferentAppProtocolVersionEncounterSubject.OnNext(
                 new DifferentAppProtocolVersionEncounter(peer, apv1, apv2)
             );

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -292,7 +292,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             IObservable<ExecutionResult> stream = subscribeResult.Streams!.Values.First();
             Assert.NotNull(stream);
 
-            Currency currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            Currency currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             FungibleAssetValue fungibleAssetValue = new FungibleAssetValue(currency, major, minor);
             StandaloneContextFx.MonsterCollectionStatusSubject.OnNext(
                 new MonsterCollectionStatus(
@@ -411,7 +414,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.NotNull(stream);
             Assert.NotEmpty(StandaloneContextFx.AgentAddresses);
 
-            Currency currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            Currency currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             FungibleAssetValue fungibleAssetValue = new FungibleAssetValue(currency, major, minor);
             StandaloneContextFx.AgentAddresses[address].statusSubject.OnNext(
                 new MonsterCollectionStatus(
@@ -478,7 +484,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.NotNull(stream);
             Assert.NotEmpty(StandaloneContextFx.AgentAddresses);
 
-            Currency currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            Currency currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             FungibleAssetValue fungibleAssetValue = new FungibleAssetValue(currency, major, minor);
             StandaloneContextFx.AgentAddresses[address].balanceSubject.OnNext(fungibleAssetValue.GetQuantityString(true));
             ExecutionResult rawEvents = await stream.Take(1);

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AgentStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AgentStateTypeTest.cs
@@ -35,7 +35,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 hasTradedItem
                 crystal
             }";
-            var goldCurrency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var agentState = new AgentState(new Address())
             {
                 avatarAddresses =

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/FungibleAssetValueTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/FungibleAssetValueTypeTest.cs
@@ -21,7 +21,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 currency
                 quantity
             }";
-            var goldCurrency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var fav = new FungibleAssetValue(goldCurrency, major, minor);
             var queryResult = await ExecuteQueryAsync<FungibleAssetValueType>(query, source: fav);
             var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/StakeStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/StakeStateTypeTest.cs
@@ -18,7 +18,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
         [MemberData(nameof(Members))]
         public async Task Query(StakeState stakeState, long deposit, Dictionary<string, object> expected)
         {
-            var goldCurrency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
 
             IValue? GetStateMock(Address address)
             {

--- a/NineChronicles.Headless.Tests/GraphTypes/TransferNCGHistoryTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/TransferNCGHistoryTypeTest.cs
@@ -23,7 +23,10 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Random random = new Random();
             Address sender = new PrivateKey().ToAddress(),
                 recipient = new PrivateKey().ToAddress();
-            Currency currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            Currency currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             byte[] buffer = new byte[HashDigest<SHA256>.Size];
             random.NextBytes(buffer);
             BlockHash blockHash = new BlockHash(buffer);

--- a/NineChronicles.Headless/DifferentAppProtocolVersionEncounter.cs
+++ b/NineChronicles.Headless/DifferentAppProtocolVersionEncounter.cs
@@ -4,14 +4,14 @@ namespace NineChronicles.Headless
 {
     public class DifferentAppProtocolVersionEncounter
     {
-        public Peer Peer { get; }
+        public BoundPeer Peer { get; }
 
         public AppProtocolVersion PeerVersion { get; }
 
         public AppProtocolVersion LocalVersion { get; }
 
         public DifferentAppProtocolVersionEncounter(
-            Peer peer,
+            BoundPeer peer,
             AppProtocolVersion peerVersion,
             AppProtocolVersion localVersion)
         {

--- a/NineChronicles.Headless/GraphQLServiceExtensions.cs
+++ b/NineChronicles.Headless/GraphQLServiceExtensions.cs
@@ -38,6 +38,8 @@ namespace NineChronicles.Headless
             services.TryAddSingleton<Libplanet.Explorer.GraphTypes.TxResultType>();
             services.TryAddSingleton<Libplanet.Explorer.GraphTypes.TxStatusType>();
             services.TryAddSingleton<Libplanet.Explorer.GraphTypes.BencodexValueType>();
+            services.TryAddSingleton<Libplanet.Explorer.GraphTypes.FungibleAssetValueType>();
+            services.TryAddSingleton<Libplanet.Explorer.GraphTypes.CurrencyType>();
 
             return services;
         }
@@ -62,6 +64,11 @@ namespace NineChronicles.Headless
             services.TryAddSingleton<BlockQuery<T>>();
             services.TryAddSingleton<TransactionQuery<T>>();
             services.TryAddSingleton<ExplorerQuery<T>>();
+            services.TryAddSingleton(_ => new StateQuery<T>()
+            {
+                Name = "LibplanetStateQuery",
+            });
+            services.TryAddSingleton<BlockPolicyType<T>>();
 
             return services;
         }

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -37,6 +37,7 @@ namespace NineChronicles.Headless
                 services.AddSingleton(provider => service);
                 services.AddSingleton(provider => service.Swarm);
                 services.AddSingleton(provider => service.BlockChain);
+                services.AddSingleton(provider => service.Store);
                 if (properties.Libplanet is { } libplanetNodeServiceProperties)
                 {
                     services.AddSingleton<LibplanetNodeServiceProperties<PolymorphicAction<ActionBase>>>(provider => libplanetNodeServiceProperties);

--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -300,7 +300,7 @@ namespace NineChronicles.Headless
             }
 
             properties.Libplanet.DifferentAppProtocolVersionEncountered =
-                (Peer peer, AppProtocolVersion peerVersion, AppProtocolVersion localVersion) =>
+                (BoundPeer peer, AppProtocolVersion peerVersion, AppProtocolVersion localVersion) =>
                 {
                     context.DifferentAppProtocolVersionEncounterSubject.OnNext(
                         new DifferentAppProtocolVersionEncounter(peer, peerVersion, localVersion)


### PR DESCRIPTION
[Recently, maximum supply cap and total supply tracking was introduced in `Currency` in Libplanet.](https://github.com/planetarium/libplanet/pull/2200) This introduced changes in `IAccountStateDelta` interface and how `Currency` is defined. [lib9c#1308](https://github.com/planetarium/lib9c/pull/1308) incorporates the API changes to lib9c, and this PR applies the changes to NineChronicles.Headless.

Resolution order: planetarium/libplanet#2225 -> planetarium/lib9c#1308 -> planetarium/NineChronicles.Headless#1497 & planetarium/NineChronicles#1838