### PR TITLE
Introduce command `replay blocks`

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs
@@ -51,8 +51,7 @@ namespace NineChronicles.Headless.Executable.Commands
             [Option('v', Description = "Verbose mode.")]
             bool verbose = false,
             [Option('o', Description = "An path of output file.")]
-            string? outputPath = null
-        )
+            string outputPath = "")
         {
             var (outputFs, outputSw) =
                 GetOutputFileStream(outputPath, "replay-tx-output.log");
@@ -206,10 +205,13 @@ namespace NineChronicles.Headless.Executable.Commands
             [Option('e', Description = "Target end block height. Tip as default. (Min: 1)" +
                                        "If not set, same as START-INDEX.")]
             long? endIndex = null,
+            [Option('r', Description = "Repeat count. (Min: 1)" +
+                                       "If not set, default is 1.")]
+            int repeatCount = 1,
             [Option('v', Description = "Verbose mode.")]
             bool verbose = false,
             [Option('o', Description = "The path of output file.")]
-            string? outputPath = null)
+            string outputPath = "")
         {
             var (outputFs, outputSw) =
                 GetOutputFileStream(outputPath, "replay-blocks-output.log");
@@ -280,12 +282,12 @@ namespace NineChronicles.Headless.Executable.Commands
         }
 
         private static (FileStream? fs, StreamWriter? sw) GetOutputFileStream(
-            string? outputPath,
+            string outputPath,
             string defaultFileName)
         {
             FileStream? outputFs = null;
             StreamWriter? outputSw = null;
-            if (outputPath is null)
+            if (string.IsNullOrEmpty(outputPath))
             {
                 return (outputFs, outputSw);
             }

--- a/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -11,9 +12,9 @@ using Cocona.Help;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
 using Libplanet.RocksDBStore;
 using Libplanet.Store;
-using Libplanet.Store.Trie;
 using Libplanet.Tx;
 using Nekoyume.BlockChain.Policy;
 using NineChronicles.Headless.Executable.IO;
@@ -40,29 +41,22 @@ namespace NineChronicles.Headless.Executable.Commands
 
         [Command(Description = "Evaluate tx and calculate result state")]
         public int Tx(
-            [Argument("TX-PATH", Description = "A JSON file path of tx.")]
+            [Option('t', Description = "A JSON file path of tx.")]
             string txPath,
-            [Option("STORE-PATH", Description = "An absolute path of block storage.")]
+            [Option('s', Description = "An absolute path of block storage.(rocksdb)")]
             string storePath,
-            [Option("BLOCK-INDEX", Description = "Target block height to evaluate tx. Tip as default. (Min: 1)" +
-                                                 "If you set 100, using block 99 as previous state.")]
-            int blockIndex = 1,
-            [Option("VERBOSE", Description = "Verbose mode.")]
+            [Option('i', Description = "Target block height to evaluate tx. Tip as default. (Min: 1)" +
+                                       "If you set 100, using block 99 as previous state.")]
+            long blockIndex = 1,
+            [Option('v', Description = "Verbose mode.")]
             bool verbose = false,
-            [Option("OUTPUT-PATH", Description = "An absolute path of output file.")]
+            [Option('o', Description = "An path of output file.")]
             string? outputPath = null
         )
         {
-            FileStream? outputFs = null;
-            StreamWriter? outputSw = null;
-            if (outputPath is not null)
-            {
-                var fileName = Path.GetFileName(outputPath);
-                Directory.CreateDirectory(outputPath.Replace(fileName, string.Empty));
-                outputFs = new FileStream(outputPath, FileMode.Create);
-                outputSw = new StreamWriter(outputFs);
-            }
-
+            var (outputFs, outputSw) =
+                GetOutputFileStream(outputPath, "replay-tx-output.log");
+            var disposables = new List<IDisposable?> { outputFs, outputSw };
             try
             {
                 if (blockIndex < 1)
@@ -73,69 +67,14 @@ namespace NineChronicles.Headless.Executable.Commands
                     );
                 }
 
-                // Read json file and parse to transaction.
-                using var stream = new FileStream(txPath, FileMode.Open);
-                stream.Seek(0, SeekOrigin.Begin);
-                var bytes = new byte[stream.Length];
-                while (stream.Position < stream.Length)
-                {
-                    bytes[stream.Position] = (byte)stream.ReadByte();
-                }
-
-                var converter = new BencodexJsonConverter();
-                var txReader = new Utf8JsonReader(bytes);
-                var txValue = converter.Read(
-                    ref txReader,
-                    typeof(object),
-                    new JsonSerializerOptions());
-                if (txValue is not Dictionary txDict)
-                {
-                    throw new CommandExitedException(
-                        $"The given json file, {txPath} is not a transaction.",
-                        -1);
-                }
-
-                var tx = new Transaction<NCAction>(txDict);
+                var tx = LoadTx(txPath);
                 var msg = $"tx id: {tx.Id}";
                 _console.Out.WriteLine(msg);
                 outputSw?.WriteLine(msg);
 
-                // Load store and genesis block.
-                if (!Directory.Exists(storePath))
-                {
-                    throw new CommandExitedException($"The given STORE-PATH, {storePath} does not found.", -1);
-                }
-
-                var store = StoreType.RocksDb.CreateStore(storePath);
-                if (store.GetCanonicalChainId() is not { } chainId)
-                {
-                    throw new CommandExitedException($"There is no canonical chain: {storePath}", -1);
-                }
-
-                var genesisBlockHash = store.IndexBlockHash(chainId, 0) ??
-                                       throw new CommandExitedException(
-                                           $"The given blockIndex {0} does not found", -1);
-                var genesisBlock = store.GetBlock<NCAction>(genesisBlockHash);
-                if (verbose)
-                {
-                    msg = $"genesis block hash: {genesisBlock.Hash}";
-                    _console.Out.WriteLine(msg);
-                    outputSw?.WriteLine(msg);
-                }
-
-                // Make BlockChain and blocks.
-                var policy = new BlockPolicy<NCAction>();
-                var stagePolicy = new VolatileStagePolicy<NCAction>();
-                IKeyValueStore stateKeyValueStore = new RocksDBKeyValueStore(Path.Combine(storePath, "states"));
-                var stateStore = new TrieStateStore(stateKeyValueStore);
-                var blockChain = new BlockChain<NCAction>(
-                    policy,
-                    stagePolicy,
-                    store,
-                    stateStore,
-                    genesisBlock,
-                    renderers: new[] { new BlockPolicySource(Logger.None).BlockRenderer });
-
+                var (store, stateStore, blockChain) = LoadBlockchain(storePath);
+                disposables.Add(store);
+                disposables.Add(stateStore);
                 var previousBlock = blockChain[blockIndex - 1];
                 var targetBlock = blockChain[blockIndex];
                 if (verbose)
@@ -150,15 +89,25 @@ namespace NineChronicles.Headless.Executable.Commands
 
                 // Evaluate tx.
                 IAccountStateDelta previousStates = new AccountStateDeltaImpl(
-                    addresses => blockChain.GetStates(addresses, previousBlock.Hash),
-                    (address, currency) => blockChain.GetBalance(address, currency, previousBlock.Hash),
-                    currency => blockChain.GetTotalSupply(currency, previousBlock.Hash),
+                    addresses => blockChain.GetStates(
+                        addresses,
+                        previousBlock.Hash,
+                        StateCompleters<NCAction>.Reject),
+                    (address, currency) => blockChain.GetBalance(
+                        address,
+                        currency,
+                        previousBlock.Hash,
+                        FungibleAssetStateCompleters<NCAction>.Reject),
+                    currency => blockChain.GetTotalSupply(
+                        currency,
+                        previousBlock.Hash,
+                        TotalSupplyStateCompleters<NCAction>.Reject),
                     tx.Signer);
                 var actions = tx.SystemAction is { } sa
                     ? ImmutableList.Create(sa)
                     : ImmutableList.CreateRange(tx.CustomActions!.Cast<IAction>());
                 var actionEvaluations = EvaluateActions(
-                    genesisHash: genesisBlockHash,
+                    genesisHash: blockChain.Genesis.Hash,
                     preEvaluationHash: targetBlock.PreEvaluationHash,
                     blockIndex: blockIndex,
                     txid: tx.Id,
@@ -221,7 +170,6 @@ namespace NineChronicles.Headless.Executable.Commands
                             msg = $"- action #{actionNum} updated address #{addressNum}({updatedAddress}) end..";
                             _console.Out.WriteLine(msg);
                             outputSw?.WriteLine(msg);
-                            break;
                         }
 
                         addressNum++;
@@ -240,9 +188,106 @@ namespace NineChronicles.Headless.Executable.Commands
             }
             finally
             {
-                outputSw?.Dispose();
-                outputFs?.Dispose();
+                foreach (var disposable in disposables)
+                {
+                    disposable?.Dispose();
+                }
+
+                disposables.Clear();
             }
