### PR TITLE
Use appsettings file to run headless server

### DIFF
--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -1,0 +1,245 @@
+using NineChronicles.Headless.Properties;
+
+namespace NineChronicles.Headless.Executable
+{
+    public class Configuration
+    {
+        public const bool DefaultNoReduceStore = false;
+        public const bool DefaultNoMiner = false;
+        public const int DefaultWorkers = 5;
+        public const int DefaultConfirmations = 0;
+        public const bool DefaultNonblockRenderer = false;
+        public const int DefaultNonblockRendererQueue = 512;
+        public const int DefaultMessageTimeout = 60;
+        public const int DefaultTipTimeout = 60;
+        public const int DefaultDemandBuffer = 1150;
+        public const bool DefaultSkipPreload = true;
+        public const int DefaultMinimumBroadcastTarget = 10;
+        public const int DefaultBucketSize = 16;
+        public const string DefaultChainTipStaleBehaviorType = "reboot";
+        public const int DefaultMaximumPollPeers = int.MaxValue;
+
+        public const bool DefaultGraphQLServer = false;
+        public const bool DefaultNoCors = false;
+        public const bool DefaultRpcServer = false;
+        public const string DefaultRpcListenHost = "0.0.0.0";
+
+        public class DevConfiguration
+        {
+            public int? BlockInterval { get; set; }
+            public int? ReorgInterval { get; set; }
+        }
+
+        public string? AppProtocolVersionString
+        {
+            get;
+            set;
+            // set => AppProtocolVersion = Libplanet.Net.AppProtocolVersion.FromToken(value);
+        }
+
+        public AppProtocolVersion? AppProtocolVersion { get; set; }
+
+        public string[]? TrustedAppProtocolVersionSignerStrings
+        {
+            get;
+            set;
+            // set => TrustedAppProtocolVersionSigners = value
+            // ?.Select(s => new PublicKey(ByteUtil.ParseHex(s)))
+            // ?.ToHashSet();
+        }
+
+        public HashSet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; }
+        public string? GenesisBlockPath { get; set; }
+        public string? Host { get; set; }
+        public ushort? Port { get; set; }
+
+        public string? SwarmPrivateKeyString
+        {
+            get;
+            set;
+            // set => SwarmPrivateKey = string.IsNullOrEmpty(value)
+            // ? new PrivateKey()
+            // : new PrivateKey(ByteUtil.ParseHex(value));
+        }
+
+        public PrivateKey? SwarmPrivateKey { get; set; }
+        public int? Workers { get; set; }
+
+        // Storage
+        public string? StoreType { get; set; }
+        public string? StorePath { get; set; }
+        public bool? NoReduceStore { get; set; }
+
+        // Miner
+        public bool? NoMiner { get; set; }
+        public int? MinerCount { get; set; }
+        public string? MinerPrivateKeyString { get; set; }
+
+        // Networking
+        public NetworkType? NetworkType { get; set; } = Properties.NetworkType.Main;
+        public string[]? IceServerStrings { get; set; }
+        public string[]? PeerStrings { get; set; }
+        public ImmutableArray<BoundPeer>? Peers { get; set; }
+
+        // RPC Server
+        public bool? RpcServer { get; set; }
+        public string? RpcListenHost { get; set; }
+        public int? RpcListenPort { get; set; }
+        public bool? RpcRemoteServer { get; set; }
+        public bool? RpcHttpServer { get; set; }
+
+        // GraphQL Server
+        public bool? GraphQLServer { get; set; }
+        public string? GraphQLHost { get; set; }
+        public int? GraphQLPort { get; set; }
+        public string? GraphQLSecretTokenPath { get; set; }
+        public bool? NoCors { get; set; }
+
+        // Rendering
+        public bool? NonblockRenderer { get; set; }
+        public int? NonblockRendererQueue { get; set; }
+        public bool? StrictRendering { get; set; }
+        public bool? LogActionRenders { get; set; }
+
+        // Development
+        public bool? IsDev { get; set; }
+
+        public int? BlockInterval
+        {
+            get => Dev.BlockInterval;
+            set => Dev.BlockInterval = value;
+        }
+
+        public int? ReorgInterval
+        {
+            get => Dev.ReorgInterval;
+            set => Dev.ReorgInterval = value;
+        }
+
+        public DevConfiguration Dev { get; } = new();
+
+        // AWS
+        public string? AwsCognitoIdentity { get; set; }
+        public string? AwsAccessKey { get; set; }
+        public string? AwsSecretKey { get; set; }
+        public string? AwsRegion { get; set; }
+
+        // Settings
+        public int? Confirmations { get; set; }
+        public int? TxLifeTime { get; set; }
+        public int? MessageTimeout { get; set; }
+        public int? TipTimeout { get; set; }
+        public int? DemandBuffer { get; set; }
+        public string[]? StaticPeerStrings { get; set; }
+        public bool? SkipPreload { get; set; }
+        public int? MinimumBroadcastTarget { get; set; }
+        public int? BucketSize { get; set; }
+        public string? ChainTipStaleBehaviorType { get; set; }
+        public int? TxQuotaPerSigner { get; set; }
+        public int? MaximumPollPeers { get; set; }
+
+        public void Overwrite(
+            string? appProtocolVersionString,
+            string[]? trustedAppProtocolVersionSignerStrings,
+            string? genesisBlockPath,
+            string? host,
+            ushort? port,
+            string? swarmPrivateKeyString,
+            int? workers,
+            string? storeType,
+            string? storePath,
+            bool? noReduceStore,
+            bool? noMiner,
+            int? minerCount,
+            string? minerPrivateKeyString,
+            NetworkType? networkType,
+            string[]? iceServerStrings,
+            string[]? peerStrings,
+            bool? rpcServer,
+            string? rpcListenHost,
+            int? rpcListenPort,
+            bool? rpcRemoteServer,
+            bool? rpcHttpServer,
+            bool? graphQlServer,
+            string? graphQLHost,
+            int? graphQLPort,
+            string? graphQlSecretTokenPath,
+            bool? noCors,
+            bool? nonblockRenderer,
+            int? nonblockRendererQueue,
+            bool? strictRendering,
+            bool? logActionRenders,
+            bool? isDev,
+            int? blockInterval,
+            int? reorgInterval,
+            string? awsCognitoIdentity,
+            string? awsAccessKey,
+            string? awsSecretKey,
+            string? awsRegion,
+            int? confirmations,
+            int? txLifeTime,
+            int? messageTimeout,
+            int? tipTimeout,
+            int? demandBuffer,
+            string[]? staticPeerStrings,
+            bool? skipPreload,
+            int? minimumBroadcastTarget,
+            int? bucketSize,
+            string? chainTipStaleBehaviorType,
+            int? txQuotaPerSigner,
+            int? maximumPollPeers
+        )
+        {
+            AppProtocolVersionString = appProtocolVersionString ?? AppProtocolVersionString;
+            TrustedAppProtocolVersionSignerStrings =
+                trustedAppProtocolVersionSignerStrings ?? TrustedAppProtocolVersionSignerStrings;
+            GenesisBlockPath = genesisBlockPath ?? GenesisBlockPath;
+            Host = host ?? Host;
+            Port = port ?? Port;
+            SwarmPrivateKeyString = swarmPrivateKeyString ?? SwarmPrivateKeyString;
+            Workers = workers ?? Workers;
+            StoreType = storeType ?? StoreType;
+            StorePath = storePath ?? StorePath;
+            NoReduceStore = noReduceStore ?? NoReduceStore;
+            NoMiner = noMiner ?? NoMiner;
+            MinerCount = minerCount ?? MinerCount;
+            MinerPrivateKeyString = minerPrivateKeyString ?? MinerPrivateKeyString;
+            NetworkType = networkType ?? NetworkType;
+            IceServerStrings = iceServerStrings ?? IceServerStrings;
+            PeerStrings = peerStrings ?? PeerStrings;
+            RpcServer = rpcServer ?? RpcServer;
+            RpcListenHost = rpcListenHost ?? RpcListenHost;
+            RpcListenPort = rpcListenPort ?? RpcListenPort;
+            RpcRemoteServer = rpcRemoteServer ?? RpcRemoteServer;
+            RpcHttpServer = rpcHttpServer ?? RpcHttpServer;
+            GraphQLServer = graphQlServer ?? GraphQLServer;
+            GraphQLHost = graphQLHost ?? GraphQLHost;
+            GraphQLPort = graphQLPort ?? GraphQLPort;
+            GraphQLSecretTokenPath = graphQlSecretTokenPath ?? GraphQLSecretTokenPath;
+            NoCors = noCors ?? NoCors;
+            NonblockRenderer = nonblockRenderer ?? NonblockRenderer;
+            NonblockRendererQueue = nonblockRendererQueue ?? NonblockRendererQueue;
+            StrictRendering = strictRendering ?? StrictRendering;
+            LogActionRenders = logActionRenders ?? LogActionRenders;
+            IsDev = isDev ?? IsDev;
+            Dev.BlockInterval = blockInterval ?? Dev.BlockInterval;
+            Dev.ReorgInterval = reorgInterval ?? Dev.ReorgInterval;
+            AwsCognitoIdentity = awsCognitoIdentity ?? AwsCognitoIdentity;
+            AwsAccessKey = awsAccessKey ?? AwsAccessKey;
+            AwsSecretKey = awsSecretKey ?? AwsSecretKey;
+            AwsRegion = awsRegion ?? AwsRegion;
+            Confirmations = confirmations ?? Confirmations;
+            TxLifeTime = txLifeTime ?? TxLifeTime;
+            MessageTimeout = messageTimeout ?? MessageTimeout;
+            TipTimeout = tipTimeout ?? TipTimeout;
+            DemandBuffer = demandBuffer ?? DemandBuffer;
+            StaticPeerStrings = staticPeerStrings ?? StaticPeerStrings;
+            SkipPreload = skipPreload ?? SkipPreload;
+            MinimumBroadcastTarget = minimumBroadcastTarget ?? MinimumBroadcastTarget;
+            BucketSize = bucketSize ?? BucketSize;
+            ChainTipStaleBehaviorType = chainTipStaleBehaviorType ?? ChainTipStaleBehaviorType;
+            TxQuotaPerSigner = txQuotaPerSigner ?? TxQuotaPerSigner;
+            MaximumPollPeers = maximumPollPeers ?? MaximumPollPeers;
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using NineChronicles.Headless.Properties;
 
 namespace NineChronicles.Headless.Executable
@@ -24,7 +26,16 @@ namespace NineChronicles.Headless.Executable
 
         // Storage
         public string? StoreType { get; set; }
-        public string? StorePath { get; set; }
+
+        public string? StorePath { get; set; } =
+            Path.Combine(
+                new string[]
+                {
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    "AppData", "Local", "planetarium", "9c-main-partition"
+                }
+            );
+
         public bool NoReduceStore { get; set; }
         public int StoreStateCacheSize { get; set; } = 100;
 

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -4,38 +4,10 @@ namespace NineChronicles.Headless.Executable
 {
     public class Configuration
     {
-        public const bool DefaultNoReduceStore = false;
-        public const int DefaultStoreStateCacheSize = 100;
-        public const bool DefaultNoMiner = false;
-        public const int DefaultWorkers = 5;
-        public const int DefaultConfirmations = 0;
-        public const bool DefaultNonblockRenderer = false;
-        public const int DefaultNonblockRendererQueue = 512;
-        public const int DefaultMessageTimeout = 60;
-        public const int DefaultTipTimeout = 60;
-        public const int DefaultDemandBuffer = 1150;
-        public const bool DefaultSkipPreload = true;
-        public const int DefaultMinimumBroadcastTarget = 10;
-        public const int DefaultBucketSize = 16;
-        public const string DefaultChainTipStaleBehaviorType = "reboot";
-        public const int DefaultMaximumPollPeers = int.MaxValue;
-        public const NetworkType DefaultNetworkType = Properties.NetworkType.Main;
-        public const bool DefaultIsDev = false;
-        public const int DefaultBlockInterval = 100;
-        public const int DefaultReorgInterval = 100;
-        public const bool DefaultStrictRendering = false;
-        public const int DefaultTxLifeTime = 1000;
-        public const int DefaultMinerCount = 1;
-        public const int DefaultTxQuotaPerSigner = 10;
-        public const bool DefaultGraphQLServer = false;
-        public const bool DefaultNoCors = false;
-        public const bool DefaultRpcServer = false;
-        public const string DefaultRpcListenHost = "0.0.0.0";
-
         public class DevConfiguration
         {
-            public int? BlockInterval { get; set; }
-            public int? ReorgInterval { get; set; }
+            public int BlockInterval { get; set; } = 100;
+            public int ReorgInterval { get; set; } = 100;
         }
 
         public string? AppProtocolVersionString { get; set; }
@@ -48,53 +20,54 @@ namespace NineChronicles.Headless.Executable
 
         public string? SwarmPrivateKeyString { get; set; }
 
-        public int? Workers { get; set; }
+        public int Workers { get; set; } = 5;
 
         // Storage
         public string? StoreType { get; set; }
         public string? StorePath { get; set; }
-        public bool? NoReduceStore { get; set; }
+        public bool NoReduceStore { get; set; }
+        public int StoreStateCacheSize { get; set; } = 100;
 
         // Miner
-        public bool? NoMiner { get; set; }
-        public int? MinerCount { get; set; }
+        public bool NoMiner { get; set; }
+        public int MinerCount { get; set; } = 1;
         public string? MinerPrivateKeyString { get; set; }
 
         // Networking
-        public NetworkType? NetworkType { get; set; } = Properties.NetworkType.Main;
+        public NetworkType NetworkType { get; set; } = NetworkType.Main;
         public string[]? IceServerStrings { get; set; }
         public string[]? PeerStrings { get; set; }
 
         // RPC Server
-        public bool? RpcServer { get; set; }
-        public string? RpcListenHost { get; set; }
+        public bool RpcServer { get; set; }
+        public string RpcListenHost { get; set; } = "0.0.0.0";
         public int? RpcListenPort { get; set; }
         public bool? RpcRemoteServer { get; set; }
         public bool? RpcHttpServer { get; set; }
 
         // GraphQL Server
-        public bool? GraphQLServer { get; set; }
+        public bool GraphQLServer { get; set; }
         public string? GraphQLHost { get; set; }
         public int? GraphQLPort { get; set; }
         public string? GraphQLSecretTokenPath { get; set; }
-        public bool? NoCors { get; set; }
+        public bool NoCors { get; set; }
 
         // Rendering
-        public bool? NonblockRenderer { get; set; }
-        public int? NonblockRendererQueue { get; set; }
-        public bool? StrictRendering { get; set; }
+        public bool NonblockRenderer { get; set; }
+        public int NonblockRendererQueue { get; set; } = 512;
+        public bool StrictRendering { get; set; }
         public bool? LogActionRenders { get; set; }
 
         // Development
-        public bool? IsDev { get; set; }
+        public bool IsDev { get; set; }
 
-        public int? BlockInterval
+        public int BlockInterval
         {
             get => Dev.BlockInterval;
             set => Dev.BlockInterval = value;
         }
 
-        public int? ReorgInterval
+        public int ReorgInterval
         {
             get => Dev.ReorgInterval;
             set => Dev.ReorgInterval = value;
@@ -109,18 +82,18 @@ namespace NineChronicles.Headless.Executable
         public string? AwsRegion { get; set; }
 
         // Settings
-        public int? Confirmations { get; set; }
-        public int? TxLifeTime { get; set; }
-        public int? MessageTimeout { get; set; }
-        public int? TipTimeout { get; set; }
-        public int? DemandBuffer { get; set; }
+        public int Confirmations { get; set; }
+        public int TxLifeTime { get; set; } = 1000;
+        public int MessageTimeout { get; set; } = 60;
+        public int TipTimeout { get; set; } = 60;
+        public int DemandBuffer { get; set; } = 1150;
         public string[]? StaticPeerStrings { get; set; }
-        public bool? SkipPreload { get; set; }
-        public int? MinimumBroadcastTarget { get; set; }
-        public int? BucketSize { get; set; }
-        public string? ChainTipStaleBehaviorType { get; set; }
-        public int? TxQuotaPerSigner { get; set; }
-        public int? MaximumPollPeers { get; set; }
+        public bool SkipPreload { get; set; }
+        public int MinimumBroadcastTarget { get; set; } = 10;
+        public int BucketSize { get; set; } = 16;
+        public string ChainTipStaleBehaviorType { get; set; } = "reboot";
+        public int TxQuotaPerSigner { get; set; } = 10;
+        public int MaximumPollPeers { get; set; } = int.MaxValue;
 
         public void Overwrite(
             string? appProtocolVersionString,

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -38,39 +38,16 @@ namespace NineChronicles.Headless.Executable
             public int? ReorgInterval { get; set; }
         }
 
-        public string? AppProtocolVersionString
-        {
-            get;
-            set;
-            // set => AppProtocolVersion = Libplanet.Net.AppProtocolVersion.FromToken(value);
-        }
+        public string? AppProtocolVersionString { get; set; }
 
-        public AppProtocolVersion? AppProtocolVersion { get; set; }
+        public string[]? TrustedAppProtocolVersionSignerStrings { get; set; }
 
-        public string[]? TrustedAppProtocolVersionSignerStrings
-        {
-            get;
-            set;
-            // set => TrustedAppProtocolVersionSigners = value
-            // ?.Select(s => new PublicKey(ByteUtil.ParseHex(s)))
-            // ?.ToHashSet();
-        }
-
-        public HashSet<PublicKey>? TrustedAppProtocolVersionSigners { get; set; }
         public string? GenesisBlockPath { get; set; }
         public string? Host { get; set; }
         public ushort? Port { get; set; }
 
-        public string? SwarmPrivateKeyString
-        {
-            get;
-            set;
-            // set => SwarmPrivateKey = string.IsNullOrEmpty(value)
-            // ? new PrivateKey()
-            // : new PrivateKey(ByteUtil.ParseHex(value));
-        }
+        public string? SwarmPrivateKeyString { get; set; }
 
-        public PrivateKey? SwarmPrivateKey { get; set; }
         public int? Workers { get; set; }
 
         // Storage
@@ -87,7 +64,6 @@ namespace NineChronicles.Headless.Executable
         public NetworkType? NetworkType { get; set; } = Properties.NetworkType.Main;
         public string[]? IceServerStrings { get; set; }
         public string[]? PeerStrings { get; set; }
-        public ImmutableArray<BoundPeer>? Peers { get; set; }
 
         // RPC Server
         public bool? RpcServer { get; set; }

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -5,6 +5,7 @@ namespace NineChronicles.Headless.Executable
     public class Configuration
     {
         public const bool DefaultNoReduceStore = false;
+        public const int DefaultStoreStateCacheSize = 100;
         public const bool DefaultNoMiner = false;
         public const int DefaultWorkers = 5;
         public const int DefaultConfirmations = 0;
@@ -18,7 +19,14 @@ namespace NineChronicles.Headless.Executable
         public const int DefaultBucketSize = 16;
         public const string DefaultChainTipStaleBehaviorType = "reboot";
         public const int DefaultMaximumPollPeers = int.MaxValue;
-
+        public const NetworkType DefaultNetworkType = Properties.NetworkType.Main;
+        public const bool DefaultIsDev = false;
+        public const int DefaultBlockInterval = 100;
+        public const int DefaultReorgInterval = 100;
+        public const bool DefaultStrictRendering = false;
+        public const int DefaultTxLifeTime = 1000;
+        public const int DefaultMinerCount = 1;
+        public const int DefaultTxQuotaPerSigner = 10;
         public const bool DefaultGraphQLServer = false;
         public const bool DefaultNoCors = false;
         public const bool DefaultRpcServer = false;

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -111,7 +111,7 @@ namespace NineChronicles.Headless.Executable
             [Option("trusted-app-protocol-version-signer", new[] { 'T' },
                 Description = "Trustworthy signers who claim new app protocol versions")]
             string[]? trustedAppProtocolVersionSigners = null,
-            [Option(Description = "Run RPC server?")]
+            [Option(Description = "Use this option if you want to make unity clients to communicate with this server with RPC")]
             bool? rpcServer = null,
             [Option(Description = "RPC listen host")]
             string? rpcListenHost = null,
@@ -123,7 +123,8 @@ namespace NineChronicles.Headless.Executable
             [Option(Description = "If you enable this option with \"rpcRemoteServer\" option at the same time, " +
                                   "RPC server will use HTTP/1, not gRPC.")]
             bool? rpcHttpServer = null,
-            [Option("graphql-server", Description = "Run GraphQL server?")]
+            [Option("graphql-server", 
+                Description = "Use this option if you want to enable GraphQL server to enable querying data.")]
             bool? graphQLServer = null,
             [Option("graphql-host", Description = "GraphQL listen host")]
             string? graphQLHost = null,
@@ -198,7 +199,8 @@ namespace NineChronicles.Headless.Executable
             int? txQuotaPerSigner = null,
             [Option(Description = "The maximum number of peers to poll blocks. int.MaxValue by default.")]
             int? maximumPollPeers = null,
-            [Option("config", new[] { 'C' }, Description = "The full path of appsettings.json file")]
+            [Option("config", new[] { 'C' }, 
+                Description = "Absolute path of \"appsettings.json\" file to provide headless configurations.")]
             string? configPath = "appsettings.json",
             [Ignore] CancellationToken? cancellationToken = null
         )

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -293,7 +293,7 @@ namespace NineChronicles.Headless.Executable
 
             Log.Logger = loggerConf.CreateLogger();
 
-            if (headlessConfig.NoMiner != true && headlessConfig.MinerPrivateKeyString is null)
+            if (!headlessConfig.NoMiner && headlessConfig.MinerPrivateKeyString is null)
             {
                 throw new CommandExitedException(
                     "--miner-private-key must be present to turn on mining at libplanet node.",
@@ -310,7 +310,7 @@ namespace NineChronicles.Headless.Executable
                     KeyStore = Web3KeyStore.DefaultKeyStore,
                 };
 
-                if (headlessConfig.GraphQLServer == true)
+                if (headlessConfig.GraphQLServer)
                 {
                     string? secretToken = null;
                     if (headlessConfig.GraphQLSecretTokenPath is { })
@@ -323,13 +323,13 @@ namespace NineChronicles.Headless.Executable
 
                     var graphQLNodeServiceProperties = new GraphQLNodeServiceProperties
                     {
-                        GraphQLServer = headlessConfig.GraphQLServer ?? Configuration.DefaultGraphQLServer,
+                        GraphQLServer = headlessConfig.GraphQLServer,
                         GraphQLListenHost = headlessConfig.GraphQLHost,
                         GraphQLListenPort = headlessConfig.GraphQLPort,
                         SecretToken = secretToken,
-                        NoCors = headlessConfig.NoCors ?? Configuration.DefaultNoCors,
-                        UseMagicOnion = headlessConfig.RpcServer ?? Configuration.DefaultRpcServer,
-                        HttpOptions = headlessConfig.RpcServer == true && headlessConfig.RpcHttpServer == true
+                        NoCors = headlessConfig.NoCors,
+                        UseMagicOnion = headlessConfig.RpcServer,
+                        HttpOptions = headlessConfig.RpcServer && headlessConfig.RpcHttpServer == true
                             ? new GraphQLNodeServiceProperties.MagicOnionHttpOptions(
                                 $"{headlessConfig.RpcListenHost}:{headlessConfig.RpcListenPort}")
                             : (GraphQLNodeServiceProperties.MagicOnionHttpOptions?)null,
@@ -348,31 +348,28 @@ namespace NineChronicles.Headless.Executable
                         headlessConfig.SwarmPrivateKeyString,
                         headlessConfig.StoreType,
                         headlessConfig.StorePath,
-                        headlessConfig.NoReduceStore ?? Configuration.DefaultNoReduceStore,
-                        Configuration.DefaultStoreStateCacheSize,
+                        headlessConfig.NoReduceStore,
+                        headlessConfig.StoreStateCacheSize,
                         headlessConfig.IceServerStrings,
                         headlessConfig.PeerStrings,
                         headlessConfig.TrustedAppProtocolVersionSignerStrings,
-                        headlessConfig.NoMiner ?? Configuration.DefaultNoMiner,
-                        workers: headlessConfig.Workers ?? Configuration.DefaultWorkers,
-                        confirmations: headlessConfig.Confirmations ?? Configuration.DefaultConfirmations,
-                        nonblockRenderer: headlessConfig.NonblockRenderer ?? Configuration.DefaultNonblockRenderer,
-                        nonblockRendererQueue: headlessConfig.NonblockRendererQueue ??
-                                               Configuration.DefaultNonblockRendererQueue,
-                        messageTimeout: headlessConfig.MessageTimeout ?? Configuration.DefaultMessageTimeout,
-                        tipTimeout: headlessConfig.TipTimeout ?? Configuration.DefaultTipTimeout,
-                        demandBuffer: headlessConfig.DemandBuffer ?? Configuration.DefaultDemandBuffer,
+                        headlessConfig.NoMiner,
+                        workers: headlessConfig.Workers,
+                        confirmations: headlessConfig.Confirmations,
+                        nonblockRenderer: headlessConfig.NonblockRenderer,
+                        nonblockRendererQueue: headlessConfig.NonblockRendererQueue,
+                        messageTimeout: headlessConfig.MessageTimeout,
+                        tipTimeout: headlessConfig.TipTimeout,
+                        demandBuffer: headlessConfig.DemandBuffer,
                         staticPeerStrings: headlessConfig.StaticPeerStrings,
-                        preload: !(headlessConfig.SkipPreload ?? Configuration.DefaultSkipPreload),
-                        minimumBroadcastTarget: headlessConfig.MinimumBroadcastTarget ??
-                                                Configuration.DefaultMinimumBroadcastTarget,
-                        bucketSize: headlessConfig.BucketSize ?? Configuration.DefaultBucketSize,
-                        chainTipStaleBehaviorType: headlessConfig.ChainTipStaleBehaviorType ??
-                                                   Configuration.DefaultChainTipStaleBehaviorType,
-                        maximumPollPeers: headlessConfig.MaximumPollPeers ?? Configuration.DefaultMaximumPollPeers
+                        preload: !headlessConfig.SkipPreload,
+                        minimumBroadcastTarget: headlessConfig.MinimumBroadcastTarget,
+                        bucketSize: headlessConfig.BucketSize,
+                        chainTipStaleBehaviorType: headlessConfig.ChainTipStaleBehaviorType,
+                        maximumPollPeers: headlessConfig.MaximumPollPeers
                     );
 
-                if (headlessConfig.RpcServer == true)
+                if (headlessConfig.RpcServer)
                 {
                     properties.Render = true;
                     properties.LogActionRenders = true;
@@ -390,26 +387,23 @@ namespace NineChronicles.Headless.Executable
                 {
                     MinerPrivateKey = minerPrivateKey,
                     Libplanet = properties,
-                    NetworkType = headlessConfig.NetworkType ?? Configuration.DefaultNetworkType,
-                    Dev = headlessConfig.IsDev ?? Configuration.DefaultIsDev,
-                    StrictRender = headlessConfig.StrictRendering ?? Configuration.DefaultStrictRendering,
-                    BlockInterval = headlessConfig.Dev.BlockInterval ?? Configuration.DefaultBlockInterval,
-                    ReorgInterval = headlessConfig.Dev.ReorgInterval ?? Configuration.DefaultReorgInterval,
-                    TxLifeTime = TimeSpan.FromMinutes(headlessConfig.TxLifeTime ?? Configuration.DefaultTxLifeTime),
-                    MinerCount = headlessConfig.MinerCount ?? Configuration.DefaultMinerCount,
-                    TxQuotaPerSigner = headlessConfig.TxQuotaPerSigner ?? Configuration.DefaultTxQuotaPerSigner
+                    NetworkType = headlessConfig.NetworkType,
+                    Dev = headlessConfig.IsDev,
+                    StrictRender = headlessConfig.StrictRendering,
+                    BlockInterval = headlessConfig.Dev.BlockInterval,
+                    ReorgInterval = headlessConfig.Dev.ReorgInterval,
+                    TxLifeTime = TimeSpan.FromMinutes(headlessConfig.TxLifeTime),
+                    MinerCount = headlessConfig.MinerCount,
+                    TxQuotaPerSigner = headlessConfig.TxQuotaPerSigner,
                 };
-                hostBuilder.ConfigureServices(services =>
-                {
-                    services.AddSingleton(_ => standaloneContext);
-                });
+                hostBuilder.ConfigureServices(services => { services.AddSingleton(_ => standaloneContext); });
                 hostBuilder.UseNineChroniclesNode(nineChroniclesProperties, standaloneContext);
-                if (headlessConfig.RpcServer == true)
+                if (headlessConfig.RpcServer)
                 {
                     hostBuilder.UseNineChroniclesRPC(
                         NineChroniclesNodeServiceProperties
                             .GenerateRpcNodeServiceProperties(
-                                headlessConfig.RpcListenHost ?? Configuration.DefaultRpcListenHost,
+                                headlessConfig.RpcListenHost,
                                 headlessConfig.RpcListenPort,
                                 headlessConfig.RpcRemoteServer == true
                             )

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -111,7 +111,8 @@ namespace NineChronicles.Headless.Executable
             [Option("trusted-app-protocol-version-signer", new[] { 'T' },
                 Description = "Trustworthy signers who claim new app protocol versions")]
             string[]? trustedAppProtocolVersionSigners = null,
-            [Option(Description = "Use this option if you want to make unity clients to communicate with this server with RPC")]
+            [Option(Description =
+                "Use this option if you want to make unity clients to communicate with this server with RPC")]
             bool? rpcServer = null,
             [Option(Description = "RPC listen host")]
             string? rpcListenHost = null,
@@ -123,7 +124,7 @@ namespace NineChronicles.Headless.Executable
             [Option(Description = "If you enable this option with \"rpcRemoteServer\" option at the same time, " +
                                   "RPC server will use HTTP/1, not gRPC.")]
             bool? rpcHttpServer = null,
-            [Option("graphql-server", 
+            [Option("graphql-server",
                 Description = "Use this option if you want to enable GraphQL server to enable querying data.")]
             bool? graphQLServer = null,
             [Option("graphql-host", Description = "GraphQL listen host")]
@@ -199,7 +200,7 @@ namespace NineChronicles.Headless.Executable
             int? txQuotaPerSigner = null,
             [Option(Description = "The maximum number of peers to poll blocks. int.MaxValue by default.")]
             int? maximumPollPeers = null,
-            [Option("config", new[] { 'C' }, 
+            [Option("config", new[] { 'C' },
                 Description = "Absolute path of \"appsettings.json\" file to provide headless configurations.")]
             string? configPath = "appsettings.json",
             [Ignore] CancellationToken? cancellationToken = null

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -69,10 +69,10 @@ namespace NineChronicles.Headless.Executable
         public async Task Run(
             [Option("app-protocol-version", new[] { 'V' },
                 Description = "App protocol version token.")]
-            string appProtocolVersionToken,
+            string? appProtocolVersionToken = null,
             [Option('G',
                 Description = "Genesis block path of blockchain. Blockchain is recognized by its genesis block.")]
-            string genesisBlockPath,
+            string? genesisBlockPath = null,
             [Option('H',
                 Description = "Hostname of this node for another nodes to access. " +
                               "This is not listening host like 0.0.0.0")]
@@ -85,11 +85,11 @@ namespace NineChronicles.Headless.Executable
                               "If you leave this null, a randomly generated value will be used.")]
             string? swarmPrivateKeyString = null,
             [Option("workers", Description = "Number of workers to use in Swarm")]
-            int workers = 5,
+            int? workers = null,
             [Option(Description = "Disable block mining.")]
-            bool noMiner = false,
+            bool? noMiner = null,
             [Option("miner-count", Description = "The number of miner task(thread).")]
-            int minerCount = 1,
+            int? minerCount = null,
             [Option("miner-private-key",
                 Description = "The private key used for mining blocks. " +
                               "Must not be null if you want to turn on mining with libplanet-node.")]
@@ -102,7 +102,7 @@ namespace NineChronicles.Headless.Executable
                                   "This value is required if you use persistent storage e.g. \"rocksdb\"")]
             string? storePath = null,
             [Option(Description = "Do not reduce storage. Enabling this option will use enormous disk spaces.")]
-            bool noReduceStore = false,
+            bool? noReduceStore = null,
             [Option("ice-server", new[] { 'I', },
                 Description = "ICE server to NAT traverse.")]
             string[]? iceServerStrings = null,
@@ -112,21 +112,21 @@ namespace NineChronicles.Headless.Executable
                 Description = "Trustworthy signers who claim new app protocol versions")]
             string[]? trustedAppProtocolVersionSigners = null,
             [Option(Description = "Run RPC server?")]
-            bool rpcServer = false,
+            bool? rpcServer = null,
             [Option(Description = "RPC listen host")]
-            string rpcListenHost = "0.0.0.0",
+            string? rpcListenHost = null,
             [Option(Description = "RPC listen port")]
             int? rpcListenPort = null,
             [Option(Description = "Do a role as RPC remote server?" +
                                   " If you enable this option, multiple Unity clients can connect to your RPC server.")]
-            bool rpcRemoteServer = false,
+            bool? rpcRemoteServer = null,
             [Option(Description = "If you enable this option with \"rpcRemoteServer\" option at the same time, " +
                                   "RPC server will use HTTP/1, not gRPC.")]
-            bool rpcHttpServer = false,
+            bool? rpcHttpServer = null,
             [Option("graphql-server", Description = "Run GraphQL server?")]
-            bool graphQLServer = false,
+            bool? graphQLServer = null,
             [Option("graphql-host", Description = "GraphQL listen host")]
-            string graphQLHost = "0.0.0.0",
+            string? graphQLHost = null,
             [Option("graphql-port", Description = "GraphQL listen port")]
             int? graphQLPort = null,
             [Option("graphql-secret-token-path",
@@ -135,34 +135,34 @@ namespace NineChronicles.Headless.Executable
                               "you should use this option and take it into headers.")]
             string? graphQLSecretTokenPath = null,
             [Option(Description = "Run without CORS policy.")]
-            bool noCors = false,
+            bool? noCors = null,
             [Option("confirmations",
                 Description = "The number of required confirmations to recognize a block."
             )]
-            int confirmations = 0,
+            int? confirmations = null,
             [Option("nonblock-renderer",
                 Description = "Uses non-blocking renderer, which prevents the blockchain & " +
                               "swarm from waiting slow rendering. Turned off by default.")]
-            bool nonblockRenderer = false,
+            bool? nonblockRenderer = null,
             [Option("nonblock-renderer-queue",
                 Description = "The size of the queue used by the non-blocking renderer. " +
                               "Ignored if --nonblock-renderer is turned off.")]
-            int nonblockRendererQueue = 512,
+            int? nonblockRendererQueue = null,
             [Option("strict-rendering", Description = "Flag to turn on validating action renderer.")]
-            bool strictRendering = false,
+            bool? strictRendering = null,
             [Option(Description = "Log action renders besides block renders. --rpc-server implies this.")]
-            bool logActionRenders = false,
+            bool? logActionRenders = null,
             [Option("network-type", Description = "Network type.")]
-            NetworkType networkType = NetworkType.Main,
+            NetworkType? networkType = null,
             [Option("dev", Description = "Flag to turn on the dev mode. false by default.")]
-            bool isDev = false,
+            bool? isDev = null,
             [Option("dev.block-interval",
                 Description = "The time interval between blocks. It's unit is milliseconds. " +
                               "Works only when dev mode is on.")]
-            int blockInterval = 10000,
+            int? blockInterval = null,
             [Option("dev.reorg-interval",
                 Description = "The size of reorg interval. Works only when dev mode is on.")]
-            int reorgInterval = 0,
+            int? reorgInterval = null,
             [Option(Description = "The Cognito identity for AWS CloudWatch logging.")]
             string? awsCognitoIdentity = null,
             [Option(Description = "The access key for AWS CloudWatch logging.")]
@@ -173,35 +173,34 @@ namespace NineChronicles.Headless.Executable
             string? awsRegion = null,
             [Option(Description =
                 "The lifetime of each transaction, which uses minute as its unit.")]
-            int txLifeTime = 180,
+            int? txLifeTime = null,
             [Option(Description =
                 "The grace period for new messages, which uses second as its unit.")]
-            int messageTimeout = 60,
+            int? messageTimeout = null,
             [Option(Description = "The grace period for tip update, which uses second as its unit.")]
-            int tipTimeout = 60,
+            int? tipTimeout = null,
             [Option(Description = "A number of block size that determines how far behind the demand " +
                                   "the tip of the chain will publish `NodeException` to GraphQL subscriptions.")]
-            int demandBuffer = 1150,
+            int? demandBuffer = null,
             [Option("static-peer",
                 Description = "A list of peers that the node will continue to maintain.")]
             string[]? staticPeerStrings = null,
             [Option(Description = "Run node without preloading.")]
-            bool skipPreload = false,
+            bool? skipPreload = null,
             [Option(Description = "Minimum number of peers to broadcast message.")]
-            int minimumBroadcastTarget = 10,
+            int? minimumBroadcastTarget = null,
             [Option(Description = "Number of the peers can be stored in each bucket.")]
-            int bucketSize = 16,
+            int? bucketSize = null,
             [Option(Description = "Determines behavior when the chain's tip is stale. \"reboot\" and \"preload\" " +
                                   "is available and \"reboot\" option is selected by default.")]
-            string chainTipStaleBehaviorType = "reboot",
+            string? chainTipStaleBehaviorType = null,
             [Option(Description = "The number of maximum transactions can be included in stage per signer.")]
-            int txQuotaPerSigner = 10,
+            int? txQuotaPerSigner = null,
             [Option(Description = "The maximum number of peers to poll blocks. int.MaxValue by default.")]
-            int maximumPollPeers = int.MaxValue,
+            int? maximumPollPeers = null,
             [Option("config", new[] { 'C' }, Description = "The full path of appsettings.json file")]
             string? configPath = "appsettings.json",
-            [Ignore]
-            CancellationToken? cancellationToken = null
+            [Ignore] CancellationToken? cancellationToken = null
         )
         {
 #if SENTRY || ! DEBUG

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -349,7 +349,7 @@ namespace NineChronicles.Headless.Executable
                         headlessConfig.StoreType,
                         headlessConfig.StorePath,
                         headlessConfig.NoReduceStore ?? Configuration.DefaultNoReduceStore,
-                        100,
+                        Configuration.DefaultStoreStateCacheSize,
                         headlessConfig.IceServerStrings,
                         headlessConfig.PeerStrings,
                         headlessConfig.TrustedAppProtocolVersionSignerStrings,
@@ -390,14 +390,14 @@ namespace NineChronicles.Headless.Executable
                 {
                     MinerPrivateKey = minerPrivateKey,
                     Libplanet = properties,
-                    NetworkType = headlessConfig.NetworkType ?? NetworkType.Main,
-                    Dev = headlessConfig.IsDev ?? false,
-                    StrictRender = headlessConfig.StrictRendering ?? false,
-                    BlockInterval = headlessConfig.Dev.BlockInterval ?? 100,
-                    ReorgInterval = headlessConfig.Dev.ReorgInterval ?? 100,
-                    TxLifeTime = TimeSpan.FromMinutes(headlessConfig.TxLifeTime ?? 1000),
-                    MinerCount = headlessConfig.MinerCount ?? 1,
-                    TxQuotaPerSigner = headlessConfig.TxQuotaPerSigner ?? 10
+                    NetworkType = headlessConfig.NetworkType ?? Configuration.DefaultNetworkType,
+                    Dev = headlessConfig.IsDev ?? Configuration.DefaultIsDev,
+                    StrictRender = headlessConfig.StrictRendering ?? Configuration.DefaultStrictRendering,
+                    BlockInterval = headlessConfig.Dev.BlockInterval ?? Configuration.DefaultBlockInterval,
+                    ReorgInterval = headlessConfig.Dev.ReorgInterval ?? Configuration.DefaultReorgInterval,
+                    TxLifeTime = TimeSpan.FromMinutes(headlessConfig.TxLifeTime ?? Configuration.DefaultTxLifeTime),
+                    MinerCount = headlessConfig.MinerCount ?? Configuration.DefaultMinerCount,
+                    TxQuotaPerSigner = headlessConfig.TxQuotaPerSigner ?? Configuration.DefaultTxQuotaPerSigner
                 };
                 hostBuilder.ConfigureServices(services =>
                 {

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -1,6 +1,10 @@
 {
     "Serilog": {
-        "Using": [ "Serilog.Expressions", "Serilog.Sinks.Console", "Serilog.Sinks.RollingFile" ],
+        "Using": [
+            "Serilog.Expressions",
+            "Serilog.Sinks.Console",
+            "Serilog.Sinks.RollingFile"
+        ],
         "MinimumLevel": "Debug",
         "WriteTo": [
             {
@@ -84,5 +88,38 @@
                 }
             }
         ]
+    },
+    "Headless": {
+        "AppProtocolVersionString": "100291/6ec8E598962F1f475504F82fD5bF3410eAE58B9B/MEUCIQCA3lzUAt0QBfG.+ezw4CQ69zBy669sANEt5juSJgzqcgIgbozfpcyeuKJDeJoT5exyGYDYBqCpxklsMEfs0SQ6qzo=/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTcyOmh0dHBzOi8vcmVsZWFzZS5uaW5lLWNocm9uaWNsZXMuY29tL21haW4vdjEwMDI5MS9sYXVuY2hlci92MS9XaW5kb3dzLnppcHU5OnRpbWVzdGFtcHUxMDoyMDIyLTA5LTA3ZQ==",
+        "GenesisBlockPath": "https://release.nine-chronicles.com/genesis-block-9c-main",
+        "StoreType": "rocksdb",
+        "StorePath": "/home/ulismoon/AppData/Local/planetarium/9c-main-partition",
+        "IceServerStrings": [
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us2.planetarium.dev:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us3.planetarium.dev:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us5.planetarium.dev:3478"
+        ],
+        "PeerStrings": [
+            "027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6,9c-main-tcp-seed-1.planetarium.dev,31234",
+            "02f164e3139e53eef2c17e52d99d343b8cbdb09eeed88af46c352b1c8be6329d71,9c-main-tcp-seed-2.planetarium.dev,31234",
+            "0247e289aa332260b99dfd50e578f779df9e6702d67e50848bb68f3e0737d9b9a5,9c-main-tcp-seed-3.planetarium.dev,31234"
+        ],
+        "TrustedAppProtocolVersionSignerStrings": [
+            "03eeedcd574708681afb3f02fb2aef7c643583089267d17af35e978ecaf2a1184e"
+        ],
+        "NoMiner": true,
+        "RpcServer": true,
+        "RpcListenHost": "127.0.0.1",
+        "RpcListenPort": 23234,
+        "GraphQLServer": true,
+        "GraphQLHost": "127.0.0.1",
+        "GraphQLPort": 23233,
+        "Workers": 1000,
+        "Confirmations": 0,
+        "MinimumBroadcastTarget": 20,
+        "BucketSize": 20,
+        "ChainTipStaleBehaviorType": "reboot",
+        "TipTimeout": 180
     }
 }

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -93,7 +93,8 @@
         "AppProtocolVersionString": "100291/6ec8E598962F1f475504F82fD5bF3410eAE58B9B/MEUCIQCA3lzUAt0QBfG.+ezw4CQ69zBy669sANEt5juSJgzqcgIgbozfpcyeuKJDeJoT5exyGYDYBqCpxklsMEfs0SQ6qzo=/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTcyOmh0dHBzOi8vcmVsZWFzZS5uaW5lLWNocm9uaWNsZXMuY29tL21haW4vdjEwMDI5MS9sYXVuY2hlci92MS9XaW5kb3dzLnppcHU5OnRpbWVzdGFtcHUxMDoyMDIyLTA5LTA3ZQ==",
         "GenesisBlockPath": "https://release.nine-chronicles.com/genesis-block-9c-main",
         "StoreType": "rocksdb",
-        "StorePath": "/home/ulismoon/AppData/Local/planetarium/9c-main-partition",
+        "StorePath": "~/AppData/Local/planetarium/9c-main-partition",
+        "Port": 31234,
         "IceServerStrings": [
             "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478",
             "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us2.planetarium.dev:3478",
@@ -111,15 +112,14 @@
         "NoMiner": true,
         "RpcServer": true,
         "RpcListenHost": "127.0.0.1",
-        "RpcListenPort": 23234,
+        "RpcListenPort": 31238,
+        "RpcRemoteServer": true,
         "GraphQLServer": true,
         "GraphQLHost": "127.0.0.1",
-        "GraphQLPort": 23233,
+        "GraphQLPort": 31280,
+        "NoCors": true,
         "Workers": 1000,
         "Confirmations": 0,
-        "MinimumBroadcastTarget": 20,
-        "BucketSize": 20,
-        "ChainTipStaleBehaviorType": "reboot",
-        "TipTimeout": 180
+        "ChainTipStaleBehaviorType": "reboot"
     }
 }

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -93,7 +93,6 @@
         "AppProtocolVersionString": "100291/6ec8E598962F1f475504F82fD5bF3410eAE58B9B/MEUCIQCA3lzUAt0QBfG.+ezw4CQ69zBy669sANEt5juSJgzqcgIgbozfpcyeuKJDeJoT5exyGYDYBqCpxklsMEfs0SQ6qzo=/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTcyOmh0dHBzOi8vcmVsZWFzZS5uaW5lLWNocm9uaWNsZXMuY29tL21haW4vdjEwMDI5MS9sYXVuY2hlci92MS9XaW5kb3dzLnppcHU5OnRpbWVzdGFtcHUxMDoyMDIyLTA5LTA3ZQ==",
         "GenesisBlockPath": "https://release.nine-chronicles.com/genesis-block-9c-main",
         "StoreType": "rocksdb",
-        "StorePath": "~/AppData/Local/planetarium/9c-main-partition",
         "Port": 31234,
         "IceServerStrings": [
             "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 $ dotnet run --project ./NineChronicles.Headless.Executable/ -- --help
 
 Usage: NineChronicles.Headless.Executable [command]
-Usage: NineChronicles.Headless.Executable [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <UInt16>] [--swarm-private-key <String>] [--workers <Int32>] [--no-miner] [--miner-count <Int32>] [--miner-private-key <String>] [--store-type <String>] [--store-path <String>] [--no-reduce-store] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Int32>] [--rpc-remote-server] [--rpc-http-server] [--graphql-server] [--graphql-host <String>] [--graphql-port <Int32>] [--graphql-secret-token-path <String>] [--no-cors] [--confirmations <Int32>] [--nonblock-renderer] [--nonblock-renderer-queue <Int32>] [--strict-rendering] [--log-action-renders] [--network-type <NetworkType>] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--static-peer <String>...] [--skip-preload] [--minimum-broadcast-target <Int32>] [--bucket-size <Int32>] [--chain-tip-stale-behavior-type <String>] [--tx-quota-per-signer <Int32>] [--maximum-poll-peers <Int32>] [--help] [--version]
+Usage: NineChronicles.Headless.Executable [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <UInt16>] [--swarm-private-key <String>] [--workers <Int32>] [--no-miner] [--miner-count <Int32>] [--miner-private-key <String>] [--store-type <String>] [--store-path <String>] [--no-reduce-store] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Int32>] [--rpc-remote-server] [--rpc-http-server] [--graphql-server] [--graphql-host <String>] [--graphql-port <Int32>] [--graphql-secret-token-path <String>] [--no-cors] [--confirmations <Int32>] [--nonblock-renderer] [--nonblock-renderer-queue <Int32>] [--strict-rendering] [--log-action-renders] [--network-type <NetworkType>] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--static-peer <String>...] [--skip-preload] [--minimum-broadcast-target <Int32>] [--bucket-size <Int32>] [--chain-tip-stale-behavior-type <String>] [--tx-quota-per-signer <Int32>] [--maximum-poll-peers <Int32>] [--config <String>] [--help] [--version]
 
 NineChronicles.Headless.Executable
 
@@ -35,14 +35,14 @@ Commands:
   genesis
 
 Options:
-  -V, --app-protocol-version <String>                      App protocol version token. (Required)
-  -G, --genesis-block-path <String>                        Genesis block path of blockchain. Blockchain is recognized by its genesis block. (Required)
+  -V, --app-protocol-version <String>                      App protocol version token.
+  -G, --genesis-block-path <String>                        Genesis block path of blockchain. Blockchain is recognized by its genesis block.
   -H, --host <String>                                      Hostname of this node for another nodes to access. This is not listening host like 0.0.0.0
   -P, --port <UInt16>                                      Port of this node for another nodes to access.
   --swarm-private-key <String>                             The private key used for signing messages and to specify your node. If you leave this null, a randomly generated value will be used.
-  --workers <Int32>                                        Number of workers to use in Swarm (Default: 5)
+  --workers <Int32>                                        Number of workers to use in Swarm
   --no-miner                                               Disable block mining.
-  --miner-count <Int32>                                    The number of miner task(thread). (Default: 1)
+  --miner-count <Int32>                                    The number of miner task(thread).
   --miner-private-key <String>                             The private key used for mining blocks. Must not be null if you want to turn on mining with libplanet-node.
   --store-type <String>                                    The type of storage to store blockchain data. If not provided, "LiteDB" will be used as default. Available type: ["rocksdb", "memory"]
   --store-path <String>                                    Path of storage. This value is required if you use persistent storage e.g. "rocksdb"
@@ -50,43 +50,52 @@ Options:
   -I, --ice-server <String>...                             ICE server to NAT traverse.
   --peer <String>...                                       Seed peer list to communicate to another nodes.
   -T, --trusted-app-protocol-version-signer <String>...    Trustworthy signers who claim new app protocol versions
-  --rpc-server                                             Run RPC server?
-  --rpc-listen-host <String>                               RPC listen host (Default: 0.0.0.0)
+  --rpc-server                                             Use this option if you want to make unity clients to communicate with this server with RPC
+  --rpc-listen-host <String>                               RPC listen host
   --rpc-listen-port <Int32>                                RPC listen port
   --rpc-remote-server                                      Do a role as RPC remote server? If you enable this option, multiple Unity clients can connect to your RPC server.
   --rpc-http-server                                        If you enable this option with "rpcRemoteServer" option at the same time, RPC server will use HTTP/1, not gRPC.
-  --graphql-server                                         Run GraphQL server?
-  --graphql-host <String>                                  GraphQL listen host (Default: 0.0.0.0)
+  --graphql-server                                         Use this option if you want to enable GraphQL server to enable querying data.
+  --graphql-host <String>                                  GraphQL listen host
   --graphql-port <Int32>                                   GraphQL listen port
   --graphql-secret-token-path <String>                     The path to write GraphQL secret token. If you want to protect this headless application, you should use this option and take it into headers.
   --no-cors                                                Run without CORS policy.
-  --confirmations <Int32>                                  The number of required confirmations to recognize a block. (Default: 0)
-  --nonblock-renderer                                      Uses non-blocking renderer, which prevents the blockchain & swarm from waiting slow rendering.  Turned off by default.
-  --nonblock-renderer-queue <Int32>                        The size of the queue used by the non-blocking renderer. Ignored if --nonblock-renderer is turned off. (Default: 512)
+  --confirmations <Int32>                                  The number of required confirmations to recognize a block.
+  --nonblock-renderer                                      Uses non-blocking renderer, which prevents the blockchain & swarm from waiting slow rendering. Turned off by default.
+  --nonblock-renderer-queue <Int32>                        The size of the queue used by the non-blocking renderer. Ignored if --nonblock-renderer is turned off.
   --strict-rendering                                       Flag to turn on validating action renderer.
-  --log-action-renders                                     Log action renders besides block renders.  --rpc-server implies this.
-  --network-type <NetworkType>                             Network type. (Default: Main) (Allowed values: Main, Internal, Permanent, Test, Default)
-  --dev                                                    Flag to turn on the dev mode.  false by default.
-  --dev.block-interval <Int32>                             The time interval between blocks. It's unit is milliseconds. Works only when dev mode is on. (Default: 10000)
-  --dev.reorg-interval <Int32>                             The size of reorg interval. Works only when dev mode is on. (Default: 0)
+  --log-action-renders                                     Log action renders besides block renders. --rpc-server implies this.
+  --network-type <NetworkType>                             Network type. (Allowed values: Main, Internal, Permanent, Test, Default)
+  --dev                                                    Flag to turn on the dev mode. false by default.
+  --dev.block-interval <Int32>                             The time interval between blocks. It's unit is milliseconds. Works only when dev mode is on.
+  --dev.reorg-interval <Int32>                             The size of reorg interval. Works only when dev mode is on.
   --aws-cognito-identity <String>                          The Cognito identity for AWS CloudWatch logging.
   --aws-access-key <String>                                The access key for AWS CloudWatch logging.
   --aws-secret-key <String>                                The secret key for AWS CloudWatch logging.
   --aws-region <String>                                    The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2).
-  --tx-life-time <Int32>                                   The lifetime of each transaction, which uses minute as its unit. (Default: 180)
-  --message-timeout <Int32>                                The grace period for new messages, which uses second as its unit. (Default: 60)
-  --tip-timeout <Int32>                                    The grace period for tip update, which uses second as its unit. (Default: 60)
-  --demand-buffer <Int32>                                  A number of block size that determines how far behind the demand the tip of the chain will publish `NodeException` to GraphQL subscriptions. (Default: 1150)
+  --tx-life-time <Int32>                                   The lifetime of each transaction, which uses minute as its unit.
+  --message-timeout <Int32>                                The grace period for new messages, which uses second as its unit.
+  --tip-timeout <Int32>                                    The grace period for tip update, which uses second as its unit.
+  --demand-buffer <Int32>                                  A number of block size that determines how far behind the demand the tip of the chain will publish `NodeException` to GraphQL subscriptions.
   --static-peer <String>...                                A list of peers that the node will continue to maintain.
   --skip-preload                                           Run node without preloading.
-  --minimum-broadcast-target <Int32>                       Minimum number of peers to broadcast message. (Default: 10)
-  --bucket-size <Int32>                                    Number of the peers can be stored in each bucket. (Default: 16)
-  --chain-tip-stale-behavior-type <String>                 Determines behavior when the chain's tip is stale. "reboot" and "preload" is available and "reboot" option is selected by default. (Default: reboot)
-  --tx-quota-per-signer <Int32>                            The number of maximum transactions can be included in stage per signer. (Default: 10)
-  --maximum-poll-peers <Int32>                             The maximum number of peers to poll blocks. int.MaxValue by default. (Default: 2147483647)
+  --minimum-broadcast-target <Int32>                       Minimum number of peers to broadcast message.
+  --bucket-size <Int32>                                    Number of the peers can be stored in each bucket.
+  --chain-tip-stale-behavior-type <String>                 Determines behavior when the chain's tip is stale. "reboot" and "preload" is available and "reboot" option is selected by default.
+  --tx-quota-per-signer <Int32>                            The number of maximum transactions can be included in stage per signer.
+  --maximum-poll-peers <Int32>                             The maximum number of peers to poll blocks. int.MaxValue by default.
+  -C, --config <String>                                    Absolute path of "appsettings.json" file to provide headless configurations. (Default: appsettings.json)
   -h, --help                                               Show help message
   --version                                                Show version
 ```
+
+### Use `appsettings.json` to provide CLI options
+
+You can provide headless CLI options using file, `appsettings.json`. You'll find the default file at [here](NineChronicles.Headless.Executable/appsettings.json).  
+The path of `appsettings.json` can be either local file storage or URL.  
+Refer full configuration fields from [this file](NineChronicles.Headless.Executable/Configuration.cs), set your options into `appsettings.json` under `Headless` section.  
+You can also run headless server with previous way; You don't need to change anything if you don't want to.  
+In case that the same option is provided from both `appsetting.json` and CLI option, the CLI option value is used instead from `appsettings.json`.  
 
 ## Docker Build
 


### PR DESCRIPTION
## Summary
Now we can use `appsettings.json` to run headless.
`appsettings.json` can be local file or web storage like S3.

## Problem
We have to pass a bunch of command line options to run headless server so far and this is very inconvenient work.

## Solution
Read headless launch options from `appsettings.json`.
The old CLI options are still alive and this will overwrite options from `appsettings.json`

---

Related issue: https://github.com/planetarium/NineChronicles.Headless/issues/1556