### PR TITLE
Introduce Sentry Tracing on Action Execute

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -112,6 +112,10 @@ namespace NineChronicles.Headless.Executable.Commands
                     _console.Out.WriteLine("Admin address not provided. Give admin privilege to initialMinter");
                     adminState = new AdminState(initialMinter.ToAddress(), config.Value.ValidUntil);
                 }
+                else
+                {
+                    adminState = new AdminState(new Address(config.Value.Address), config.Value.ValidUntil);
+                }
             }
             else
             {

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -78,6 +78,8 @@ namespace NineChronicles.Headless.Executable
         public int TxQuotaPerSigner { get; set; } = 10;
         public int MaximumPollPeers { get; set; } = int.MaxValue;
 
+        public string SentryDsn { get; set; } = "";
+
         public double SentryTraceSampleRate { get; set; } = 0.1;
 
         public void Overwrite(
@@ -124,6 +126,7 @@ namespace NineChronicles.Headless.Executable
             string? chainTipStaleBehaviorType,
             int? txQuotaPerSigner,
             int? maximumPollPeers,
+            string? sentryDsn,
             double? sentryTraceSampleRate
         )
         {
@@ -171,6 +174,7 @@ namespace NineChronicles.Headless.Executable
             ChainTipStaleBehaviorType = chainTipStaleBehaviorType ?? ChainTipStaleBehaviorType;
             TxQuotaPerSigner = txQuotaPerSigner ?? TxQuotaPerSigner;
             MaximumPollPeers = maximumPollPeers ?? MaximumPollPeers;
+            SentryDsn = sentryDsn ?? SentryDsn;
             SentryTraceSampleRate = sentryTraceSampleRate ?? SentryTraceSampleRate;
         }
     }

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -80,7 +80,7 @@ namespace NineChronicles.Headless.Executable
 
         public string SentryDsn { get; set; } = "";
 
-        public double SentryTraceSampleRate { get; set; } = 0.1;
+        public double SentryTraceSampleRate { get; set; } = 0.01;
 
         public void Overwrite(
             string? appProtocolVersionString,

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -78,6 +78,8 @@ namespace NineChronicles.Headless.Executable
         public int TxQuotaPerSigner { get; set; } = 10;
         public int MaximumPollPeers { get; set; } = int.MaxValue;
 
+        public double SentryTraceSampleRate { get; set; } = 0.1;
+
         public void Overwrite(
             string? appProtocolVersionString,
             string[]? trustedAppProtocolVersionSignerStrings,
@@ -121,7 +123,8 @@ namespace NineChronicles.Headless.Executable
             int? bucketSize,
             string? chainTipStaleBehaviorType,
             int? txQuotaPerSigner,
-            int? maximumPollPeers
+            int? maximumPollPeers,
+            double? sentryTraceSampleRate
         )
         {
             AppProtocolVersionString = appProtocolVersionString ?? AppProtocolVersionString;
@@ -168,6 +171,7 @@ namespace NineChronicles.Headless.Executable
             ChainTipStaleBehaviorType = chainTipStaleBehaviorType ?? ChainTipStaleBehaviorType;
             TxQuotaPerSigner = txQuotaPerSigner ?? TxQuotaPerSigner;
             MaximumPollPeers = maximumPollPeers ?? MaximumPollPeers;
+            SentryTraceSampleRate = sentryTraceSampleRate ?? SentryTraceSampleRate;
         }
     }
 }

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
     <PackageReference Include="Sentry.Serilog" Version="3.23.0" />