+        }
+
+        private static (FileStream? fs, StreamWriter? sw) GetOutputFileStream(
+            string? outputPath,
+            string defaultFileName)
+        {
+            FileStream? outputFs = null;
+            StreamWriter? outputSw = null;
+            if (outputPath is null)
+            {
+                return (outputFs, outputSw);
+            }
+
+            var fileName = Path.GetFileName(outputPath);
+            if (string.IsNullOrEmpty(fileName))
+            {
+                fileName = defaultFileName;
+                outputPath = Path.Combine(outputPath, fileName);
+            }
+
+            Directory.CreateDirectory(outputPath.Replace(fileName, string.Empty));
+            outputFs = new FileStream(outputPath, FileMode.Create);
+            outputSw = new StreamWriter(outputFs);
+
+            return (outputFs, outputSw);
+        }
+
+        private (
+            IStore store,
+            IStateStore stateStore,
+            BlockChain<NCAction> blockChain) LoadBlockchain(string storePath)
+        {
+            // Load store and genesis block.
+            if (!Directory.Exists(storePath))
+            {
+                throw new CommandExitedException(
+                    $"The given STORE-PATH, {storePath} does not found.",
+                    -1);
+            }
+
+            var store = StoreType.RocksDb.CreateStore(storePath);
+            if (store.GetCanonicalChainId() is not { } chainId)
+            {
+                throw new CommandExitedException(
+                    $"There is no canonical chain: {storePath}",
+                    -1);
+            }
+
+            var genesisBlockHash = store.IndexBlockHash(chainId, 0) ??
+                                   throw new CommandExitedException(
+                                       $"The given blockIndex {0} does not found", -1);
+            var genesisBlock = store.GetBlock<NCAction>(genesisBlockHash);
+
+            // Make BlockChain and blocks.
+            var policy = new BlockPolicySource(Logger.None).GetPolicy();
+            var stagePolicy = new VolatileStagePolicy<NCAction>();
+            var stateKeyValueStore = new RocksDBKeyValueStore(Path.Combine(storePath, "states"));
+            var stateStore = new TrieStateStore(stateKeyValueStore);
+            return (
+                store,
+                stateStore,
+                new BlockChain<NCAction>(
+                    policy,
+                    stagePolicy,
+                    store,
+                    stateStore,
+                    genesisBlock));
+        }
+
+        private Transaction<NCAction> LoadTx(string txPath)
+        {
+            using var stream = new FileStream(txPath, FileMode.Open);
+            stream.Seek(0, SeekOrigin.Begin);
+            var bytes = new byte[stream.Length];
+            while (stream.Position < stream.Length)
+            {
+                bytes[stream.Position] = (byte)stream.ReadByte();
+            }
+
+            var converter = new BencodexJsonConverter();
+            var txReader = new Utf8JsonReader(bytes);
+            var txValue = converter.Read(
+                ref txReader,
+                typeof(object),
+                new JsonSerializerOptions());
+            if (txValue is not Dictionary txDict)
+            {
+                throw new CommandExitedException(
+                    $"The given json file, {txPath} is not a transaction.",
+                    -1);
+            }
+
+            return new Transaction<NCAction>(txDict);
         }
     }
 }


