### PR TITLE
CLI program to test 9c actions on demand

### DIFF
--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -48,6 +48,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.Miner", "Lib9c\Lib9c.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.Tests", "Lib9c\.Lib9c.Tests\Lib9c.Tests.csproj", "{C618F86E-F445-4267-92D7-D3D300293386}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NineChronicles.Test", "NineChronicles.Test\NineChronicles.Test.csproj", "{A61C59B2-581D-4521-A79B-C97EAB1BC007}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -298,6 +300,18 @@ Global
 		{C618F86E-F445-4267-92D7-D3D300293386}.Release|x64.Build.0 = Release|Any CPU
 		{C618F86E-F445-4267-92D7-D3D300293386}.Release|x86.ActiveCfg = Release|Any CPU
 		{C618F86E-F445-4267-92D7-D3D300293386}.Release|x86.Build.0 = Release|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Debug|x64.Build.0 = Debug|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Debug|x86.Build.0 = Debug|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Release|x64.ActiveCfg = Release|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Release|x64.Build.0 = Release|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Release|x86.ActiveCfg = Release|Any CPU
+		{A61C59B2-581D-4521-A79B-C97EAB1BC007}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
+++ b/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
@@ -9,6 +9,10 @@
     <NoWarn>$(NoWarn);CS8602;CS8604</NoWarn>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
     <Nullable>enable</Nullable>
+    <PreBuildEvent>
+        dotnet build $(SolutionDir)/NineChronicles.Headless/NineChronicles.Headless.csproj /p:DefineConstants="LIB9C_DEV_EXTENSINOS" /t:Rebuild
+    </PreBuildEvent>
+    <DefineConstants>LIB9C_DEV_EXTENSIONS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -17,6 +17,10 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
+// #if LIB9C_DEV_EXTENSIONS
+using NineChronicles.Test.GraphType;
+
+// #endif
 namespace NineChronicles.Headless.GraphTypes
 {
     public class ActionQuery : ObjectGraphType
@@ -537,7 +541,12 @@ namespace NineChronicles.Headless.GraphTypes
                     };
                     return Encode(context, action);
                 });
+
+// #if LIB9C_DEV_EXTENSIONS || UNITY_EDITOR
+            this.ApplyTestActionQuery();
+// #endif
         }
+
 
         internal virtual byte[] Encode(IResolveFieldContext context, NCAction action)
         {

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -4,6 +4,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
     <Nullable>enable</Nullable>
+      <PreBuildEvent Condition="$(DefineConstants.Contains('LIB9C_DEV_EXTENSIONS'))">
+          dotnet build ../Lib9c/Lib9c.csproj /p:DefineConstants="LIB9C_DEV_EXTENSINOS" /t:Rebuild
+      </PreBuildEvent>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\Lib9c.MessagePack\Lib9c.MessagePack.csproj" />
@@ -14,6 +17,8 @@
     <ProjectReference Include="..\Lib9c\Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj" />
     <ProjectReference Include="..\Libplanet.Headless\Libplanet.Headless.csproj" />
     <ProjectReference Include="..\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared.csproj" />
+<!--    <ProjectReference Condition="$(DefineConstants.Contains('LIB9C_DEV_EXTENSIONS'))" Include="..\NineChronicles.Test\NineChronicles.Test.csproj" />-->
+    <ProjectReference Include="..\NineChronicles.Test\NineChronicles.Test.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="GraphQL.Server.Authorization.AspNetCore" Version="5.1.1" />

--- a/NineChronicles.Test/Address.cs
+++ b/NineChronicles.Test/Address.cs
@@ -1,8 +1,5 @@
-using GraphQL;
-using Libplanet;
 using Libplanet.Crypto;
 using Libplanet.KeyStore;
-using NineChronicles.Test.Type;
 
 namespace NineChronicles.Test;
 
@@ -10,19 +7,9 @@ public static class Address
 {
     public static async Task<string> ActivateAccount(PrivateKey pk, string activationCode)
     {
-        var actionTxQuery = $@"query {{
-            actionTxQuery(
-                publicKey: ""{pk.PublicKey}"",
-                nonce: 0
-            ) {{
-                activateAccount (activationCode: ""{activationCode}"")
-            }}
-        }}";
-        (bool success, ActionTxQueryResponseType data, GraphQLError[]? errors) = await Graphql.Query<ActionTxQueryResponseType>(actionTxQuery);
-        var tx = ByteUtil.ParseHex(data.ActionTxQuery.ActivateAccount);
-        var signature = pk.Sign(tx);
-        (bool stageResult, string txId) = await Graphql.Stage(tx, signature);
-        Console.WriteLine($"Account activation success: {stageResult} :: TxID {txId}");
+        var query = $" activateAccount (activationCode: \"{activationCode}\") }}";
+        (bool result, string txId) = await Graphql.Action(pk, query);
+        Console.WriteLine($"Account activation: {result} :: TxID {txId}");
         return txId;
     }
 

