### PR TITLE
Bump `lib9c` and Apply the changes related to `ClaimStakeReward`

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
@@ -6,6 +6,7 @@ using Bencodex.Types;
 using Libplanet;
 using Libplanet.Crypto;
 using Nekoyume.Action;
+using Nekoyume.Action.Factory;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
 using NineChronicles.Headless.Executable.Commands;
@@ -60,10 +61,10 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         }
 
         [Theory]
-        [InlineData(false, 0, 197)]
-        [InlineData(false, 5_000_000, 197)]
-        [InlineData(true, 0, 197)]
-        [InlineData(true, 5_000_000, 72)]
+        [InlineData(false, 0, 198)]
+        [InlineData(false, 5_000_000, 198)]
+        [InlineData(true, 0, 198)]
+        [InlineData(true, 5_000_000, 73)]
         public void List(bool excludeObsolete, long blockIndex, int expectedCommandCount)
         {
             var commandList = _command.List(excludeObsolete, blockIndex);
@@ -193,6 +194,65 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             else
             {
                 Assert.Contains("System.FormatException: Could not find any recognizable digits.", _console.Error.ToString());
+            }
+        }
+
+        [Theory]
+        [InlineData(0L, typeof(ClaimStakeReward))]
+        [InlineData(Nekoyume.Action.ClaimStakeReward.ObsoletedIndex - 1, typeof(ClaimStakeReward))]
+        [InlineData(Nekoyume.Action.ClaimStakeReward.ObsoletedIndex, typeof(ClaimStakeReward))]
+        [InlineData(Nekoyume.Action.ClaimStakeReward.ObsoletedIndex + 1, typeof(ClaimStakeReward3))]
+        [InlineData(long.MaxValue, typeof(ClaimStakeReward3))]
+        public void ClaimStakeRewardWithBlockIndex(long blockIndex, Type expectedActionType)
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            var addr = new PrivateKey().ToAddress();
+            var resultCode = _command.ClaimStakeReward(
+                addr.ToHex(),
+                filePath,
+                blockIndex: blockIndex);
+            Assert.Equal(0, resultCode);
+
+            var rawAction = Convert.FromBase64String(File.ReadAllText(filePath));
+            var decoded = (List)_codec.Decode(rawAction);
+            var plainValue = Assert.IsType<Dictionary>(decoded[1]);
+            var action = ClaimStakeRewardFactory.CreateByBlockIndex(blockIndex, addr);
+            action.LoadPlainValue(plainValue);
+            string type = (Text)decoded[0];
+            Assert.Equal(action.GetType().Name, type);
+        }
+        
+        [Theory]
+        [InlineData(0, 0, -1)]
+        [InlineData(1, 3, 0)]
+        [InlineData(4, 4, -1)]
+        public void ClaimStakeRewardWithActionVersion(
+            int actionVersionMin,
+            int actionVersionMax,
+            int expectedCode)
+        {
+            for (var i = actionVersionMin; i < actionVersionMax + 1; i++)
+            {
+                var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+                var addr = new PrivateKey().ToAddress();
+                var resultCode = _command.ClaimStakeReward(
+                    addr.ToHex(),
+                    filePath,
+                    actionVersion: i);
+                Assert.Equal(expectedCode, resultCode);
+
+                if (expectedCode < 0)
+                {
+                    continue;
+                }
+
+                var rawAction = Convert.FromBase64String(File.ReadAllText(filePath));
+                var decoded = (List)_codec.Decode(rawAction);
+                var plainValue = Assert.IsType<Dictionary>(decoded[1]);
+                var action = ClaimStakeRewardFactory.CreateByVersion(i, addr);
+                action.LoadPlainValue(plainValue);
+                string type = (Text)decoded[0];
+                Assert.Equal(action.GetType().Name, type);
             }
         }
 

--- a/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
@@ -221,7 +221,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             string type = (Text)decoded[0];
             Assert.Equal(action.GetType().Name, type);
         }
-        
+
         [Theory]
         [InlineData(0, 0, -1)]
         [InlineData(1, 3, 0)]

--- a/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
@@ -4,6 +4,7 @@ using Libplanet;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Tx;
+using Nekoyume.Action;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
 using NineChronicles.Headless.Executable.Commands;
@@ -87,13 +88,26 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             Assert_Tx(1, filePath);
         }
 
