### PR TITLE
remove ListKeys method in `PruneStates`

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -333,15 +333,12 @@ namespace NineChronicles.Headless.Executable.Commands
                     -1);
             }
 
-            _console.Out.WriteLine("Counting keys in states store.");
-            var totalKeyCount = stateKeyValueStore.ListKeys().Count();
-            _console.Out.WriteLine($"Pruning States Start. Total Number of State Keys: {totalKeyCount}");
+            _console.Out.WriteLine($"Pruning States Start.");
             var start = DateTimeOffset.Now;
             stateStore.CopyStates(ImmutableHashSet<HashDigest<SHA256>>.Empty
                 .Add(snapshotTipStateRootHash), newStateStore);
-            var prunedKeyCount = totalKeyCount - newStateKeyValueStore.ListKeys().Count();
             var end = DateTimeOffset.Now;
-            _console.Out.WriteLine($"Pruning States Done. Pruned {prunedKeyCount} out of {totalKeyCount} keys.Time Taken: {end - start:g}");
+            _console.Out.WriteLine($"Pruning States Done.Time Taken: {end - start:g}");
             store.Dispose();
             stateStore.Dispose();
             newStateStore.Dispose();


### PR DESCRIPTION
This PR partially addresses https://github.com/planetarium/NineChronicles.Headless/issues/1575.

It removes the `stateKeyValueStore.ListKeys()` method which took really long (approximately 1 hour) when tested on a state store that's around 600GB.
This method is only used for debugging so it doesn't affect the actual command.