-    <PackageReference Include="HaemmerElectronics.SeppPenner.Serilog.Sinks.AmazonS3" Version="1.1.3" />
     <PackageReference Include="Sentry" Version="3.23.0" />
     <PackageReference Include="Sentry.AspNetCore.Grpc" Version="3.22.0" />
     <PackageReference Include="Sentry.DiagnosticSource" Version="3.22.0" />

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -13,8 +13,12 @@
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
-    <PackageReference Include="Sentry.Serilog" Version="2.1.*" />
-    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
+    <PackageReference Include="Sentry.Serilog" Version="3.23.0" />
+    <PackageReference Include="HaemmerElectronics.SeppPenner.Serilog.Sinks.AmazonS3" Version="1.1.3" />
+    <PackageReference Include="Sentry" Version="3.23.0" />
+    <PackageReference Include="Sentry.AspNetCore.Grpc" Version="3.22.0" />
+    <PackageReference Include="Sentry.DiagnosticSource" Version="3.22.0" />
+    <PackageReference Include="Serilog.Expressions" Version="1.1.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blocks;
@@ -235,9 +236,11 @@ namespace NineChronicles.Headless.Executable
             {
                 o.SendDefaultPii = true;
                 o.Dsn = headlessConfig.SentryDsn;
-                // TODO: o.Release 설정하면 좋을 것 같은데 빌드 버전 체계가 아직 없어서 어떻게 해야 할 지...
+                // TODO: We need to specify `o.Release` after deciding the version scheme.
                 // https://docs.sentry.io/workflow/releases/?platform=csharp
                 //o.Debug = true;
+                o.Release = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion ?? "Unknown";
                 o.SampleRate = headlessConfig.SentryTraceSampleRate > 0
                     ? (float)headlessConfig.SentryTraceSampleRate
                     : 0.01f;
@@ -368,7 +371,7 @@ namespace NineChronicles.Headless.Executable
                 hostBuilder.ConfigureServices(services =>
                 {
                     services.AddSingleton(_ => standaloneContext);
-                    services.AddSingleton(_ => new ConcurrentDictionary<string, ITransaction>());
+                    services.AddSingleton<ConcurrentDictionary<string, ITransaction>>();
                 });
                 hostBuilder.UseNineChroniclesNode(nineChroniclesProperties, standaloneContext);
                 if (headlessConfig.RpcServer)

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -247,6 +247,12 @@ namespace NineChronicles.Headless.Executable
                 o.AddExceptionFilterForType<CommunicationFailException>();
                 o.AddExceptionFilterForType<InvalidBlockIndexException>();
             });
+
+            // Set global tag
+            SentrySdk.ConfigureScope(scope =>
+            {
+                scope.SetTag("host", headlessConfig.Host ?? "no-host");
+            });
 #endif
 
             // Clean-up previous temporary log files.

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -204,7 +204,7 @@ namespace NineChronicles.Headless.Executable
             {
                 configurationBuilder.AddJsonFile(configPath);
             }
-            
+
             // Setup logger.
             var configuration = configurationBuilder.Build();
             var loggerConf = new LoggerConfiguration()
@@ -365,7 +365,8 @@ namespace NineChronicles.Headless.Executable
                     services.AddSingleton(_ => new ConcurrentDictionary<string, ITransaction>());
                 });
                 hostBuilder.UseNineChroniclesNode(nineChroniclesProperties, standaloneContext);
-                if (headlessConfig.RpcServer) {
+                if (headlessConfig.RpcServer)
+                {
                     hostBuilder.UseNineChroniclesRPC(
                         NineChroniclesNodeServiceProperties
                             .GenerateRpcNodeServiceProperties(

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -22,6 +22,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+// import necessary for sentry exception filters
 using Libplanet.Blocks;
 using Libplanet.Net.Transports;
 

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -361,8 +361,7 @@ namespace NineChronicles.Headless.Executable
                     services.AddSingleton(_ => new ConcurrentDictionary<string, ITransaction>());
                 });
                 hostBuilder.UseNineChroniclesNode(nineChroniclesProperties, standaloneContext);
-                if (headlessConfig.RpcServer)
-                {
+                if (headlessConfig.RpcServer) {
                     hostBuilder.UseNineChroniclesRPC(
                         NineChroniclesNodeServiceProperties
                             .GenerateRpcNodeServiceProperties(

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -21,6 +21,8 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Libplanet.Blocks;
+using Libplanet.Net.Transports;
 
 namespace NineChronicles.Headless.Executable
 {
@@ -242,6 +244,8 @@ namespace NineChronicles.Headless.Executable
                 o.TracesSampleRate = headlessConfig.SentryTraceSampleRate;
                 o.AddExceptionFilterForType<TimeoutException>();
                 o.AddExceptionFilterForType<IOException>();
+                o.AddExceptionFilterForType<CommunicationFailException>();
+                o.AddExceptionFilterForType<InvalidBlockIndexException>();
             });
 #endif
 

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -18,6 +18,7 @@ using NineChronicles.Headless.GraphTypes;
 using NineChronicles.Headless.Tests.Common;
 using Serilog;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -25,6 +26,7 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Lib9c.Tests;
+using Sentry;
 using Xunit.Abstractions;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
@@ -94,7 +96,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 ncService.NodeStatusRenderer,
                 "",
                 0,
-                new RpcContext()
+                new RpcContext(),
+                new ConcurrentDictionary<string, ITransaction>()
             );
             services.AddSingleton(publisher);
             services.AddSingleton(StandaloneContextFx);

--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -368,7 +368,7 @@ namespace NineChronicles.Headless
                                 Log.Error(e, "[{ClientAddress}] Skip broadcasting render due to the unexpected exception", _clientAddress);
                             }
 
-                            if (SentryTraces.TryRemove(ev.TxId?.ToString() ?? "", out var sentryTrace))
+                            if (ev.TxId != null && SentryTraces.TryRemove(ev.TxId.ToString() ?? "", out var sentryTrace))
                             {
                                 var span = sentryTrace.GetLastActiveSpan();
                                 span?.Finish();

--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -370,6 +370,14 @@ namespace NineChronicles.Headless
                                 // FIXME add logger as property
                                 Log.Error(e, "[{ClientAddress}] Skip broadcasting render due to the unexpected exception", _clientAddress);
                             }
+
+                            _sentryTraces.TryRemove(ev.TxId.ToString() ?? "", out var sentryTrace);
+                            if (sentryTrace != null)
+                            {
+                                var span = sentryTrace.GetLastActiveSpan();
+                                span?.Finish();
+                                sentryTrace.Finish();
+                            }
                         }
                     );
 

--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -368,8 +368,7 @@ namespace NineChronicles.Headless
                                 Log.Error(e, "[{ClientAddress}] Skip broadcasting render due to the unexpected exception", _clientAddress);
                             }
 