--- a/NineChronicles.Test/Address.cs
+++ b/NineChronicles.Test/Address.cs
@@ -36,24 +36,7 @@ public static class Address
             Console.WriteLine($"{item.index + 1}: {item.value.Item2.Address.ToString()}");
         }
 
-        Console.WriteLine();
-
-        bool usable = false;
-        int index = -1;
-        while (!usable)
-        {
-            var selectedIndex = Console.ReadLine();
-            usable = int.TryParse(selectedIndex, out index);
-            if (!usable)
-            {
-                Console.WriteLine("Please input number.");
-            }
-            else if (index > keystore.List().Count())
-            {
-                Console.WriteLine($"{index} is not on the list. Please set right one: ");
-                usable = false;
-            }
-        }
+        var index = Util.Select(keystore.List());
 
         if (index == 0)
         {

--- a/NineChronicles.Test/Address.cs
+++ b/NineChronicles.Test/Address.cs
@@ -1,0 +1,78 @@
+using Libplanet.Crypto;
+using Libplanet.KeyStore;
+
+namespace NineChronicles.Test;
+
+public static class Address
+{
+    public static PrivateKey GetKey()
+    {
+        var keystore = Web3KeyStore.DefaultKeyStore;
+        Console.WriteLine("Pick your 9c address to test action:");
+        Console.WriteLine("0: Create New Address");
+        foreach (var item in keystore.List().Select((value, index) => (value, index)))
+        {
+            Console.WriteLine($"{item.index + 1}: {item.value.Item2.Address.ToString()}");
+        }
+
+        Console.WriteLine();
+
+        bool usable = false;
+        int index = -1;
+        while (!usable)
+        {
+            var selectedIndex = Console.ReadLine();
+            usable = int.TryParse(selectedIndex, out index);
+            if (!usable)
+            {
+                Console.WriteLine("Please input number.");
+            }
+            else if (index > keystore.List().Count())
+            {
+                Console.WriteLine($"{index} is not on the list. Please set right one: ");
+                usable = false;
+            }
+        }
+
+        if (index == 0)
+        {
+            var pk = new PrivateKey();
+            string? passphrase = String.Empty;
+            while (true)
+            {
+                Console.Write("Passphrase: ");
+                passphrase = Console.ReadLine();
+                Console.Write("Passphrase again: ");
+                var check = Console.ReadLine();
+                if (passphrase == check)
+                {
+                    break;
+                }
+
+                Console.WriteLine("Passphrase not matched. Try again.");
+            }
+
+            var ppk = ProtectedPrivateKey.Protect(pk, passphrase);
+            keystore.Add(ppk);
+            Console.WriteLine("New key generated.");
+            Console.WriteLine($"Your address is: {ppk.Address} . Now preparing account to do action...");
+            return pk;
+        }
+
+        while (true)
+        {
+            var ppk = keystore.List().ElementAt(index - 1).Item2;
+            Console.Write("Passphrase: ");
+            try
+            {
+                var pk = ppk.Unprotect(Console.ReadLine());
+                Console.WriteLine("Address unlocked. Now preparing account to do action...");
+                return pk;
+            }
+            catch (Exception e) when (e is IncorrectPassphraseException || e is MismatchedAddressException)
+            {
+                Console.WriteLine("Failed to unlock your address.");
+            }
+        }
+    }
+}

--- a/NineChronicles.Test/Avatar.cs
+++ b/NineChronicles.Test/Avatar.cs
@@ -1,0 +1,92 @@
+using GraphQL;
+using Libplanet;
+using Libplanet.Crypto;
+using NineChronicles.Test.Type;
+
+namespace NineChronicles.Test;
+
+public class Avatar
+{
+    public static async Task<AvatarStateType[]> GetAvatarStates(Libplanet.Address address)
+    {
+        var query = $@"query {{
+                    stateQuery {{
+                        agent(address: ""{address}"") {{
+                            address
+                            avatarStates {{
+                                index
+                                address
+                                name 
+                            }}
+                        }}
+                    }}
+                }}";
+        (bool success, StateQueryResponseType data, GraphQLError[]? errors) =
+            await Graphql.Query<StateQueryResponseType>(query);
+        if (!success || data.StateQuery.Agent is null)
+        {
+            Console.WriteLine("Error!");
+            foreach (GraphQLError e in errors ?? new GraphQLError[] { })
+            {
+                Console.WriteLine(e.Message);
+            }
+
+            return new AvatarStateType[] { };
+        }
+
+        return data.StateQuery.Agent.AvatarStates;
+    }
+
+    public static async Task<Libplanet.Address?> CreateAvatar(PrivateKey pk, int index = 1)
+    {
+        var query = $@"createAvatar (
+            index: {index},
+            name: ""avatar{index}""
+        )";
+        (bool success, string txId) = await Graphql.Action(pk, query);
+        string txResult = await Graphql.WaitTxMining(txId);
+        if (txResult == "SUCCESS")
+        {
+            Console.WriteLine("Avatar created");
+            var avatarStates = await GetAvatarStates(pk.ToAddress());
+            return avatarStates[0].Address;
+        }
+
+        Console.WriteLine("Avatar create failed. Please try later.");
+        return null;
+    }
+
+    public static async Task<Libplanet.Address?> SelectAvatar(PrivateKey pk)
+    {
+        var avatarStates = await GetAvatarStates(pk.ToAddress());
+        if (avatarStates.Length == 0)
+        {
+            Console.WriteLine("No avatar created. Creating one...");
+            return await CreateAvatar(pk);
+        }
+
+        Console.WriteLine($"You have {avatarStates.Length} avatars in your address. Select one to use");
+        if (avatarStates.Length < 3)
+        {
+            Console.WriteLine("0. Create new avatar");
+        }
+
+        foreach (var item in avatarStates.Select((value, index) => (value, index)))
+        {
+            Console.WriteLine($"{item.index + 1}: {item.value.Address}");
+        }
+
+        var index = Util.Select(avatarStates);
+        Libplanet.Address? avatarAddress;
+        if (index == 0)
+        {
+            avatarAddress = await CreateAvatar(pk);
+        }
+        else
+        {
+            avatarAddress = avatarStates[index - 1].Address;
+        }
+
+        return avatarAddress;
+    }
+}

