### PR TITLE
ci(gh-actions): update actions used node12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.*
       - name: Install dependencies

--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - uses: actions/setup-dotnet@v1.7.2
+      - uses: actions/setup-dotnet@v3.7.2
         name: Set up .NET Core SDK
         with:
           dotnet-version: 6.0.*

--- a/.github/workflows/deploy_ghpackages_docker.yml
+++ b/.github/workflows/deploy_ghpackages_docker.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Build the Docker image

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,9 @@ jobs:
     format:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Setup .NET Core
-              uses: actions/setup-dotnet@v1
+              uses: actions/setup-dotnet@v3
               with:
                   dotnet-version: 6.0.*
             - name: dotnet format

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: login

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check if a new tag refers a merge commit
       run: |
         set -evx


### PR DESCRIPTION
This pull request updates deprecated actions, used `node12` environment, `actions/checkout` and `actions/setup-dotnet`.

See also https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/