### PR TITLE
Throttle DAP subscription

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -75,6 +75,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             StandaloneContextFx = new StandaloneContext
             {
                 KeyStore = keyStore,
+                DifferentAppProtocolVersionEncounterInterval = TimeSpan.FromSeconds(1),
             };
             ncService.ConfigureContext(StandaloneContextFx);
 

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -172,9 +172,13 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             var apv1 = AppProtocolVersion.Sign(apvPrivateKey, 1);
             var apv2 = AppProtocolVersion.Sign(apvPrivateKey, 0);
             var peer = new BoundPeer(apvPrivateKey.PublicKey, new DnsEndPoint("0.0.0.0", 0));
-            StandaloneContextFx.DifferentAppProtocolVersionEncounterSubject.OnNext(
-                new DifferentAppProtocolVersionEncounter(peer, apv1, apv2)
-            );
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                StandaloneContextFx.DifferentAppProtocolVersionEncounterSubject.OnNext(
+                    new DifferentAppProtocolVersionEncounter(peer, apv1, apv2)
+                );
+            });
             var rawEvents = await stream.Take(1);
             var rawEvent = (Dictionary<string, object>)((ExecutionNode)rawEvents.Data!).ToValue()!;
             var differentAppProtocolVersionEncounter =

--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -137,7 +137,10 @@ namespace NineChronicles.Headless.GraphTypes
                 Resolver = new FuncFieldResolver<DifferentAppProtocolVersionEncounter>(context =>
                     (DifferentAppProtocolVersionEncounter)context.Source!),
                 Subscriber = new EventStreamResolver<DifferentAppProtocolVersionEncounter>(context =>
-                    StandaloneContext.DifferentAppProtocolVersionEncounterSubject.AsObservable()),
+                    StandaloneContext.DifferentAppProtocolVersionEncounterSubject
+                        .Sample(standaloneContext.DifferentAppProtocolVersionEncounterInterval)
+                        .AsObservable()
+                    ),
             });
             AddField(new EventStreamFieldType
             {

--- a/NineChronicles.Headless/StandaloneContext.cs
+++ b/NineChronicles.Headless/StandaloneContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Reactive.Subjects;
 using Libplanet;
@@ -22,8 +23,8 @@ namespace NineChronicles.Headless
         public bool IsMining { get; set; }
         public ReplaySubject<NodeStatusType> NodeStatusSubject { get; } = new ReplaySubject<NodeStatusType>();
         public ReplaySubject<PreloadState> PreloadStateSubject { get; } = new ReplaySubject<PreloadState>();
-        public ReplaySubject<DifferentAppProtocolVersionEncounter> DifferentAppProtocolVersionEncounterSubject { get; }
-            = new ReplaySubject<DifferentAppProtocolVersionEncounter>();
+        public Subject<DifferentAppProtocolVersionEncounter> DifferentAppProtocolVersionEncounterSubject { get; }
+            = new Subject<DifferentAppProtocolVersionEncounter>();
         public ReplaySubject<Notification> NotificationSubject { get; } = new ReplaySubject<Notification>(1);
         public ReplaySubject<NodeException> NodeExceptionSubject { get; } = new ReplaySubject<NodeException>();
         public ReplaySubject<MonsterCollectionState> MonsterCollectionStateSubject { get; } = new ReplaySubject<MonsterCollectionState>();
@@ -44,5 +45,7 @@ namespace NineChronicles.Headless
         };
 
         public IStore? Store { get; internal set; }
+
+        internal TimeSpan DifferentAppProtocolVersionEncounterInterval { get; set; } = TimeSpan.FromSeconds(30);
     }
 }


### PR DESCRIPTION
This PR adds `.Sample()` operator on `StandaloneContext.DifferentAppProtocolVersionEncounterSubject` to throttle events.