--- a/NineChronicles.Test/Avatar.cs
+++ b/NineChronicles.Test/Avatar.cs
@@ -43,7 +43,21 @@ public class Avatar
             index: {index},
             name: ""avatar{index}""
         )";
-        (bool success, string txId) = await Graphql.Action(pk, query);
+        (bool success, ActionTxQueryResponseType data, GraphQLError[]? erros) = await Graphql.Action(pk, query);
+        if (!success)
+        {
+            Console.WriteLine($"createAvatar Action failed. Try again later. :: {erros}");
+        }
+
+        var tx = ByteUtil.ParseHex(data.ActionTxQuery.CreateAvatar);
+        var signature = pk.Sign(tx);
+        (bool result, string txId) = await Graphql.Stage(tx, signature);
+        if (!result)
+        {
+            Console.WriteLine("Create avatar action stage failed");
+            return null;
+        }
+
         string txResult = await Graphql.WaitTxMining(txId);
         if (txResult == "SUCCESS")
         {

--- a/NineChronicles.Test/GameAction.cs
+++ b/NineChronicles.Test/GameAction.cs
@@ -1,0 +1,68 @@
+using GraphQL;
+using Libplanet;
+using Libplanet.Crypto;
+using NineChronicles.Test.Type;
+
+namespace NineChronicles.Test;
+
+public class GameAction
+{
+    public static async Task<bool> GetStatus(PrivateKey pk)
+    {
+        var query = $@"query {{
+            stateQuery {{
+                agent(address: ""{pk.ToAddress()}"") {{
+                    address
+                    gold
+                    crystal
+                    avatarStates {{
+                        index
+                        address
+                        name
+                        level
+                        exp
+                        actionPoint
+                    }}
+                }}
+            }}
+        }}";
+        (bool success, StateQueryResponseType data, GraphQLError[]? errors) = await Graphql.Query<StateQueryResponseType>(query);
+        if (!success)
+        {
+            Console.WriteLine("Get Status action failed.");
+            return false;
+        }
+        Console.WriteLine(data.StateQuery.Agent);
+        return true;
+    }
+
+    public static async Task<bool> RuneEnhancement(PrivateKey pk)
+    {
+        var query = $@"";
+        (bool success, ActionTxQueryResponseType data, GraphQLError[]? errors) = await Graphql.Action(pk, query);
+        if (!success)
+        {
+            Console.WriteLine("Rune enhancement action failed.");
+            return false;
+        }
+
+        var tx = ByteUtil.ParseHex(data.ActionTxQuery.RuneEnhancement);
+        var signature = pk.Sign(tx);
+        (bool result, string txId) = await Graphql.Stage(tx, signature);
+        if (!result)
+        {
+            Console.WriteLine("Rune enhancement action stage failed");
+            return false;
+        }
+
+        var txResult = await Graphql.WaitTxMining(txId);
+        if (txResult == "SUCCESS")
+        {
+            Console.WriteLine("Rune Enhancement Done.");
+            return true;
+        }
+
+        Console.WriteLine($"Rune Enhancement Failed: {txResult}");
+        return false;
+    }
+}

