### PR TITLE
Separate libplanet explorer into a new endpoint

### DIFF
--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -4,6 +4,7 @@ using GraphQL.Server;
 using GraphQL.Utilities;
 using Grpc.Core;
 using Grpc.Net.Client;
+using Libplanet.Explorer.Schemas;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -123,6 +124,7 @@ namespace NineChronicles.Headless
                     .AddWebSockets()
                     .AddDataLoader()
                     .AddGraphTypes(typeof(StandaloneSchema))
+                    .AddGraphTypes(typeof(LibplanetExplorerSchema<NCAction>))
                     .AddLibplanetExplorer<NCAction>()
                     .AddUserContextBuilder<UserContextBuilder>()
                     .AddGraphQLAuthorization(
@@ -187,6 +189,7 @@ namespace NineChronicles.Headless
                 app.UseWebSockets();
                 app.UseGraphQLWebSockets<StandaloneSchema>("/graphql");
                 app.UseGraphQL<StandaloneSchema>("/graphql");
+                app.UseGraphQL<LibplanetExplorerSchema<NCAction>>("/graphql/explorer");
 
                 // Prints 
                 app.UseMiddleware<GraphQLSchemaMiddleware<StandaloneSchema>>("/schema.graphql");

--- a/NineChronicles.Headless/GraphQLServiceExtensions.cs
+++ b/NineChronicles.Headless/GraphQLServiceExtensions.cs
@@ -6,6 +6,7 @@ using Libplanet.Action;
 using Libplanet.Explorer.GraphTypes;
 using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.Queries;
+using Libplanet.Explorer.Schemas;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
@@ -58,6 +59,7 @@ namespace NineChronicles.Headless
         {
             services.AddLibplanetScalarTypes();
             services.AddBlockChainContext();
+            services.AddSingleton<LibplanetExplorerSchema<T>>();
 
             services.TryAddSingleton<ActionType<T>>();
             services.TryAddSingleton<BlockType<T>>();

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -166,6 +166,7 @@ namespace NineChronicles.Headless.GraphTypes
 
             Field<NonNullGraphType<Libplanet.Explorer.Queries.ExplorerQuery<NCAction>>>(
                 name: "chainQuery",
+                deprecationReason: "Use /graphql/explorer",
                 resolve: context => new { }
             );
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26626194/202664251-cd2b54b3-08c7-4789-bd11-5c7cb7369a78.png)
This pull request enables `/graphql/explorer` endpoint and deprecates `query.chainQuery` (not obsolete).

This pull request closes #1690 