### PR TITLE
bump lib9c

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
@@ -60,10 +60,10 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         }
 
         [Theory]
-        [InlineData(false, 0, 196)]
-        [InlineData(false, 5_000_000, 196)]
-        [InlineData(true, 0, 196)]
-        [InlineData(true, 5_000_000, 71)]
+        [InlineData(false, 0, 197)]
+        [InlineData(false, 5_000_000, 197)]
+        [InlineData(true, 0, 197)]
+        [InlineData(true, 5_000_000, 72)]
         public void List(bool excludeObsolete, long blockIndex, int expectedCommandCount)
         {
             var commandList = _command.List(excludeObsolete, blockIndex);


### PR DESCRIPTION
Bumping lib9c to the latest development branch with `GrandFinale` related actions.