--- a/NineChronicles.Test/GraphType/FaucetRuneInputType.cs
+++ b/NineChronicles.Test/GraphType/FaucetRuneInputType.cs
@@ -1,0 +1,20 @@
+using GraphQL.Types;
+using Nekoyume.Action;
+
+namespace NineChronicles.Test.GraphType;
+
+public class FaucetRuneInputType : InputObjectGraphType<FaucetRuneInfo>
+{
+    public FaucetRuneInputType()
+    {
+        Field<NonNullGraphType<IntGraphType>>("runeId");
+        Field<NonNullGraphType<IntGraphType>>("amount");
+    }
+
+    public override object ParseDictionary(IDictionary<string, object?> value)
+    {
+        int runeId = (int)value["runeId"]!;
+        int amount = (int)value["amount"]!;
+        return new FaucetRuneInfo(runeId, amount);
+    }
+}

--- a/NineChronicles.Test/GraphType/TestActionQuery.cs
+++ b/NineChronicles.Test/GraphType/TestActionQuery.cs
@@ -1,0 +1,84 @@
+using Bencodex;
+using GraphQL;
+using GraphQL.Types;
+using Lib9c.DevExtensions.Action;
+using Libplanet.Explorer.GraphTypes;
+using Nekoyume.Action;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace NineChronicles.Test.GraphType;
+
+public static class TestActionQuery
+{
+    private static readonly Codec Codec = new Codec();
+
+    public static void ApplyTestActionQuery(this ObjectGraphType actionQuery)
+    {
+        actionQuery.Field<NonNullGraphType<ByteStringType>>(
+            "faucetCurrency",
+            arguments: new QueryArguments(
+                new QueryArgument<NonNullGraphType<AddressType>>
+                {
+                    Name = "agentAddress",
+                    Description = "9c Address to use faucet"
+                },
+                new QueryArgument<IntGraphType>
+                {
+                    Name = "faucetNcg",
+                    Description = "Amount of NCG to get.",
+                },
+                new QueryArgument<IntGraphType>
+                {
+                    Name = "faucetCrystal",
+                    Description = "Amount of Crystal to get.",
+                }
+            ),
+            resolve: context =>
+            {
+                var agentAddress = context.GetArgument<Libplanet.Address>("agentAddress");
+                var faucetNcg = context.GetArgument<int>("faucetNcg");
+                var faucetCrystal = context.GetArgument<int>("faucetCrystal");
+                NCAction action = new FaucetCurrency
+                {
+                    AgentAddress = agentAddress,
+                    FaucetNcg = faucetNcg,
+                    FaucetCrystal = faucetCrystal
+                };
+                return Encode(context, action);
+            }
+        );
+
+        actionQuery.Field<NonNullGraphType<ByteStringType>>(
+            "faucetRune",
+            arguments: new QueryArguments(
+                new QueryArgument<NonNullGraphType<AddressType>>
+                {
+                    Name = "avatarAddress",
+                    Description = "avatar Address to use faucet"
+                },
+                new QueryArgument<ListGraphType<NonNullGraphType<FaucetRuneInputType>>>
+                {
+                    Name = "faucetRuneInfos",
+                    Description = "List of rune info to get: [{runeId: <int>, amount: <int>}].",
+                    DefaultValue = new List<FaucetRuneInfo>()
+                }
+            ),
+            resolve: context =>
+            {
+                var avatarAddress = context.GetArgument<Libplanet.Address>("avatarAddress");
+                var faucetRuneInfos = context.GetArgument<List<FaucetRuneInfo>>("faucetRuneInfos");
+                NCAction action = new FaucetRune
+                {
+                    AvatarAddress = avatarAddress,
+                    FaucetRuneInfos = faucetRuneInfos
+                };
+                return Encode(context, action);
+            }
+        );
+    }
+
+    internal static byte[] Encode(IResolveFieldContext context, NCAction action)
+    {
+        return Codec.Encode(action.PlainValue);
+    }
+}

