### PR TITLE
feat(graphql): deprecate GraphQL APIs to handle private key

### DIFF
--- a/NineChronicles.Headless/GraphTypes/KeyStoreMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/KeyStoreMutation.cs
@@ -13,6 +13,8 @@ namespace NineChronicles.Headless.GraphTypes
     {
         public KeyStoreMutation()
         {
+            DeprecationReason = "Use `planet key` command instead.  https://www.npmjs.com/package/@planetarium/cli";
+
             Field<NonNullGraphType<PrivateKeyType>>("createPrivateKey",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<StringGraphType>>

--- a/NineChronicles.Headless/GraphTypes/KeyStoreType.cs
+++ b/NineChronicles.Headless/GraphTypes/KeyStoreType.cs
@@ -14,6 +14,8 @@ namespace NineChronicles.Headless.GraphTypes
     {
         public KeyStoreType()
         {
+            DeprecationReason = "Use `planet key` command instead.  https://www.npmjs.com/package/@planetarium/cli";
+
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<ProtectedPrivateKeyType>>>>(
                 name: "protectedPrivateKeys",
                 resolve: context => context.Source.List().Select(t => t.Item2));

--- a/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneMutation.cs
@@ -32,6 +32,7 @@ namespace NineChronicles.Headless.GraphTypes
 
             Field<KeyStoreMutation>(
                 name: "keyStore",
+                deprecationReason: "Use `planet key` command instead.  https://www.npmjs.com/package/@planetarium/cli",
                 resolve: context => standaloneContext.KeyStore);
 
             Field<ActivationStatusMutation>(

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -149,6 +149,7 @@ namespace NineChronicles.Headless.GraphTypes
 
             Field<KeyStoreType>(
                 name: "keyStore",
+                deprecationReason: "Use `planet key` command instead.  https://www.npmjs.com/package/@planetarium/cli",
                 resolve: context => standaloneContext.KeyStore
             ).AuthorizeWithLocalPolicyIf(useSecretToken);
 


### PR DESCRIPTION
This pull request is related with #1567 discussion.

I think we should recommend to use `planet key` command to handle private key. This pull request deprecates the GraphQL fields and types:

 - `KeyStoreType` type
 - `KeyStoreMutation` type
 - `mutation.keyStore` field
 - `query.keyStore` field