### PR TITLE
Remove Lib9c.Tests from solution

### DIFF
--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -40,8 +40,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.DevExtensions", "Lib9
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Net", "Lib9c\.Libplanet\Libplanet.Net\Libplanet.Net.csproj", "{858AEAB3-CC9C-41C4-9727-4243708FD803}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.Tests", "Lib9c\.Lib9c.Tests\Lib9c.Tests.csproj", "{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.MessagePack", "Lib9c\Lib9c.MessagePack\Lib9c.MessagePack.csproj", "{A9513460-EE7A-455F-A823-5005DB6BA8FC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Crypto.Secp256k1", "Lib9c\Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj", "{84EBA886-FAD6-4167-9857-36BA1B394EBB}"
@@ -250,18 +248,6 @@ Global
 		{858AEAB3-CC9C-41C4-9727-4243708FD803}.Release|x64.Build.0 = Release|Any CPU
 		{858AEAB3-CC9C-41C4-9727-4243708FD803}.Release|x86.ActiveCfg = Release|Any CPU
 		{858AEAB3-CC9C-41C4-9727-4243708FD803}.Release|x86.Build.0 = Release|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Debug|x64.Build.0 = Debug|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Debug|x86.Build.0 = Debug|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Release|x64.ActiveCfg = Release|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Release|x64.Build.0 = Release|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Release|x86.ActiveCfg = Release|Any CPU
-		{1DB5C746-0DBD-4D92-BE6D-1DF7536D62B6}.Release|x86.Build.0 = Release|Any CPU
 		{A9513460-EE7A-455F-A823-5005DB6BA8FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A9513460-EE7A-455F-A823-5005DB6BA8FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A9513460-EE7A-455F-A823-5005DB6BA8FC}.Debug|x64.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
I think there is no reason to build *Lib9c.Tests* in *NineChronicles.Headless* project.