--- a/NineChronicles.Test/Graphql.cs
+++ b/NineChronicles.Test/Graphql.cs
@@ -60,6 +60,18 @@ public static class Graphql
         return (success, result.stageTransaction);
     }
 
+    public static async Task<string> WaitTxMining(string txId)
+    {
+        Console.WriteLine("Waiting for block mining...");
+        string txResult = await TxResult(txId);
+        while (txResult == "STAGING")
+        {
+            txResult = await TxResult(txId);
+        }
+
+        return txResult;
+    }
+
     public static async Task<long> GetNextTxNonce(Libplanet.Address address)
     {
         var query = $@"query {{

--- a/NineChronicles.Test/Graphql.cs
+++ b/NineChronicles.Test/Graphql.cs
@@ -1,0 +1,73 @@
+using GraphQL;
+using GraphQL.Client.Http;
+using GraphQL.Client.Serializer.SystemTextJson;
+using Libplanet;
+using NineChronicles.Test.Type;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace NineChronicles.Test;
+
+public static class Graphql
+{
+    public static GraphQLHttpClient Client = new(
+        // "http://9c-main-rpc-1.nine-chronicles.com/graphql",
+        "http://localhost:31280/graphql",
+        new SystemTextJsonSerializer()
+    );
+
+    /// <summary>
+    /// The general function to request any query and get anything.
+    /// You have to parse query result on your own.
+    /// </summary>
+    /// <param name="query">The complete, valid GQL query string to request</param>
+    /// <returns>Data part of query result if query succeeded or return error..</returns>
+    public static async Task<(bool success, T data, GraphQLError[]? errors)> Query<T>(string query)
+    {
+        var resp = await Client.SendQueryAsync<T>(new GraphQLRequest(query));
+        // var response = ToObject<T>(resp.Data);
+        return (resp.Errors is null, resp.Data, resp.Errors);
+    }
+
+    public static async Task<(bool, string)> Stage(byte[] tx, byte[] signature)
+    {
+        var signTxQuery = $@"query {{
+            transaction {{
+                signTransaction(
+                    unsignedTransaction: ""{ByteUtil.Hex(tx)}"",
+                    signature: ""{ByteUtil.Hex(signature)}""
+                )
+            }}
+        }}";
+        (bool success, TransactionResponseType data, GraphQLError[]? errors) = await Query<TransactionResponseType>(signTxQuery);
+        var stageQuery = $@"mutation {{
+            stageTransaction(payload: ""{data.Transaction.SignTransaction}"")
+        }}";
+        (success, MutationResponseType result, errors) = await Query<MutationResponseType>(stageQuery);
+        return (success, result.stageTransaction);
+    }
+
+    public static async Task<long> GetNextTxNonce(Libplanet.Address address)
+    {
+        var query = $@"query {{
+            transaction {{
+                nextTxNonce(address: ""{address}"")
+            }}
+        }}";
+        (bool success, TransactionResponseType data, GraphQLError[]? errors) = await Query<TransactionResponseType>(query);
+        return data.Transaction.NextTxNonce;
+    }
+
+    public static async Task<string> TxResult(string txId)
+    {
+        var query = $@"query {{
+            transaction {{
+                transactionResult(txId: ""{txId}"") {{
+                    txStatus
+                }}
+            }}
+        }}";
+        (bool success, TransactionResponseType data, GraphQLError[]? errors) =
+            await Query<TransactionResponseType>(query);
+        return data.Transaction.TransactionResult.TxStatus;
+    }
+}