-        [Fact]
-        public void Sign_ClaimStakeReward()
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(0, null)]
+        [InlineData(ClaimStakeReward.ObsoletedIndex - 1, null)]
+        [InlineData(ClaimStakeReward.ObsoletedIndex, null)]
+        [InlineData(ClaimStakeReward.ObsoletedIndex + 1, null)]
+        [InlineData(long.MaxValue, null)]
+        [InlineData(null, 1)]
+        [InlineData(null, 2)]
+        [InlineData(null, 3)]
+        public void Sign_ClaimStakeReward(long? blockIndex, int? actionVersion)
         {
             var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
             var actionCommand = new ActionCommand(_console);
             var avatarAddress = new Address();
-            actionCommand.ClaimStakeReward(avatarAddress.ToHex(), filePath);
+            actionCommand.ClaimStakeReward(
+                avatarAddress.ToHex(),
+                filePath,
+                blockIndex,
+                actionVersion);
             Assert_Tx(1, filePath);
         }
 

--- a/NineChronicles.Headless.Executable/Commands/ActionCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ActionCommand.cs
@@ -11,6 +11,7 @@ using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
 using Nekoyume.Action;
+using Nekoyume.Action.Factory;
 using Nekoyume.Model;
 using NineChronicles.Headless.Executable.IO;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
@@ -302,18 +303,50 @@ namespace NineChronicles.Headless.Executable.Commands
             [Argument("AVATAR-ADDRESS", Description = "A hex-encoded avatar address.")]
             string encodedAddress,
             [Argument("PATH", Description = "A file path of base64 encoded action.")]
-            string? filePath = null
+            string? filePath = null,
+            [Option("BLOCK-INDEX", Description = "A block index which is used to specifying the action version.")]
+            long? blockIndex = null,
+            [Option("ACTION-VERSION", Description = "A version of action.")]
+            int? actionVersion = null
         )
         {
             try
             {
+                if (blockIndex.HasValue && actionVersion.HasValue)
+                {
+                    throw new CommandExitedException(
+                        "You can't specify both block index and action version.",
+                        -1);
+                }
+
                 Address avatarAddress = new Address(ByteUtil.ParseHex(encodedAddress));
-                Nekoyume.Action.ClaimStakeReward action = new ClaimStakeReward(avatarAddress);
+                IClaimStakeReward? action = null;
+                if (blockIndex.HasValue)
+                {
+                    action = ClaimStakeRewardFactory.CreateByBlockIndex(
+                        blockIndex.Value,
+                        avatarAddress);
+                }
+
+                if (actionVersion.HasValue)
+                {
+                    action = ClaimStakeRewardFactory.CreateByVersion(
+                        actionVersion.Value,
+                        avatarAddress);
+                }
+
+                // NOTE: If neither block index nor action version is specified,
+                //       it will be created by the type of the class.
+                //       I considered to create action with max value of
+                //       block index(i.e., long.MaxValue), but it is not good
+                //       because the action of the next version may come along
+                //       with the current version.
+                action ??= new ClaimStakeReward(avatarAddress);
 
                 byte[] raw = Codec.Encode(new List(
                     new[]
                     {
-                        (Text) nameof(Nekoyume.Action.ClaimStakeReward),
+                        (Text) action.GetType().Name,
                         action.PlainValue
                     }
                 ));

--- a/NineChronicles.Headless.Executable/Commands/TxCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/TxCommand.cs
@@ -65,7 +65,10 @@ namespace NineChronicles.Headless.Executable.Commands
                     nameof(MonsterCollect) => new MonsterCollect(),
                     nameof(ClaimMonsterCollectionReward) => new ClaimMonsterCollectionReward(),
                     nameof(Stake) => new Stake(),
+                    // FIXME: This `ClaimStakeReward` cases need to reduce to one case.
+                    nameof(ClaimStakeReward1) => new ClaimStakeReward1(),
                     nameof(ClaimStakeReward) => new ClaimStakeReward(),
+                    nameof(ClaimStakeReward3) => new ClaimStakeReward3(),
                     nameof(TransferAsset) => new TransferAsset(),
                     nameof(MigrateMonsterCollection) => new MigrateMonsterCollection(),
                     _ => throw new CommandExitedException($"Unsupported action type was passed '{type}'", 128)


### PR DESCRIPTION
- Bump `lib9c`
- Expand `ActionCommand.ClaimStakeReward()` method
- Consider all versions of the `ClaimStakeReward` actions on `TxCommand.Sign()` method

## Related pull requests

- https://github.com/planetarium/lib9c/pull/1530
- https://github.com/planetarium/lib9c/pull/1533