### PR TITLE
Fix output messages of replay command

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs
@@ -267,7 +267,7 @@ namespace NineChronicles.Headless.Executable.Commands
                     {
                         if (verbose)
                         {
-                            msg = $"-- repeat #{i + 1} / {repeatCount}";
+                            msg = $"-- repeat {i + 1}/{repeatCount}..";
                             _console.Out.Write(msg);
                             outputSw?.Write(msg);
                         }
@@ -284,9 +284,6 @@ namespace NineChronicles.Headless.Executable.Commands
                                 _console.Out.WriteLine(msg);
                                 outputSw?.WriteLine(msg);
                                 LoggingActionEvaluations(actionEvaluations, outputSw);
-                                msg = "- block #{block.Index} evaluating end successfully.";
-                                _console.Out.WriteLine(msg);
-                                outputSw?.WriteLine(msg);
                             }
                         }
                         catch (InvalidBlockStateRootHashException)
@@ -488,13 +485,14 @@ namespace NineChronicles.Headless.Executable.Commands
             IReadOnlyList<ActionEvaluation> actionEvaluations,
             TextWriter? textWriter)
         {
-            for (var i = 0; i < actionEvaluations.Count; i++)
+            var count = actionEvaluations.Count;
+            for (var i = 0; i < count; i++)
             {
                 var actionEvaluation = actionEvaluations[i];
                 var actionType = actionEvaluation.Action is NCAction nca
                     ? ActionTypeAttribute.ValueOf(nca.InnerAction.GetType())
                     : actionEvaluation.Action.GetType().Name;
-                var prefix = $"--- action evaluation #{i + 1}";
+                var prefix = $"--- action evaluation {i + 1}/{count}:";
                 var msg = prefix +
                           $" tx-id({actionEvaluation.InputContext.TxId})" +
                           $", action-type(\"{actionType}\")";


### PR DESCRIPTION
- Fix minor bug of message.
- Fix messages more readable.

before

```
dotnet run -- replay blocks \
-s ~/Downloads/FileZilla/9c-snapshots/20221110031332_9c-main-snapshot-symlink/ \
-i 5371565 \
-e 5371570 \
-o ./ \
-v
Replay blocks start from #5371565 to #5371570.(range: 6, repeat: 1)
Local block protocol version(bpv): 3
- block #5371565 evaluating start: bpv(3), bloc-hash(e082cc5db1c56ec6dfa2371137bcf9b7f6e87ad3c6cae8ec492fa1ee0c4e42d0), state-root-hash(2196a6f816fc21c400cf239162739462154f5ee565e9475dc703049488604821), tx-count(0)
-- repeat #1 / 1(o)
--- action evaluation #1 tx-id(), action-type("RewardGold"), no-exception
- block #{block.Index} evaluating end successfully.
- block #5371566 evaluating start: bpv(3), bloc-hash(a4108314b9ac82c90f86018664586636d785369b0c2a9b8c36b18dcc8f4a5a1a), state-root-hash(9f441fce99afadb4755645805529159630c58190b732654fd478a980cd761eca), tx-count(0)
-- repeat #1 / 1(o)
--- action evaluation #1 tx-id(), action-type("RewardGold"), no-exception
- block #{block.Index} evaluating end successfully.
- block #5371567 evaluating start: bpv(3), bloc-hash(fbd94ec6b6f7f8ea84ec0cfb49085843a1b41063d6bd89306b25df416c90d1a1), state-root-hash(3614b8ea93ac5894bf78060716d0d4a2bab1930158d0d051624c85d9f64dbaa9), tx-count(0)
-- repeat #1 / 1(o)
--- action evaluation #1 tx-id(), action-type("RewardGold"), no-exception
- block #{block.Index} evaluating end successfully.
- block #5371568 evaluating start: bpv(3), bloc-hash(fbb671c096e24f45de82fcb79f4551a19661895ec2652818c9e21054cd86550a), state-root-hash(8f048de6b2177a64b1dbcc5528ef642d9edc64f752db068259a092f7703cb6c3), tx-count(0)
-- repeat #1 / 1(o)
--- action evaluation #1 tx-id(), action-type("RewardGold"), no-exception
- block #{block.Index} evaluating end successfully.
- block #5371569 evaluating start: bpv(3), bloc-hash(687f8559904396365774210e23c40eff5315ca6cfaeec3a3057460e57af5767e), state-root-hash(f6baf0699003c50765026a10412032ec8b8ca934a6da8501100f3d09d5390939), tx-count(1)
-- repeat #1 / 1(x)
--- action evaluation #1 tx-id(0a3e35c8a33850ceed1a776f8b3c43faa9e28cfb13fc2c6c832d686502c503d1), action-type("hack_and_slash18"), no-exception
--- action evaluation #2 tx-id(), action-type("RewardGold"), no-exception
- block #5371569 evaluating failed with Libplanet.Blocks.InvalidBlockStateRootHashException: Block #5371569 687f8559904396365774210e23c40eff5315ca6cfaeec3a3057460e57af5767e's state root hash is f6baf0699003c50765026a10412032ec8b8ca934a6da8501100f3d09d5390939, but the execution result is 31fb1c8ef8e3dcd2cebf0c78741271856b87acc48b8b54ca5abeae3abb5f4c14.
   at Libplanet.Blockchain.BlockChain`1.ExecuteActions(Block`1 block, Nullable`1 stateCompleters) in /Users/seungmin/Repositories/9c-launcher/NineChronicles.Headless/Lib9c/.Libplanet/Libplanet/Blockchain/BlockChain.cs:line 918
   at NineChronicles.Headless.Executable.Commands.ReplayCommand.Blocks(String storePath, Int64 startIndex, Nullable`1 endIndex, Int32 repeatCount, Boolean verbose, String outputPath) in /Users/seungmin/Repositories/9c-launcher/NineChronicles.Headless/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs:line 277
Replay blocks end with exception.
```

after

```
Replay blocks start from #5371565 to #5371570.(range: 6, repeat: 1)
Local block protocol version(bpv): 3
- block #5371565 evaluating start: bpv(3), bloc-hash(e082cc5db1c56ec6dfa2371137bcf9b7f6e87ad3c6cae8ec492fa1ee0c4e42d0), state-root-hash(2196a6f816fc21c400cf239162739462154f5ee565e9475dc703049488604821), tx-count(0)
-- repeat 1/1..(o)
--- action evaluation 1/1: tx-id(), action-type("RewardGold"), no-exception
- block #5371566 evaluating start: bpv(3), bloc-hash(a4108314b9ac82c90f86018664586636d785369b0c2a9b8c36b18dcc8f4a5a1a), state-root-hash(9f441fce99afadb4755645805529159630c58190b732654fd478a980cd761eca), tx-count(0)
-- repeat 1/1..(o)
--- action evaluation 1/1: tx-id(), action-type("RewardGold"), no-exception
- block #5371567 evaluating start: bpv(3), bloc-hash(fbd94ec6b6f7f8ea84ec0cfb49085843a1b41063d6bd89306b25df416c90d1a1), state-root-hash(3614b8ea93ac5894bf78060716d0d4a2bab1930158d0d051624c85d9f64dbaa9), tx-count(0)
-- repeat 1/1..(o)
--- action evaluation 1/1: tx-id(), action-type("RewardGold"), no-exception
- block #5371568 evaluating start: bpv(3), bloc-hash(fbb671c096e24f45de82fcb79f4551a19661895ec2652818c9e21054cd86550a), state-root-hash(8f048de6b2177a64b1dbcc5528ef642d9edc64f752db068259a092f7703cb6c3), tx-count(0)
-- repeat 1/1..(o)
--- action evaluation 1/1: tx-id(), action-type("RewardGold"), no-exception
- block #5371569 evaluating start: bpv(3), bloc-hash(687f8559904396365774210e23c40eff5315ca6cfaeec3a3057460e57af5767e), state-root-hash(f6baf0699003c50765026a10412032ec8b8ca934a6da8501100f3d09d5390939), tx-count(1)
-- repeat 1/1..(x)
--- action evaluation 1/2: tx-id(0a3e35c8a33850ceed1a776f8b3c43faa9e28cfb13fc2c6c832d686502c503d1), action-type("hack_and_slash18"), no-exception
--- action evaluation 2/2: tx-id(), action-type("RewardGold"), no-exception
- block #5371569 evaluating failed with Libplanet.Blocks.InvalidBlockStateRootHashException: Block #5371569 687f8559904396365774210e23c40eff5315ca6cfaeec3a3057460e57af5767e's state root hash is f6baf0699003c50765026a10412032ec8b8ca934a6da8501100f3d09d5390939, but the execution result is 31fb1c8ef8e3dcd2cebf0c78741271856b87acc48b8b54ca5abeae3abb5f4c14.
   at Libplanet.Blockchain.BlockChain`1.ExecuteActions(Block`1 block, Nullable`1 stateCompleters) in /Users/seungmin/Repositories/9c-launcher/NineChronicles.Headless/Lib9c/.Libplanet/Libplanet/Blockchain/BlockChain.cs:line 918
   at NineChronicles.Headless.Executable.Commands.ReplayCommand.Blocks(String storePath, Int64 startIndex, Nullable`1 endIndex, Int32 repeatCount, Boolean verbose, String outputPath) in /Users/seungmin/Repositories/9c-launcher/NineChronicles.Headless/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs:line 277
Replay blocks end with exception.
```