--- a/NineChronicles.Test/Graphql.cs
+++ b/NineChronicles.Test/Graphql.cs
@@ -52,7 +52,8 @@ public static class Graphql
                 )
             }}
         }}";
-        (bool success, TransactionResponseType data, GraphQLError[]? errors) = await Query<TransactionResponseType>(signTxQuery);
+        (bool success, TransactionResponseType data, GraphQLError[]? errors) =
+            await Query<TransactionResponseType>(signTxQuery);
         var stageQuery = $@"mutation {{
             stageTransaction(payload: ""{data.Transaction.SignTransaction}"")
         }}";
@@ -79,7 +80,8 @@ public static class Graphql
                 nextTxNonce(address: ""{address}"")
             }}
         }}";
-        (bool success, TransactionResponseType data, GraphQLError[]? errors) = await Query<TransactionResponseType>(query);
+        (bool success, TransactionResponseType data, GraphQLError[]? errors) =
+            await Query<TransactionResponseType>(query);
         return data.Transaction.NextTxNonce;
     }
 

--- a/NineChronicles.Test/NineChronicles.Test.csproj
+++ b/NineChronicles.Test/NineChronicles.Test.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
+      <ProjectReference Include="..\NineChronicles.Headless\NineChronicles.Headless.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="GraphQL" Version="4.7.1" />
+      <PackageReference Include="GraphQL.Client" Version="5.1.0" />
+      <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="5.1.0" />
+    </ItemGroup>
+
+</Project>

--- a/NineChronicles.Test/NineChronicles.Test.csproj
+++ b/NineChronicles.Test/NineChronicles.Test.csproj
@@ -8,8 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.Explorer\Libplanet.Explorer.csproj" />
       <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
-      <ProjectReference Include="..\NineChronicles.Headless\NineChronicles.Headless.csproj" />
+      <ProjectReference Include="..\Lib9c\Lib9c.DevExtensions\Lib9c.DevExtensions.csproj" />
+      <ProjectReference Include="..\Lib9c\Lib9c\Lib9c.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NineChronicles.Test/Program.cs
+++ b/NineChronicles.Test/Program.cs
@@ -1,0 +1,9 @@
+﻿namespace NineChronicles.Test;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var pk = Address.GetKey();
+    }
+}

--- a/NineChronicles.Test/Program.cs
+++ b/NineChronicles.Test/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Libplanet;
+using Libplanet.Crypto;
 
 namespace NineChronicles.Test;
 
