### PR TITLE
Make `transferNCGHistories` use common interface of `transfer_asset*` actions

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -123,12 +123,12 @@ namespace NineChronicles.Headless.GraphTypes
                         .Select(store.GetTransaction<NCAction>);
                     var filteredTransactions = txs.Where(tx =>
                         tx.CustomActions!.Count == 1 &&
-                        tx.CustomActions.First().InnerAction is TransferAsset transferAsset &&
+                        tx.CustomActions.First().InnerAction is ITransferAsset transferAsset &&
                         (!recipient.HasValue || transferAsset.Recipient == recipient) &&
                         transferAsset.Amount.Currency.Ticker == "NCG" &&
                         store.GetTxExecution(blockHash, tx.Id) is TxSuccess);
 
-                    TransferNCGHistory ToTransferNCGHistory(TxSuccess txSuccess, string memo)
+                    TransferNCGHistory ToTransferNCGHistory(TxSuccess txSuccess, string? memo)
                     {
                         var rawTransferNcgHistories = txSuccess.FungibleAssetsDelta.Select(pair =>
                                 (pair.Key, pair.Value.Values.First(fav => fav.Currency.Ticker == "NCG")))
@@ -148,7 +148,7 @@ namespace NineChronicles.Headless.GraphTypes
 
                     var histories = filteredTransactions.Select(tx =>
                         ToTransferNCGHistory((TxSuccess)store.GetTxExecution(blockHash, tx.Id),
-                            ((TransferAsset)tx.CustomActions!.Single().InnerAction).Memo));
+                            ((ITransferAsset)tx.CustomActions!.Single().InnerAction).Memo));
 
                     return histories;
                 });


### PR DESCRIPTION
There is a bug where the `query.transferNCGHistories` GraphQL query returns histories of the latest `transfer_asset*` action. That means it returns only `transfer_asset3`'s histories though `transfer_asset2` can be still used yet.

This pull request bumps Lib9c to use https://github.com/planetarium/lib9c/pull/1407 and applies it.