### PR TITLE
Unlink Lib9c.Tools to prepare deprecation

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -290,7 +290,7 @@ namespace NineChronicles.Headless.Executable.Commands
             /// <value>
             /// Dump file path of pending activation state created using <c>9c-tools</c><br/>
             /// This will set activation codes that can be used to genesis block. <br/>
-            /// See <a href="https://github.com/planetarium/lib9c/blob/development/.Lib9c.Tools/SubCommand/Tx.cs">Tx.cs</a> to create activation key.
+            /// See <see cref="TxCommand"/> to create activation key.
             /// </value>
             public string? PendingActivationStatePath { get; set; }
         }

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ Activation key is the code for 9c account to register/activate into NineChronicl
 You can create activation key whenever you want later, so you can just skip this step.
 
 ```shell
-dotnet run --project ./.Lib9c.Tools tx create-activation-keys 10 > ActivationKeys.csv  # Change [10] to your number of new activation keys
-dotnet run --project ./.Lib9c.Tools tx create-pending-activations ActivationKeys.csv > PendingActivation
+dotnet run --project NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj -- tx create-activation-keys 10 > ActivationKeys.csv  # Change [10] to your number of new activation keys
+dotnet run --project NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj -- tx create-pending-activations ActivationKeys.csv > PendingActivation
 ```
 
 ### 2. Create config file for genesis block


### PR DESCRIPTION
Since #1602, `Lib9c.Tools` commands were moved from the `lib9c` repository to the `NineChronicles.Headless.Exectuable` command project. And `Lib9c.Tools` became deprecated. But the `NineChronicles.Headless` project still has references to `Lib9c.Tools`. This pull request removes them.