@@ -11,7 +12,12 @@ class Program
         {
             Console.WriteLine("Account activation required. Please input activation code");
             var activationCode = Console.ReadLine();
-            string txId = await Address.ActivateAccount(pk, activationCode!);
+            string? txId = await Address.ActivateAccount(pk, activationCode!);
+            if (txId is null)
+            {
+                return;
+            }
+
             string txResult = await Graphql.WaitTxMining(txId);
             if (txResult == "SUCCESS")
             {

--- a/NineChronicles.Test/Program.cs
+++ b/NineChronicles.Test/Program.cs
@@ -1,9 +1,25 @@
-﻿namespace NineChronicles.Test;
+﻿using Libplanet;
+
+namespace NineChronicles.Test;
 
 class Program
 {
     static async Task Main(string[] args)
     {
-        var pk = Address.GetKey();
+        var pk = await Address.GetKey();
+        if (await Graphql.GetNextTxNonce(pk.ToAddress()) == 0)
+        {
+            Console.WriteLine("Account activation required. Please input activation code");
+            var activationCode = Console.ReadLine();
+            string txId = await Address.ActivateAccount(pk, activationCode!);
+            Console.WriteLine("Waiting for tx confirmed...");
+            string txResult = await Graphql.TxResult(txId);
+            while (txResult == "STAGING")
+            {
+                txResult = await Graphql.TxResult(txId);
+            }
+
+            Console.WriteLine("Account activated.");
+        }
     }
 }

--- a/NineChronicles.Test/Program.cs
+++ b/NineChronicles.Test/Program.cs
@@ -12,14 +12,23 @@ class Program
             Console.WriteLine("Account activation required. Please input activation code");
             var activationCode = Console.ReadLine();
             string txId = await Address.ActivateAccount(pk, activationCode!);
-            Console.WriteLine("Waiting for tx confirmed...");
-            string txResult = await Graphql.TxResult(txId);
-            while (txResult == "STAGING")
+            string txResult = await Graphql.WaitTxMining(txId);
+            if (txResult == "SUCCESS")
             {
-                txResult = await Graphql.TxResult(txId);
+                Console.WriteLine("Account activated.");
             }
-
-            Console.WriteLine("Account activated.");
+            else
+            {
+                Console.WriteLine("Account activation failed. Please try with another activation code");
+            }
         }
+
+        var avatarAddress = await Avatar.SelectAvatar(pk);
+        if (avatarAddress is null)
+        {
+            Console.WriteLine("No avatar selected. Exiting...");
+            return;
+        }
+        // TODO: Do action
     }
 }

--- a/NineChronicles.Test/Type/ActionTxQueryType.cs
+++ b/NineChronicles.Test/Type/ActionTxQueryType.cs
@@ -1,0 +1,14 @@
+using System.Security.Cryptography.X509Certificates;
+using Libplanet;
+
+namespace NineChronicles.Test.Type;
+
+public class ActionTxQueryResponseType
+{
+    public ActionTxQueryType ActionTxQuery { get; set; }
+}
+
+public class ActionTxQueryType
+{
+    public string ActivateAccount  { get; set; }
+}

--- a/NineChronicles.Test/Type/ActionTxQueryType.cs
+++ b/NineChronicles.Test/Type/ActionTxQueryType.cs
@@ -1,6 +1,3 @@
-using System.Security.Cryptography.X509Certificates;
-using Libplanet;
-
 namespace NineChronicles.Test.Type;
 
 public class ActionTxQueryResponseType
@@ -10,5 +7,6 @@ public class ActionTxQueryResponseType
 
 public class ActionTxQueryType
 {
-    public string ActivateAccount  { get; set; }
+    public string ActivateAccount { get; set; }
+    public string CreateAvatar { get; set; }
 }

--- a/NineChronicles.Test/Type/MutationType.cs
+++ b/NineChronicles.Test/Type/MutationType.cs
@@ -1,0 +1,6 @@
+namespace NineChronicles.Test.Type;
+
+public class MutationResponseType
+{
+    public string stageTransaction { get; set; }
+}

--- a/NineChronicles.Test/Type/StateQueryType.cs
+++ b/NineChronicles.Test/Type/StateQueryType.cs
@@ -19,6 +19,17 @@ public class AgentType
     public long monsterCollectionRound { get; set; }
     public long monsterCollectionLevel { get; set; }
     public bool hasTradeItem { get; set; }
+
+    public override string ToString()
+    {
+        return $@"Agent Address: {address}
+Gold(NCG): {Gold}
+Crystal: {Crystal}
+Avatar: [
+{AvatarStates}
+]
+";
+    }
 }
 
 public class AvatarStateType
@@ -38,6 +49,7 @@ public class AvatarStateType
     public int Hair { get; set; }
     public int Lens { get; set; }
     public int Tail { get; set; }
+
     // // Inventory
     public Libplanet.Address[] CombinationSlotAddresses { get; set; }
     // // ItemMap
@@ -47,4 +59,14 @@ public class AvatarStateType
     // // QuestList
     // // MailBox
     // // WorldInformation
+
+    public override string ToString()
+    {
+        return $@"Avatar #{Index} : {Name}({Address})
+Lvl. {Level} (Exp {Exp})
+Action Point: {ActionPoint}
+DailyReward: {DailyRewardReceivedIndex} / Current Block {BlockIndex}
+Outfit: Ear {Ear} | Hair {Hair} | Lens {Lens} | Tail {Tail}
+";
+    }
 }

