### PR TITLE
Bump lib9c

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/StakeStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/StakeStateTypeTest.cs
@@ -100,6 +100,20 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                     ["receivedBlockIndex"] = 0,
                     ["claimableBlockIndex"] = StakeState.RewardInterval + 100,
                 }
+            },
+            new object[]
+            {
+                new StakeState(Fixtures.StakeStateAddress, 10, 50412, 201610, new StakeState.StakeAchievements()),
+                100,
+                new Dictionary<string, object>
+                {
+                    ["address"] = Fixtures.StakeStateAddress.ToString(),
+                    ["deposit"] = "100.00",
+                    ["startedBlockIndex"] = 10,
+                    ["cancellableBlockIndex"] = 201610L,
+                    ["receivedBlockIndex"] = 50412,
+                    ["claimableBlockIndex"] = 100810L,
+                }
             }
         };
     }

--- a/NineChronicles.Headless/GraphTypes/States/StakeStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/StakeStateType.cs
@@ -54,8 +54,22 @@ namespace NineChronicles.Headless.GraphTypes.States
                 "claimableBlockIndex",
                 description: "The block index the user can claim rewards.",
                 resolve: context =>
-                    Math.Max(context.Source.StakeState.ReceivedBlockIndex,
-                        context.Source.StakeState.StartedBlockIndex) + StakeState.RewardInterval);
+                {
+                    var stakeState = context.Source.StakeState;
+
+                    if (stakeState.ReceivedBlockIndex > 0)
+                    {
+                        long lastStep = Math.DivRem(
+                            stakeState.ReceivedBlockIndex - stakeState.StartedBlockIndex,
+                            StakeState.RewardInterval,
+                            out _
+                        );
+
+                        return stakeState.StartedBlockIndex + (lastStep + 1) * StakeState.RewardInterval;
+                    }
+
+                    return stakeState.StartedBlockIndex + StakeState.RewardInterval;
+                });
             Field<NonNullGraphType<StakeAchievementsType>>(
                 nameof(StakeState.Achievements),
                 description: "The staking achievements.",


### PR DESCRIPTION
This pull request bumps lib9c to the development branch's HEAD. Also it applies staking claimable index change at `StakeStateType.claimableBlockIndex` but it doesn't break its interface.

I requested reviews for @planetarium/9c-backend. The reason to request @sonohoshi is that he reviewed https://github.com/planetarium/lib9c/pull/1303 pull request.