-                            SentryTraces.TryRemove(ev.TxId.ToString() ?? "", out var sentryTrace);
-                            if (sentryTrace != null)
+                            if (SentryTraces.TryRemove(ev.TxId?.ToString() ?? "", out var sentryTrace))
                             {
                                 var span = sentryTrace.GetLastActiveSpan();
                                 span?.Finish();

--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -19,6 +19,7 @@ using Lib9c.Renderer;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Tx;
 using MagicOnion.Client;
 using MessagePack;
 using Microsoft.Extensions.Hosting;
@@ -368,7 +369,7 @@ namespace NineChronicles.Headless
                                 Log.Error(e, "[{ClientAddress}] Skip broadcasting render due to the unexpected exception", _clientAddress);
                             }
 
-                            if (ev.TxId != null && SentryTraces.TryRemove(ev.TxId.ToString() ?? "", out var sentryTrace))
+                            if (ev.TxId is TxId txId && SentryTraces.TryRemove(txId.ToString() ?? "", out var sentryTrace))
                             {
                                 var span = sentryTrace.GetLastActiveSpan();
                                 span?.Finish();

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NineChronicles.Headless.Properties;
@@ -14,6 +15,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Nekoyume.Action;
+using Sentry;
 
 namespace NineChronicles.Headless
 {
@@ -51,7 +53,8 @@ namespace NineChronicles.Headless
                         context.NineChroniclesNodeService!.NodeStatusRenderer,
                         IPAddress.Loopback.ToString(),
                         0,
-                        rpcContext
+                        rpcContext,
+                        provider.GetRequiredService<ConcurrentDictionary<string, ITransaction>>()
                     );
                 });
             });
@@ -86,7 +89,8 @@ namespace NineChronicles.Headless
                             ctx.NineChroniclesNodeService!.NodeStatusRenderer,
                             IPAddress.Loopback.ToString(),
                             properties.RpcListenPort,
-                            context
+                            context,
+                            provider.GetRequiredService<ConcurrentDictionary<string, ITransaction>>()
                         );
                     });
                     var resolver = MessagePack.Resolvers.CompositeResolver.Create(

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -27,6 +27,9 @@
     <PackageReference Include="MagicOnion.Server" Version="4.3.1" />
     <PackageReference Include="MagicOnion.Server.HttpGateway" Version="4.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Sentry" Version="3.23.0" />
+    <PackageReference Include="Sentry.AspNetCore.Grpc" Version="3.22.0" />
+    <PackageReference Include="Sentry.DiagnosticSource" Version="3.22.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="GraphQL" Version="4.7.1" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.49.0.57237">


### PR DESCRIPTION
 - Options added
   - SentryDsn
     - Prevent other local nodes from sending traces
   - SentrySampleRate
 - Inject `ConcurrentDictionary<string, ITransaction>` to pass trace from blockchain service to actionEvaluationPublisher
 - Exclude too often errors, not to deplete sentry quota
 
 ref) https://sentry.io/organizations/planetariumhq/performance/9c-headless:25f95a3f56044e16b2c1a90a7dc4be97/?project=6197051&query=transaction.duration%3A%3C15m&referrer=performance-transaction-summary&transaction=Nekoyume.Action.HackAndSlash&unselectedSeries=p100%28%29
 