### PR DESCRIPTION
This pull request resolves #1632.

The `replay` command has the `blocks` commend inside.
You can replay blocks!

## `replay blocks`

```cs
[Command(Description = "Evaluate blocks and check state root hash")]
public int Blocks(
    [Option('s', Description = "An absolute path of block storage.(rocksdb)")]
    string storePath,
    [Option('i', Description = "Target start block height. Tip as default. (Min: 1)")]
    long startIndex = 1,
    [Option('e', Description = "Target end block height. Tip as default. (Min: 1)" +
                               "If not set, same as START-INDEX.")]
    long? endIndex = null,
    [Option('r', Description = "Repeat count. (Min: 1)" +
                               "If not set, default is 1.")]
    int repeatCount = 1,
    [Option('v', Description = "Verbose mode.")]
    bool verbose = false,
    [Option('o', Description = "The path of output file.")]
    string outputPath = "")
{
    //
}
```

## How to use

```bash
dotnet run -- replay blocks \
-s {blockchain store path} \
-i {start block index} \
-e {end block index} \
-r {repeat count} \
-v {verbose} \
-o {output path}
```

## Test example

- Test store: `s3://AKIAUU3S3PEZCDQF47SF@9c-snapshots.s3.ap-northeast-2.amazonaws.com?region=ap-northeast-2/9c-test/seungmin/9c-snapshots/9c-main-partition_20221021_hyeon.7z`

