### PR TITLE
Branch `StakeStateType.claimableBlockIndex` by block index

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AgentStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AgentStateTypeTest.cs
@@ -85,7 +85,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
 
             var queryResult = await ExecuteQueryAsync<AgentStateType>(
                 query,
-                source: new AgentStateType.AgentStateContext(agentState, GetStatesMock, GetBalanceMock)
+                source: new AgentStateType.AgentStateContext(agentState, GetStatesMock, GetBalanceMock, 0)
             );
             var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             var expected = new Dictionary<string, object>()

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
@@ -47,7 +47,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
 
                         return arr;
                     },
-                    (_, _) => new FungibleAssetValue()));
+                    (_, _) => new FungibleAssetValue(),
+                    0));
             var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(expected, data);
         }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/StakeStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/StakeStateTypeTest.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using GraphQL.Execution;
 using Libplanet;
 using Libplanet.Assets;
+using Nekoyume.BlockChain.Policy;
 using Nekoyume.Model.State;
 using NineChronicles.Headless.GraphTypes.States;
 using Xunit;
@@ -16,7 +17,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
     {
         [Theory]
         [MemberData(nameof(Members))]
-        public async Task Query(StakeState stakeState, long deposit, Dictionary<string, object> expected)
+        public async Task Query(StakeState stakeState, long deposit, long blockIndex, Dictionary<string, object> expected)
         {
             var goldCurrency = new Currency("NCG", 2, minter: null);
 
@@ -52,7 +53,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 cancellableBlockIndex
                 claimableBlockIndex
             }";
-            var queryResult = await ExecuteQueryAsync<StakeStateType>(query, source: new StakeStateType.StakeStateContext(stakeState, GetStatesMock, GetBalanceMock, 0));
+            var queryResult = await ExecuteQueryAsync<StakeStateType>(query, source: new StakeStateType.StakeStateContext(stakeState, GetStatesMock, GetBalanceMock, blockIndex));
             var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(expected, data);
         }
