### PR TITLE
Release v100321-3

### DIFF
--- a/NineChronicles.Headless/GraphTypes/NodeStatus.cs
+++ b/NineChronicles.Headless/GraphTypes/NodeStatus.cs
@@ -10,12 +10,20 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Headless.GraphTypes
 {
     public class NodeStatusType : ObjectGraphType<NodeStatusType>
     {
+        private static readonly string _productVersion =
+            Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown";
+
+        private static readonly string _informationalVersion =
+            Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion ?? "Unknown";
+
         public bool BootstrapEnded { get; set; }
 
         public bool PreloadEnded { get; set; }
@@ -129,6 +137,24 @@ namespace NineChronicles.Headless.GraphTypes
             Field<AppProtocolVersionType>(
                 "appProtocolVersion",
                 resolve: _ => context.NineChroniclesNodeService?.Swarm.AppProtocolVersion);
+
+            Field<ListGraphType<AddressType>>(
+                name: "subscriberAddresses",
+                description: "A list of subscribers' address",
+                resolve: _ => context.AgentAddresses.Keys
+            );
+
+            Field<StringGraphType>(
+                name: "productVersion",
+                description: "A version of NineChronicles.Headless",
+                resolve: _ => _productVersion
+            );
+
+            Field<StringGraphType>(
+                name: "informationalVersion",
+                description: "A informational version (a.k.a. version suffix) of NineChronicles.Headless",
+                resolve: _ => _informationalVersion
+            );
         }
 
         private IEnumerable<Block<T>> GetTopmostBlocks<T>(BlockChain<T> blockChain, int offset)

--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -23,6 +23,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using NineChronicles.Headless.GraphTypes.States;
 using Libplanet.Blockchain;
+using Serilog;
 
 namespace NineChronicles.Headless.GraphTypes
 {
@@ -301,6 +302,10 @@ namespace NineChronicles.Headless.GraphTypes
                     $"{nameof(StandaloneContext.NineChroniclesNodeService)} is null.");
             }
 
+            var sw = new System.Diagnostics.Stopwatch();
+            sw.Start();
+            Log.Debug("StandaloneSubscription.RenderBlock started");
+
             BlockChain<PolymorphicAction<ActionBase>> blockChain = StandaloneContext.NineChroniclesNodeService.BlockChain;
             Currency currency =
                 new GoldCurrencyState(
@@ -312,6 +317,7 @@ namespace NineChronicles.Headless.GraphTypes
                 _tipHeader.Hash
             ).ToDotnetString();
             rewardSheet.Set(csv);
+            Log.Debug($"StandaloneSubscription.RenderBlock target addresses. (count: {StandaloneContext.AgentAddresses.Count})");
             foreach (var (address, subjects) in StandaloneContext.AgentAddresses)
             {
                 FungibleAssetValue agentBalance = blockChain.GetBalance(address, currency, _tipHeader.Hash);
@@ -340,6 +346,9 @@ namespace NineChronicles.Headless.GraphTypes
                     }
                 }
             }
+            
+            sw.Stop();
+            Log.Debug($"StandaloneSubscription.RenderBlock ended. elapsed: {sw.Elapsed}");
         }
 
         private void RenderMonsterCollectionStateSubject<T>(ActionBase.ActionEvaluation<T> eval)


### PR DESCRIPTION
This PR is a hotfix to address delayed block sync due to #1695 and #1694 .  it isn't a direct fix but it loosens a delay by GQL subscriptions via the two below approaches.

1. Specifies rendering thread for subscriptions in `StandaloneSubscription`, using `ObserveOn()`.
2. In `StandaloneSubscription.RenderBlock`, it introduces `AsParallel()` and `ForAll()` to enable parallelism.

Also, it adds a GQL query to debug this symptom and maintain versions.