### Example case 1

In this case, replay blocks from 5,214,601 to 5,214,602 with repeating 3 times for each block. And success to replay all blocks.

Input

```bash
$ dotnet run -- replay blocks \
-s /Users/seungmin/Downloads/FileZilla/9c-snapshots/9c-main-partition_20221021_hyeon \
-i 5214601 \
-e 5214602 \
-r 3
```

Output without `-v`

```text
Replay blocks start from #5214601 to #5214602.(range: 2, repeat: 3)
Replay blocks end successfully.
```

Output with `-v`: [replay-blocks-output.log](https://github.com/planetarium/NineChronicles.Headless/files/9908624/replay-blocks-output.log)

### Example case 2

In this case, replay blocks from 5,214,601 to 5,214,610 with repeating 2 times for each block. And success to replay from 5,214,601 to 5,214,603 and failure in 5,214,604 with `InvalidBlockStateRootHashException`.

Input

```bash
$ dotnet run -- replay blocks \
-s /Users/seungmin/Downloads/FileZilla/9c-snapshots/9c-main-partition_20221021_hyeon \
-i 5214601 \
-e 5214610 \
-r 2
```

Output without `-v`

```text
Replay blocks start from #5214601 to #5214610.(range: 10, repeat: 2)
Libplanet.Blocks.InvalidBlockStateRootHashException: Block #5214604 3ef7eeafbbaf0de24597b10e06324129b6bdfd9f3d57ecff2d53cfa52e6cbd5a's state root hash is febbfb93434eb83a4337f5ae1875a6da5f879f9d3ed20dd478cb301a6db030ef, but the execution result is e332b7d237eab995f340cf4c44c409d4cacf194aee4ec758dfb2d1ab0763b657.
   at Libplanet.Blockchain.BlockChain`1.ExecuteActions(Block`1 block, Nullable`1 stateCompleters) in /Users/seungmin/Repositories/9c-launcher/NineChronicles.Headless/Lib9c/.Libplanet/Libplanet/Blockchain/BlockChain.cs:line 918
   at NineChronicles.Headless.Executable.Commands.ReplayCommand.Blocks(String storePath, Int64 startIndex, Nullable`1 endIndex, Int32 repeatCount, Boolean verbose, String outputPath) in /Users/seungmin/Repositories/9c-launcher/NineChronicles.Headless/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs:line 286
Replay blocks end with exception.
```

Output with `-v`: [replay-blocks-output.log](https://github.com/planetarium/NineChronicles.Headless/files/9908613/replay-blocks-output.log)

Compare to mainnet

| num | tx id in output | tx status on mainnet | has exception in output |
| --: | :-: | :-: | :-: |
| 1 | 9454b9b147e62444f5d355df17178ebfb8469927498340da9333551707169498 | SUCCESS | x |
| 2 | 682fc6ceae609dd2641f4d680281312f34d0742acdd106be672e086a2dc01821 | FAILURE | o |
| 3 | 5d3b21d6dc9a68af30f5184a140421787b4899bb18401fbc2756d21cb45ef47b | SUCCESS | x |
| 4 | ac982dddb105f7062f79ee3814d55f52640e7242eeb04ca7f9ebb40f85af0cf0 | SUCCESS | x |
| 5 | b0579304dbfe8959b5e3d8523a7a1b6052b03a3649133255604e7eeadcb769d9 | FAILURE | o |
| 6 | a63c5f4e51541ace603d660a2269a0945fe4fd736e0b1d010362675c90ea83a1 | FAILURE | o |
| 7 | 55db9e62357fdf2b847e06bf907f73e8ee22c9a1e61d2ed431ea764ede5f843c | SUCCESS | x |
| 8 | 49f0e3352e20f0aaafbe337703448ce3007225386fba894987a1fd5daf119d17  | FAILURE | o |
| 9 | 4ec2d35e8e11f9f62e3e095c9393abd04d472d8aef3166185fec92edd9a26cab  | FAILURE | o |
| 10 | 8a47e9364ad346dde5501aec4bf10a64a8f7db8f09fc8ea1bfad9f5304d502f3  | FAILURE | o |
| 11 | 6e3feb893bb92a97593c5ec05fc589863cb6d61b0f4b048d54c7ee04d606826d | FAILURE | o |
| 12 | 6df9fb3379211d72294719efe3a56bef23b19f06c42ef9a2d81854fcbdb447ee | SUCCESS | x |
| 13 | 8975a00cba0e26e0eb0d25fee1d3192bca4c9cd0939613892a1fa7252e6a31d3 | SUCCESS | x |
| 14 | 2936ccb6d0218100e51013e5a546354778b77bd13897f16313e4a033e429f1cf | FAILURE | o |
| 15 | e7be4ec9b328e37e1a3413bc9e1cdc6b5bd665aa86217c1d40bf9248027a6795 | FAILURE | o |
| 16 | bddafdd88e3a0a9742966d29fe33a7fb835b9f9f9ed713ccca8fa34f46654946 | FAILURE | o |
| 17 | 7fb7a7ed49c8915253f43a59ebabcd74ff5f2386e04149d4515603ab8952540d | SUCCESS | x |
| 18 | fc1e86345854bc73e870665fa80776d474516e6659e42877e5607970d3d424d1 | SUCCESS | x |
| 19 | 4db0cb86a377fce756a12e568c686d2d51d95a8b89bc41e9df601e3765d76e5e | SUCCESS | x |
| 20 | 5a8073cfe38d2265e32f3ed74ba19cc91decac24cd1aa98ae9bed416e89e5a29 | SUCCESS | x |
| 21 | 443be308b2eef45c90d4ff2da706a17d7824228f17e4cc014557d7c5dea0d181 | SUCCESS | x |
| 22 | bf74d4ba43c5b7fae49b6ba9beea8c182a4dead5a2ad9abcf9f1b0c8d081956f | SUCCESS | x |
| 23 | 76b2925c8fe9d6ffb1ebb35264759afe166e606cf4a4c222a7dedb86107068b8 | SUCCESS | x |
| 24 | 6609a7f58a7a158ecb0d943655a4bb6adfaac0c97ee907ad9907297939126886 | FAILURE | o |
| 25 | 60aa077f33f5276e8ee8518e40e7c4d648b3351283fa2943a0fb43d16fd4406c | SUCCESS | x |
| 26 | c83ac694d8100d604685b1be333919a02e2106f698523c8065df6db7790ac54f | FAILURE | o |
| 27 | 54e29fb7bc4c3bf346d05557226b13a7b887f29759508a5dee25f466d5ad7268 | FAILURE | o |
| 28 | 443539e48ff1cf4d0d8c33161e63e4b550d3775671a63ca15947d64bf6b5f03f | SUCCESS | x |
| 29 | ca036e4e81b0bc3c4bbd0569761b13979b76652801ce825c308778fbbb4d7585 | SUCCESS | x |
| 30 | a0c2a14582328bafa1ea0bda3b072b1259dc78249ca457e53952f4a06d017691 | SUCCESS | x |
| 31 | fb8f4651c3c27fbbbfe8978296a3d10c262ea11b50708cfb6d3e42245a9a8e30 | FAILURE | o |
| 32 | 355c7c70aefb3edf3579ea2868ed4d0ee0f54fa3f72cb752596eb72b4887935b | SUCCESS | x |
| 33 | ba9e9dc719af984b8639076f51dbb2de8aaa4fb3fed4fa4871694feb4e584e3f | SUCCESS | x |
| 34 | 1d672469e05dd0f983016f2c2c8cfad88745bd0c4b90ec75d32e4a80464f29c1 | SUCCESS | x |
| 35 | 76e2a6e9f16346c54ff13429c2dfdf608b2a9c1e6c9cdc65dac1808a5ae1f4f9 | SUCCESS | x |
| 36 | 1187c6766d20b89708742e5402599a286db68b0465ddb68de11118bd6b6268f1 | SUCCESS | x |
| 37 | b5a6bf3f40b865b7baed3a7d268b5519ba38032e0c8e75a71be4049609ca13e9 | SUCCESS | x |
| 38 | 5102d5c3d5025de12412aa124df8f87518a077cf9aba46f7da1b7734a99e166b | SUCCESS | x |
| 39 | afe33ee6ac21620ae3d7f8de33edbfb0e0d7d23fe748bfba1b9d51ef10b4a309 | FAILURE | o |
| 40 | null("RewardGold") |||

### Example case 3

In this case, replay block 4,001,014 without repeating. And failure with `UnexpectedlyTerminatedActionException(IncompleteBlockStatesException)` in each `ActionEvaluation<T>`.

Input

```bash
$ dotnet run -- replay blocks \
-s /Users/seungmin/Downloads/FileZilla/9c-snapshots/9c-main-partition_20221021_hyeon \
-i 4001014
```

Output without `-v`

```text
Replay blocks start from #4001014 to #4001014.(range: 1, repeat: 1)
Libplanet.Blocks.InvalidBlockStateRootHashException: Block #4001014 2ab8ea908de56f484fe332396c99b16629321511eba3afce2dae16ca1573c148's state root hash is 0e264d9170676a2472278c23b8bd27d233d6bb06f5a2aa4aefcf2cc39336e361, but the execution result is 61cdee84fb562c6d6fc02c885ecbe929b1df76a348a3001e8ae743b5e490fc1b.
   at Libplanet.Blockchain.BlockChain`1.ExecuteActions(Block`1 block, Nullable`1 stateCompleters) in /Users/seungmin/Repositories/9c-launcher/NineChronicles.Headless/Lib9c/.Libplanet/Libplanet/Blockchain/BlockChain.cs:line 918
   at NineChronicles.Headless.Executable.Commands.ReplayCommand.Blocks(String storePath, Int64 startIndex, Nullable`1 endIndex, Int32 repeatCount, Boolean verbose, String outputPath) in /Users/seungmin/Repositories/9c-launcher/NineChronicles.Headless/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs:line 286
Replay blocks end with exception.
```

Output with `-v`: [replay-blocks-output.log](https://github.com/planetarium/NineChronicles.Headless/files/9908626/replay-blocks-output.log)

Compare to mainnet

| num | tx id in output | tx status on mainnet | has exception in output |
| --: | :-: | :-: | :-: |
| 1 | 2ccb4b9345f10bea77dbce6e3034e7982ebc6073e51639a2bd79b1d7eacf788b | INVALID | o |
| 2 | 657c6bae70cc3f26e2f6fc947c4d36c65a4688f37f626b88c4d136c3a5b31cf9 | INVALID | o |
| 3 | 95858ee692c42e49fef778e7a0d51060ab3ccbbfd177c75de099560f54d04cdc | INVALID | o |
| 4 | 5448ca56cf240e6a204d679fd604e2d09fa75727b0ec04b8cf2f545f5a64f82a | INVALID | o |
| 5 | null("RewardGold") | | |

> What is the INVALID status?