--- a/NineChronicles.Test/Type/StateQueryType.cs
+++ b/NineChronicles.Test/Type/StateQueryType.cs
@@ -1,0 +1,50 @@
+namespace NineChronicles.Test.Type;
+
+public class StateQueryResponseType
+{
+    public StateQueryType StateQuery { get; set; }
+}
+
+public class StateQueryType
+{
+    public AgentType? Agent { get; set; }
+}
+
+public class AgentType
+{
+    public Libplanet.Address address { get; set; }
+    public AvatarStateType[] AvatarStates { get; set; }
+    public string Gold { get; set; }
+    public string Crystal { get; set; }
+    public long monsterCollectionRound { get; set; }
+    public long monsterCollectionLevel { get; set; }
+    public bool hasTradeItem { get; set; }
+}
+
+public class AvatarStateType
+{
+    public Libplanet.Address Address { get; set; }
+    public int BlockIndex { get; set; }
+    public int CharacterId { get; set; }
+    public long DailyRewardReceivedIndex { get; set; }
+    public Libplanet.Address AgentAddress { get; set; }
+    public int Index { get; set; }
+    public long UpdatedAt { get; set; }
+    public string Name { get; set; }
+    public int Exp { get; set; }
+    public int Level { get; set; }
+    public int ActionPoint { get; set; }
+    public int Ear { get; set; }
+    public int Hair { get; set; }
+    public int Lens { get; set; }
+    public int Tail { get; set; }
+    // // Inventory
+    public Libplanet.Address[] CombinationSlotAddresses { get; set; }
+    // // ItemMap
+    // // EventMap
+    // // MonsterMap
+    // // StageMap
+    // // QuestList
+    // // MailBox
+    // // WorldInformation
+}

--- a/NineChronicles.Test/Type/TransactionType.cs
+++ b/NineChronicles.Test/Type/TransactionType.cs
@@ -1,6 +1,3 @@
-using Libplanet.Explorer.GraphTypes;
-using Nekoyume.BlockChain.Policy;
-
 namespace NineChronicles.Test.Type;
 
 public class TransactionResponseType

--- a/NineChronicles.Test/Type/TransactionType.cs
+++ b/NineChronicles.Test/Type/TransactionType.cs
@@ -1,0 +1,27 @@
+using Libplanet.Explorer.GraphTypes;
+using Nekoyume.BlockChain.Policy;
+
+namespace NineChronicles.Test.Type;
+
+public class TransactionResponseType
+{
+    public TransactionType Transaction { get; set; }
+}
+
+public class TransactionType
+{
+    public long NextTxNonce { get; set; }
+    public string SignTransaction { get; set; }
+    public TransactionResultType TransactionResult { get; set; }
+}
+
+public class TransactionResultType {
+    public string TxStatus { get; set; }
+    public long BlockIndex { get; set; }
+    public string BlockHash { get; set; }
+    public string ExceptionName { get; set; }
+    public string ExceptionMetadata { get; set; }
+    // updatedStates
+    // updatedFAV
+    // fungibleAssetsDelta
+}

--- a/NineChronicles.Test/Util.cs
+++ b/NineChronicles.Test/Util.cs
@@ -1,0 +1,26 @@
+namespace NineChronicles.Test;
+
+public class Util
+{
+    public static int Select<T>(IEnumerable<T> list)
+    {
+        bool usable = false;
+        int index = -1;
+        while (!usable)
+        {
+            var selectedIndex = Console.ReadLine();
+            usable = int.TryParse(selectedIndex, out index);
+            if (!usable)
+            {
+                Console.WriteLine("Please input number.");
+            }
+            else if (index > list.ToList().Count)
+            {
+                Console.WriteLine($"{index} is not on the list. Please set right one: ");
+                usable = false;
+            }
+        }
+
+        return index;
+    }
+}


### PR DESCRIPTION
New project `NineChronicles.Test` is created ant this is CLI program which can perform on-demand test 9c actions.

### Features
- GQL endpoints to faucet currency/crystals to player
  - Please refer [faucet actions in lib9c](https://github.com/planetarium/lib9c/pull/1585)
- CLI to load/create player and do action as player wishes.

### Caveat
- The faucet GQL endpoints must be isolated from production build environment.