@@ -63,6 +64,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             {
                 new StakeState(Fixtures.StakeStateAddress, 0),
                 100,
+                0,
                 new Dictionary<string, object>
                 {
                     ["address"] = Fixtures.StakeStateAddress.ToString(),
@@ -77,6 +79,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             {
                 new StakeState(Fixtures.StakeStateAddress, 100),
                 100,
+                0,
                 new Dictionary<string, object>
                 {
                     ["address"] = Fixtures.StakeStateAddress.ToString(),
@@ -91,6 +94,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             {
                 new StakeState(Fixtures.StakeStateAddress, 100),
                 100,
+                0,
                 new Dictionary<string, object>
                 {
                     ["address"] = Fixtures.StakeStateAddress.ToString(),
@@ -105,6 +109,22 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             {
                 new StakeState(Fixtures.StakeStateAddress, 10, 50412, 201610, new StakeState.StakeAchievements()),
                 100,
+                0,
+                new Dictionary<string, object>
+                {
+                    ["address"] = Fixtures.StakeStateAddress.ToString(),
+                    ["deposit"] = "100.00",
+                    ["startedBlockIndex"] = 10,
+                    ["cancellableBlockIndex"] = 201610L,
+                    ["receivedBlockIndex"] = 50412,
+                    ["claimableBlockIndex"] = 100812L,
+                }
+            },
+            new object[]
+            {
+                new StakeState(Fixtures.StakeStateAddress, 10, 50412, 201610, new StakeState.StakeAchievements()),
+                100,
+                BlockPolicySource.V100290ObsoleteIndex,
                 new Dictionary<string, object>
                 {
                     ["address"] = Fixtures.StakeStateAddress.ToString(),

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/StakeStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/StakeStateTypeTest.cs
@@ -52,7 +52,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 cancellableBlockIndex
                 claimableBlockIndex
             }";
-            var queryResult = await ExecuteQueryAsync<StakeStateType>(query, source: new StakeStateType.StakeStateContext(stakeState, GetStatesMock, GetBalanceMock));
+            var queryResult = await ExecuteQueryAsync<StakeStateType>(query, source: new StakeStateType.StakeStateContext(stakeState, GetStatesMock, GetBalanceMock, 0));
             var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(expected, data);
         }

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -54,7 +54,12 @@ namespace NineChronicles.Headless.GraphTypes
 
                     return new StateContext(
                         chain.ToAccountStateGetter(blockHash),
-                        chain.ToAccountBalanceGetter(blockHash)
+                        chain.ToAccountBalanceGetter(blockHash),
+                        blockHash switch
+                        {
+                            BlockHash bh => chain[bh].Index,
+                            null => chain.Tip.Index,
+                        }
                     );
                 }
             );

--- a/NineChronicles.Headless/GraphTypes/StateQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StateQuery.cs
@@ -40,7 +40,8 @@ namespace NineChronicles.Headless.GraphTypes
                         return new AvatarStateType.AvatarStateContext(
                             context.Source.AccountStateGetter.GetAvatarState(address),
                             context.Source.AccountStateGetter,
-                            context.Source.AccountBalanceGetter);
+                            context.Source.AccountBalanceGetter,
+                            context.Source.BlockIndex);
                     }
                     catch (InvalidAddressException)
                     {
@@ -157,7 +158,8 @@ namespace NineChronicles.Headless.GraphTypes
                         return new AgentStateType.AgentStateContext(
                             new AgentState(state),
                             context.Source.AccountStateGetter,
-                            context.Source.AccountBalanceGetter
+                            context.Source.AccountBalanceGetter,
+                            context.Source.BlockIndex
                         );
                     }
 
@@ -181,7 +183,8 @@ namespace NineChronicles.Headless.GraphTypes
                         return new StakeStateType.StakeStateContext(
                             new StakeState(state),
                             context.Source.AccountStateGetter,
-                            context.Source.AccountBalanceGetter
+                            context.Source.AccountBalanceGetter,
+                            context.Source.BlockIndex
                         );
                     }
 

--- a/NineChronicles.Headless/GraphTypes/States/AgentStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AgentStateType.cs
@@ -19,8 +19,8 @@ namespace NineChronicles.Headless.GraphTypes.States
     {
         public class AgentStateContext : StateContext
         {
-            public AgentStateContext(AgentState agentState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter)
-                : base(accountStateGetter, accountBalanceGetter)
+            public AgentStateContext(AgentState agentState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter, long blockIndex)
+                : base(accountStateGetter, accountBalanceGetter, blockIndex)
             {
                 AgentState = agentState;
             }
@@ -49,7 +49,8 @@ namespace NineChronicles.Headless.GraphTypes.States
                         x => new AvatarStateType.AvatarStateContext(
                             x,
                             context.Source.AccountStateGetter,
-                            context.Source.AccountBalanceGetter));
+                            context.Source.AccountBalanceGetter,
+                            context.Source.BlockIndex));
                 });
             Field<NonNullGraphType<StringGraphType>>(
                 "gold",

--- a/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
@@ -17,8 +17,8 @@ namespace NineChronicles.Headless.GraphTypes.States
     {
         public class AvatarStateContext : StateContext
         {
-            public AvatarStateContext(AvatarState avatarState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter)
-                : base(accountStateGetter, accountBalanceGetter)
+            public AvatarStateContext(AvatarState avatarState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter, long blockIndex)
+                : base(accountStateGetter, accountBalanceGetter, blockIndex)
             {
                 AvatarState = avatarState;
             }

--- a/NineChronicles.Headless/GraphTypes/States/StakeStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/StakeStateType.cs
@@ -16,8 +16,8 @@ namespace NineChronicles.Headless.GraphTypes.States
     {
         public class StakeStateContext : StateContext
         {
-            public StakeStateContext(StakeState stakeState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter)
-                : base(accountStateGetter, accountBalanceGetter)
+            public StakeStateContext(StakeState stakeState, AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter, long blockIndex)
+                : base(accountStateGetter, accountBalanceGetter, blockIndex)
             {
                 StakeState = stakeState;
             }

--- a/NineChronicles.Headless/GraphTypes/States/StateContext.cs
+++ b/NineChronicles.Headless/GraphTypes/States/StateContext.cs
@@ -8,14 +8,16 @@ namespace NineChronicles.Headless.GraphTypes.States
 {
     public class StateContext
     {
-        public StateContext(AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter)
+        public StateContext(AccountStateGetter accountStateGetter, AccountBalanceGetter accountBalanceGetter, long blockIndex)
         {
             AccountStateGetter = accountStateGetter;
             AccountBalanceGetter = accountBalanceGetter;
+            BlockIndex = blockIndex;
         }
 
         public AccountStateGetter AccountStateGetter { get; }
         public AccountBalanceGetter AccountBalanceGetter { get; }
+        public long BlockIndex { get; }
 
         public IValue? GetState(Address address) =>
             AccountStateGetter(new[] { address })[0];


### PR DESCRIPTION
This pull request make `StakeStateType.claimableBlockIndex` return the block index branched by the `BlockPolicySource.V100290ObsoleteBlockIndex` like lib9c `StakeState.IsClaimable` does.

I requested reviews to @longfin and @sonohoshi because they reviewed lib9c PR https://github.com/planetarium/lib9c/pull/1303 (for `StakeStateType.claimableBlockIndex`)

And I request reviews to @ipdae and @area363 too because they are very familiar with GraphQL codes. (for `StateContext.BlockIndex` part)