### PR TITLE
Add snapshot feature to chain command

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -268,7 +268,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             store.Dispose();
             stateStore.Dispose();
             const string apv = "1";
-            var outputDirectory = Path.Combine(Path.GetTempPath(), "test");
+            var outputDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             _command.Snapshot(
                 apv,
@@ -279,9 +279,9 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             IStore storeAfterSnapshot = storeType.CreateStore(_storePath);
             chainId = storeAfterSnapshot.GetCanonicalChainId() ?? new Guid();
             var tipHashAfterSnapshot = storeAfterSnapshot.IndexBlockHash(chainId, -1);
-            var expectedGenesisPartitionSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "partition", $"snapshot-{genesisBlockEpoch}-{genesisBlockEpoch}.zip");
-            var expectedGenesisMetadataPath = Path.Combine(Path.GetTempPath(), "test", "metadata", $"snapshot-{genesisBlockEpoch}-{genesisBlockEpoch}.json");
-            var expectedFullSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "full", $"{genesisHash}-snapshot-{tipHashAfterSnapshot}.zip");
+            var expectedGenesisPartitionSnapshotPath = Path.Combine(outputDirectory, "partition", $"snapshot-{genesisBlockEpoch}-{genesisBlockEpoch}.zip");
+            var expectedGenesisMetadataPath = Path.Combine(outputDirectory, "metadata", $"snapshot-{genesisBlockEpoch}-{genesisBlockEpoch}.json");
+            var expectedFullSnapshotPath = Path.Combine(outputDirectory, "full", $"{genesisHash}-snapshot-{tipHashAfterSnapshot}.zip");
             storeAfterSnapshot.Dispose();
 
             Assert.True(File.Exists(expectedGenesisPartitionSnapshotPath));
@@ -294,9 +294,9 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
                 _storePath,
                 1,
                 ChainCommand.SnapshotType.All);
-            var expectedPartitionSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "partition", $"snapshot-{blockEpoch}-{blockEpoch}.zip");
-            var expectedStateSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "state", "state_latest.zip");
-            var expectedMetadataPath = Path.Combine(Path.GetTempPath(), "test", "metadata", $"snapshot-{blockEpoch}-{blockEpoch}.json");
+            var expectedPartitionSnapshotPath = Path.Combine(outputDirectory, "partition", $"snapshot-{blockEpoch}-{blockEpoch}.zip");
+            var expectedStateSnapshotPath = Path.Combine(outputDirectory, "state", "state_latest.zip");
+            var expectedMetadataPath = Path.Combine(outputDirectory, "metadata", $"snapshot-{blockEpoch}-{blockEpoch}.json");
             storeAfterSnapshot = storeType.CreateStore(_storePath);
             chainId = storeAfterSnapshot.GetCanonicalChainId() ?? new Guid();
             var indexCountAfterSnapshot = storeAfterSnapshot.CountIndex(chainId);

--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -220,6 +220,97 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             Assert.Equal(prevStatesCount, outputStatesCount);
         }
 
+        [Theory]
+        [InlineData(StoreType.RocksDb)]
+        public async Task Snapshot(StoreType storeType)
+        {
+            IStore store = storeType.CreateStore(_storePath);
+            var statesPath = Path.Combine(_storePath, "states");
+            Guid chainId = Guid.NewGuid();
+            store.SetCanonicalChainId(chainId);
+            var genesisBlock = MineGenesisBlock();
+            store.PutBlock(genesisBlock);
+            store.AppendIndex(chainId, genesisBlock.Hash);
+            var stateKeyValueStore = new RocksDBKeyValueStore(statesPath);
+            var stateStore = new TrieStateStore(stateKeyValueStore);
+            IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<NCAction>();
+            IBlockPolicy<NCAction> blockPolicy = new BlockPolicySource(Logger.None).GetPolicy();
+            BlockChain<NCAction> chain = new BlockChain<NCAction>(
+                blockPolicy,
+                stagePolicy,
+                store,
+                stateStore,
+                genesisBlock);
+            var action = new HackAndSlash
+            {
+                Costumes = new List<Guid>(),
+                Equipments = new List<Guid>(),
+                Foods = new List<Guid>(),
+                WorldId = 1,
+                StageId = 1,
+                AvatarAddress = default,
+                RuneInfos = new List<RuneSlotInfo>(),
+            };
+
+            var minerKey = new PrivateKey();
+            for (var i = 0; i < 2; i++)
+            {
+                chain.MakeTransaction(minerKey, new NCAction[] { action });
+                await chain.MineBlock(minerKey, DateTimeOffset.Now);
+            }
+
+            chain.ExecuteActions(chain.Tip);
+            var indexCountBeforeSnapshot = store.CountIndex(chainId);
+            const int blockEpochUnitSeconds = 86400;
+            var blockEpoch = (int) (chain.Tip.Timestamp.ToUnixTimeSeconds() / blockEpochUnitSeconds);
+            var genesisBlockEpoch = blockEpoch - 1;
+            var genesisHash = chain.Genesis.Hash;
+            store.Dispose();
+            stateStore.Dispose();
+            const string apv = "1";
+            var outputDirectory = Path.Combine(Path.GetTempPath(), "test");
+
+            _command.Snapshot(
+                apv,
+                outputDirectory,
+                _storePath,
+                1,
+                ChainCommand.SnapshotType.All);
+            IStore storeAfterSnapshot = storeType.CreateStore(_storePath);
+            chainId = storeAfterSnapshot.GetCanonicalChainId() ?? new Guid();
+            var tipHashAfterSnapshot = storeAfterSnapshot.IndexBlockHash(chainId, -1);
+            var expectedGenesisPartitionSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "partition", $"snapshot-{genesisBlockEpoch}-{genesisBlockEpoch}.zip");
+            var expectedGenesisMetadataPath = Path.Combine(Path.GetTempPath(), "test", "metadata", $"snapshot-{genesisBlockEpoch}-{genesisBlockEpoch}.json");
+            var expectedFullSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "full", $"{genesisHash}-snapshot-{tipHashAfterSnapshot}.zip"); 
+            storeAfterSnapshot.Dispose();
+
+            Assert.True(File.Exists(expectedGenesisPartitionSnapshotPath));
+            Assert.True(File.Exists(expectedGenesisMetadataPath));
+            Assert.True(File.Exists(expectedFullSnapshotPath));
+
+            _command.Snapshot(
+                apv,
+                outputDirectory,
+                _storePath,
+                1,
+                ChainCommand.SnapshotType.All);
+            var expectedPartitionSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "partition", $"snapshot-{blockEpoch}-{blockEpoch}.zip");
+            var expectedStateSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "state", "state_latest.zip");
+            var expectedMetadataPath = Path.Combine(Path.GetTempPath(), "test", "metadata", $"snapshot-{blockEpoch}-{blockEpoch}.json");
+            storeAfterSnapshot = storeType.CreateStore(_storePath);
+            chainId = storeAfterSnapshot.GetCanonicalChainId() ?? new Guid();
+            var indexCountAfterSnapshot = storeAfterSnapshot.CountIndex(chainId);
+            storeAfterSnapshot.Dispose();
+
+            Assert.True(File.Exists(expectedPartitionSnapshotPath));
+            Assert.True(File.Exists(expectedStateSnapshotPath));
+            Assert.True(File.Exists(expectedMetadataPath));
+            Assert.Equal(3, indexCountBeforeSnapshot);
+            Assert.Equal(2, indexCountAfterSnapshot);
+
+            Directory.Delete(outputDirectory, true);
+        }
+
         private Block<NCAction> MineGenesisBlock()
         {
             Dictionary<string, string> tableSheets = Lib9cUtils.ImportSheets("../../../../Lib9c/Lib9c/TableCSV");

--- a/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ChainCommandTest.cs
@@ -262,7 +262,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             chain.ExecuteActions(chain.Tip);
             var indexCountBeforeSnapshot = store.CountIndex(chainId);
             const int blockEpochUnitSeconds = 86400;
-            var blockEpoch = (int) (chain.Tip.Timestamp.ToUnixTimeSeconds() / blockEpochUnitSeconds);
+            var blockEpoch = (int)(chain.Tip.Timestamp.ToUnixTimeSeconds() / blockEpochUnitSeconds);
             var genesisBlockEpoch = blockEpoch - 1;
             var genesisHash = chain.Genesis.Hash;
             store.Dispose();
@@ -281,7 +281,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             var tipHashAfterSnapshot = storeAfterSnapshot.IndexBlockHash(chainId, -1);
             var expectedGenesisPartitionSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "partition", $"snapshot-{genesisBlockEpoch}-{genesisBlockEpoch}.zip");
             var expectedGenesisMetadataPath = Path.Combine(Path.GetTempPath(), "test", "metadata", $"snapshot-{genesisBlockEpoch}-{genesisBlockEpoch}.json");
-            var expectedFullSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "full", $"{genesisHash}-snapshot-{tipHashAfterSnapshot}.zip"); 
+            var expectedFullSnapshotPath = Path.Combine(Path.GetTempPath(), "test", "full", $"{genesisHash}-snapshot-{tipHashAfterSnapshot}.zip");
             storeAfterSnapshot.Dispose();
 
             Assert.True(File.Exists(expectedGenesisPartitionSnapshotPath));

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -377,7 +377,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 // If store changed epoch unit seconds, this will be changed too
                 const int blockEpochUnitSeconds = 86400;
                 const int txEpochUnitSeconds = 86400;
-                
+
                 string defaultStorePath = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                     "planetarium",
@@ -414,7 +414,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 var stateHashesPath = Path.Combine(storePath, "state_hashes");
 
                 var staleDirectories =
-                new [] { mainPath, statePath, stateRefPath, stateHashesPath};
+                new[] { mainPath, statePath, stateRefPath, stateHashesPath };
 #pragma warning disable S3267
                 foreach (var staleDirectory in staleDirectories)
                 {
@@ -445,7 +445,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
 
                 var genesisHash = store.IterateIndexes(chainId, 0, 1).First();
-                var tipHash = store.IndexBlockHash(chainId, -1) 
+                var tipHash = store.IndexBlockHash(chainId, -1)
                     ?? throw new CommandExitedException("The given chain seems empty.", -1);
                 if (!(store.GetBlockIndex(tipHash) is { } tipIndex))
                 {
@@ -495,9 +495,9 @@ namespace NineChronicles.Headless.Executable.Commands
                 var stringData = $"CopyStates Done. Time Taken: {(end - start).Minutes} min";
                 _console.Out.WriteLine(stringData);
 
-                var latestBlockEpoch = (int) (tip.Timestamp.ToUnixTimeSeconds() / blockEpochUnitSeconds);
+                var latestBlockEpoch = (int)(tip.Timestamp.ToUnixTimeSeconds() / blockEpochUnitSeconds);
                 var latestBlockWithTx = tip;
-                while(!latestBlockWithTx.Transactions.Any())
+                while (!latestBlockWithTx.Transactions.Any())
                 {
                     if (latestBlockWithTx.PreviousHash is { } newHash)
                     {
@@ -506,7 +506,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 }
 
                 var txTimeSecond = latestBlockWithTx.Transactions.Max(tx => tx.Timestamp.ToUnixTimeSeconds());
-                var latestTxEpoch = (int) (txTimeSecond / txEpochUnitSeconds);
+                var latestTxEpoch = (int)(txTimeSecond / txEpochUnitSeconds);
 
                 store.Dispose();
                 stateStore.Dispose();
@@ -602,7 +602,7 @@ namespace NineChronicles.Headless.Executable.Commands
                     stringData = $"Clone State Directory Done. Time Taken: {(end - start).Minutes} min";
                     _console.Out.WriteLine(stringData);
                 }
-                
+
                 if (snapshotType is SnapshotType.Full or SnapshotType.All)
                 {
                     _console.Out.WriteLine("Create Full ZipFile Start.");
@@ -825,7 +825,7 @@ namespace NineChronicles.Headless.Executable.Commands
                     .Where(x => Path.GetExtension(x) == ".json")
                     .OrderByDescending(File.GetLastWriteTime)
                     .First();
-                var jsonObject = JObject.Parse(File.ReadAllText(previousMetadata)); 
+                var jsonObject = JObject.Parse(File.ReadAllText(previousMetadata));
                 return (int)jsonObject[epochType]!;
             }
             catch (InvalidOperationException e)
@@ -876,7 +876,7 @@ namespace NineChronicles.Headless.Executable.Commands
                 _console.Out.WriteLine(ex.Message);
             }
         }
-        
+
         private void CleanEpoch(string path, int epochLimit)
         {
             string[] directories = Directory.GetDirectories(

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography;
 using Cocona;
@@ -17,6 +18,8 @@ using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Nekoyume.Action;
 using Nekoyume.BlockChain.Policy;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NineChronicles.Headless.Executable.IO;
 using NineChronicles.Headless.Executable.Store;
 using Serilog.Core;
@@ -27,6 +30,13 @@ namespace NineChronicles.Headless.Executable.Commands
     public class ChainCommand : CoconaLiteConsoleAppBase
     {
         private readonly IConsole _console;
+
+        public enum SnapshotType
+        {
+            Full,
+            Partition,
+            All
+        }
 
         public ChainCommand(IConsole console)
         {
@@ -58,8 +68,6 @@ namespace NineChronicles.Headless.Executable.Commands
                 throw new CommandExitedException($"The given STORE-PATH, {storePath} seems not existed.", -1);
             }
 
-            IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
-            IBlockPolicy<NCAction> blockPolicy = new BlockPolicySource(Logger.None).GetPolicy();
             IStore store = storeType.CreateStore(storePath);
             if (!(store.GetCanonicalChainId() is { } chainId))
             {
@@ -72,7 +80,7 @@ namespace NineChronicles.Headless.Executable.Commands
                           ?? throw new CommandExitedException("The given chain seems empty.", -1);
             Block<NCAction> tip = store.GetBlock<NCAction>(tipHash);
             _console.Out.WriteLine(Utils.SerializeHumanReadable(tip.Header));
-            (store as IDisposable)?.Dispose();
+            store.Dispose();
         }
 
         [Command(Description = "Print each block's mining time and tx stats (total tx, hack and slash, ranking battle, " +
@@ -191,7 +199,7 @@ namespace NineChronicles.Headless.Executable.Commands
                                        $"{mimisbrunnrBattleCount}");
             }
 
-            (store as IDisposable)?.Dispose();
+            store.Dispose();
         }
 
         [Command(Description = "Truncate the chain from the tip by the input value (in blocks)")]
@@ -247,7 +255,7 @@ namespace NineChronicles.Headless.Executable.Commands
                     -1);
             }
 
-            var tip = store.GetBlock<NCAction>(tipHash);
+            var tip = store.GetBlock<Utils.DummyAction>(tipHash);
             var snapshotTipIndex = Math.Max(tipIndex - (blocksBefore + 1), 0);
             BlockHash snapshotTipHash;
 
@@ -346,21 +354,596 @@ namespace NineChronicles.Headless.Executable.Commands
             Directory.Move(newStatesPath, statesPath);
         }
 
+        [Command(Description = "Take a chain snapshot and store it in a designated directory")]
+        public void Snapshot(
+            [Argument("APV",
+                Description = "APV to include in the snapshot metadata")]
+            string apv,
+            [Argument("OUTPUT-DIRECTORY",
+                Description = "Directory path to store the snapshot file")]
+            string outputDirectory,
+            [Argument("STORE-PATH",
+                Description = "Store path of the chain to take a snapshot")]
+            string? storePath = null,
+            [Argument("BLOCK-BEFORE",
+                Description = "Number of blocks to truncate from the tip")]
+            int blockBefore = 10,
+            [Argument("SNAPSHOT-TYPE",
+                Description = "Type of snapshot to take (full, partition, or all)")]
+            SnapshotType snapshotType = SnapshotType.Partition)
+        {
+            try
+            {
+                // If store changed epoch unit seconds, this will be changed too
+                const int blockEpochUnitSeconds = 86400;
+                const int txEpochUnitSeconds = 86400;
+                
+                string defaultStorePath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "planetarium",
+                    "9c"
+                );
+
+                Directory.CreateDirectory(outputDirectory);
+                Directory.CreateDirectory(Path.Combine(outputDirectory, "partition"));
+                Directory.CreateDirectory(Path.Combine(outputDirectory, "state"));
+                Directory.CreateDirectory(Path.Combine(outputDirectory, "metadata"));
+                Directory.CreateDirectory(Path.Combine(outputDirectory, "full"));
+
+                outputDirectory = string.IsNullOrEmpty(outputDirectory)
+                    ? Environment.CurrentDirectory
+                    : outputDirectory;
+
+                var metadataDirectory = Path.Combine(outputDirectory, "metadata");
+                int currentMetadataBlockEpoch = GetMetaDataEpoch(metadataDirectory, "BlockEpoch");
+                int currentMetadataTxEpoch = GetMetaDataEpoch(metadataDirectory, "TxEpoch");
+                int previousMetadataBlockEpoch = GetMetaDataEpoch(metadataDirectory, "PreviousBlockEpoch");
+                int previousMetadataTxEpoch = GetMetaDataEpoch(metadataDirectory, "PreviousTxEpoch");
+
+                storePath = string.IsNullOrEmpty(storePath) ? defaultStorePath : storePath;
+                if (!Directory.Exists(storePath))
+                {
+                    throw new CommandExitedException("Invalid store path. Please check --store-path is valid.", -1);
+                }
+
+                var statesPath = Path.Combine(storePath, "states");
+                var mainPath = Path.Combine(storePath, "9c-main");
+                var stateRefPath = Path.Combine(storePath, "stateref");
+                var statePath = Path.Combine(storePath, "state");
+                var newStatesPath = Path.Combine(storePath, "new_states");
+                var stateHashesPath = Path.Combine(storePath, "state_hashes");
+
+                var staleDirectories =
+                new [] { mainPath, statePath, stateRefPath, stateHashesPath};
+#pragma warning disable S3267
+                foreach (var staleDirectory in staleDirectories)
+                {
+                    if (Directory.Exists(staleDirectory))
+                    {
+                        Directory.Delete(staleDirectory, true);
+                    }
+                }
+#pragma warning restore S3267
+
+                _console.Out.WriteLine(RocksDBStore.MigrateChainDBFromColumnFamilies(Path.Combine(storePath, "chain"))
+                    ? "Successfully migrated IndexDB."
+                    : "Migration not required.");
+
+                IStore store = new RocksDBStore(
+                    storePath,
+                    blockEpochUnitSeconds: blockEpochUnitSeconds,
+                    txEpochUnitSeconds: txEpochUnitSeconds);
+                IKeyValueStore stateKeyValueStore = new RocksDBKeyValueStore(statesPath);
+                IKeyValueStore newStateKeyValueStore = new RocksDBKeyValueStore(newStatesPath);
+                TrieStateStore stateStore = new TrieStateStore(stateKeyValueStore);
+                var newStateStore = new TrieStateStore(newStateKeyValueStore);
+
+                var canonicalChainId = store.GetCanonicalChainId();
+                if (!(canonicalChainId is { } chainId))
+                {
+                    throw new CommandExitedException("Canonical chain doesn't exist.", -1);
+                }
+
+                var genesisHash = store.IterateIndexes(chainId, 0, 1).First();
+                var tipHash = store.IndexBlockHash(chainId, -1) 
+                    ?? throw new CommandExitedException("The given chain seems empty.", -1);
+                if (!(store.GetBlockIndex(tipHash) is { } tipIndex))
+                {
+                    throw new CommandExitedException(
+                        $"The index of {tipHash} doesn't exist.",
+                        -1);
+                }
+
+                Block<Utils.DummyAction> tip = store.GetBlock<Utils.DummyAction>(tipHash);
+                var snapshotTipIndex = Math.Max(tipIndex - (blockBefore + 1), 0);
+                BlockHash snapshotTipHash;
+
+                do
+                {
+                    snapshotTipIndex++;
+
+                    if (!(store.IndexBlockHash(chainId, snapshotTipIndex) is { } hash))
+                    {
+                        throw new CommandExitedException(
+                            $"The index {snapshotTipIndex} doesn't exist on ${chainId}.",
+                            -1);
+                    }
+
+                    snapshotTipHash = hash;
+                } while (!stateStore.ContainsStateRoot(store.GetBlock<Utils.DummyAction>(snapshotTipHash).StateRootHash));
+
+                var forkedId = Guid.NewGuid();
+
+                Fork(chainId, forkedId, snapshotTipHash, tip, store);
+
+                store.SetCanonicalChainId(forkedId);
+                foreach (var id in store.ListChainIds().Where(id => !id.Equals(forkedId)))
+                {
+                    store.DeleteChainId(id);
+                }
+
+                var snapshotTipDigest = store.GetBlockDigest(snapshotTipHash);
+                var snapshotTipStateRootHash = store.GetStateRootHash(snapshotTipHash);
+
+                _console.Out.WriteLine("CopyStates Start.");
+                var start = DateTimeOffset.Now;
+                stateStore.CopyStates(ImmutableHashSet<HashDigest<SHA256>>.Empty
+#pragma warning disable CS8629
+                    .Add((HashDigest<SHA256>)snapshotTipStateRootHash), newStateStore);
+#pragma warning restore CS8629
+                var end = DateTimeOffset.Now;
+                var stringData = $"CopyStates Done. Time Taken: {(end - start).Minutes} min";
+                _console.Out.WriteLine(stringData);
+
+                var latestBlockEpoch = (int) (tip.Timestamp.ToUnixTimeSeconds() / blockEpochUnitSeconds);
+                var latestBlockWithTx = GetLatestBlockWithTransaction(tip, store);
+                var txTimeSecond = latestBlockWithTx.Transactions.Max(tx => tx.Timestamp.ToUnixTimeSeconds());
+                var latestTxEpoch = (int) (txTimeSecond / txEpochUnitSeconds);
+
+                store.Dispose();
+                stateStore.Dispose();
+                newStateKeyValueStore.Dispose();
+
+                _console.Out.WriteLine("Move States Start.");
+                start = DateTimeOffset.Now;
+                Directory.Delete(statesPath, recursive: true);
+                Directory.Move(newStatesPath, statesPath);
+                end = DateTimeOffset.Now;
+                stringData = $"Move States Done. Time Taken: {(end - start).Minutes} min";
+                _console.Out.WriteLine(stringData);
+
+                var partitionBaseFilename = GetPartitionBaseFileName(
+                    currentMetadataBlockEpoch,
+                    currentMetadataTxEpoch,
+                    latestBlockEpoch);
+                var stateBaseFilename = $"state_latest";
+
+                var fullSnapshotDirectory = Path.Combine(outputDirectory, "full");
+                var genesisHashHex = ByteUtil.Hex(genesisHash.ToByteArray());
+                var snapshotTipHashHex = ByteUtil.Hex(snapshotTipHash.ToByteArray());
+                var fullSnapshotFilename = $"{genesisHashHex}-snapshot-{snapshotTipHashHex}.zip";
+                var fullSnapshotPath = Path.Combine(fullSnapshotDirectory, fullSnapshotFilename);
+
+                var partitionSnapshotFilename = $"{partitionBaseFilename}.zip";
+                var partitionSnapshotPath = Path.Combine(outputDirectory, "partition", partitionSnapshotFilename);
+                var stateSnapshotFilename = $"{stateBaseFilename}.zip";
+                var stateSnapshotPath = Path.Combine(outputDirectory, "state", stateSnapshotFilename);
+                string partitionDirectory = Path.Combine(Path.GetTempPath(), "snapshot");
+                string stateDirectory = Path.Combine(Path.GetTempPath(), "state");
+
+                if (Directory.Exists(partitionDirectory))
+                {
+                    Directory.Delete(partitionDirectory, true);
+                }
+
+                if (Directory.Exists(stateDirectory))
+                {
+                    Directory.Delete(stateDirectory, true);
+                }
+
+                _console.Out.WriteLine("Clean Store Start.");
+                start = DateTimeOffset.Now;
+                CleanStore(
+                    partitionSnapshotPath,
+                    stateSnapshotPath,
+                    fullSnapshotPath,
+                    storePath);
+                end = DateTimeOffset.Now;
+                stringData = $"Clean Store Done. Time Taken: {(end - start).Minutes} min";
+                _console.Out.WriteLine(stringData);
+
+                if (snapshotType is SnapshotType.Partition or SnapshotType.All)
+                {
+                    var storeBlockPath = Path.Combine(storePath, "block");
+                    var storeTxPath = Path.Combine(storePath, "tx");
+                    var partitionDirBlockPath = Path.Combine(partitionDirectory, "block");
+                    var partitionDirTxPath = Path.Combine(partitionDirectory, "tx");
+                    _console.Out.WriteLine("Clone Partition Directory Start.");
+                    start = DateTimeOffset.Now;
+                    CopyDirectory(storeBlockPath, partitionDirBlockPath, true);
+                    CopyDirectory(storeTxPath, partitionDirTxPath, true);
+                    end = DateTimeOffset.Now;
+                    stringData = $"Clone Partition Directory Done. Time Taken: {(end - start).Minutes} min";
+                    _console.Out.WriteLine(stringData);
+
+                    // get epoch limit for block & tx
+                    var blockEpochLimit = GetEpochLimit(
+                        latestBlockEpoch,
+                        currentMetadataBlockEpoch,
+                        previousMetadataBlockEpoch);
+                    var txEpochLimit = GetEpochLimit(
+                        latestTxEpoch,
+                        currentMetadataTxEpoch,
+                        previousMetadataTxEpoch);
+
+                    _console.Out.WriteLine("Clean Partition Store Start.");
+                    start = DateTimeOffset.Now;
+                    // clean epoch directories in block & tx
+                    CleanEpoch(partitionDirBlockPath, blockEpochLimit);
+                    CleanEpoch(partitionDirTxPath, txEpochLimit);
+
+                    CleanPartitionStore(partitionDirectory);
+                    end = DateTimeOffset.Now;
+                    stringData = $"Clean Partition Store Done. Time Taken: {(end - start).Minutes} min";
+                    _console.Out.WriteLine(stringData);
+
+                    _console.Out.WriteLine("Clone State Directory Start.");
+                    start = DateTimeOffset.Now;
+                    CopyStateStore(storePath, stateDirectory);
+                    end = DateTimeOffset.Now;
+                    stringData = $"Clone State Directory Done. Time Taken: {(end - start).Minutes} min";
+                    _console.Out.WriteLine(stringData);
+                }
+                
+                if (snapshotType is SnapshotType.Full or SnapshotType.All)
+                {
+                    _console.Out.WriteLine("Create Full ZipFile Start.");
+                    start = DateTimeOffset.Now;
+                    ZipFile.CreateFromDirectory(storePath, fullSnapshotPath);
+                    end = DateTimeOffset.Now;
+                    stringData = $"Create Full ZipFile Done. Time Taken: {(end - start).Minutes} min";
+                    _console.Out.WriteLine(stringData);
+                }
+
+                if (snapshotType is SnapshotType.Partition or SnapshotType.All)
+                {
+                    _console.Out.WriteLine("Create Partition ZipFile Start.");
+                    start = DateTimeOffset.Now;
+                    ZipFile.CreateFromDirectory(partitionDirectory, partitionSnapshotPath);
+                    end = DateTimeOffset.Now;
+                    stringData = $"Create Partition ZipFile Done. Time Taken: {(end - start).Minutes} min";
+                    _console.Out.WriteLine(stringData);
+                    _console.Out.WriteLine("Create State ZipFile Start.");
+                    start = DateTimeOffset.Now;
+                    ZipFile.CreateFromDirectory(stateDirectory, stateSnapshotPath);
+                    end = DateTimeOffset.Now;
+                    stringData = $"Create State ZipFile Done. Time Taken: {(end - start).Minutes} min";
+                    _console.Out.WriteLine(stringData);
+
+                    if (snapshotTipDigest is null)
+                    {
+                        throw new CommandExitedException("Tip does not exist.", -1);
+                    }
+
+                    string stringifyMetadata = CreateMetadata(
+                        snapshotTipDigest.Value,
+                        apv,
+                        currentMetadataBlockEpoch,
+                        currentMetadataTxEpoch,
+                        previousMetadataBlockEpoch,
+                        latestBlockEpoch);
+                    var metadataFilename = $"{partitionBaseFilename}.json";
+                    var metadataPath = Path.Combine(metadataDirectory, metadataFilename);
+
+                    if (File.Exists(metadataPath))
+                    {
+                        File.Delete(metadataPath);
+                    }
+
+                    File.WriteAllText(metadataPath, stringifyMetadata);
+                    Directory.Delete(partitionDirectory, true);
+                    Directory.Delete(stateDirectory, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _console.Out.WriteLine(ex.Message);
+            }
+        }
+
+        private string GetPartitionBaseFileName(
+            int currentMetadataBlockEpoch,
+            int currentMetadataTxEpoch,
+            int latestBlockEpoch
+        )
+        {
+            // decrease latest epochs by 1 when creating genesis snapshot
+            if (currentMetadataBlockEpoch == 0 && currentMetadataTxEpoch == 0)
+            {
+                return $"snapshot-{latestBlockEpoch - 1}-{latestBlockEpoch - 1}";
+            }
+            else
+            {
+                return $"snapshot-{latestBlockEpoch}-{latestBlockEpoch}";
+            }
+        }
+
+        private int GetEpochLimit(
+            int latestEpoch,
+            int currentMetadataEpoch,
+            int previousMetadataEpoch
+        )
+        {
+            if (latestEpoch == currentMetadataEpoch)
+            {
+                // case when all epochs are the same
+                if (latestEpoch == previousMetadataEpoch)
+                {
+                    // return previousMetadataEpoch - 1
+                    // to save previous epoch in snapshot
+                    return previousMetadataEpoch - 1;
+                }
+
+                // case when metadata points to genesis snapshot
+                if (previousMetadataEpoch == 0)
+                {
+                    return currentMetadataEpoch - 1;
+                }
+
+                return previousMetadataEpoch;
+            }
+
+            return currentMetadataEpoch;
+        }
+
+        private string CreateMetadata(
+            BlockDigest snapshotTipDigest,
+            string apv,
+            int currentMetadataBlockEpoch,
+            int currentMetadataTxEpoch,
+            int previousMetadataBlockEpoch,
+            int latestBlockEpoch)
+        {
+            BlockHeader snapshotTipHeader = snapshotTipDigest.GetHeader();
+            JObject jsonObject = JObject.FromObject(snapshotTipHeader);
+            jsonObject.Add("APV", apv);
+
+            jsonObject = AddPreviousEpochs(
+                jsonObject,
+                currentMetadataBlockEpoch,
+                previousMetadataBlockEpoch,
+                latestBlockEpoch,
+                "PreviousBlockEpoch",
+                "PreviousTxEpoch");
+
+            // decrease latest epochs by 1 for genesis snapshot
+            if (currentMetadataBlockEpoch == 0 && currentMetadataTxEpoch == 0)
+            {
+                jsonObject.Add("BlockEpoch", latestBlockEpoch - 1);
+                jsonObject.Add("TxEpoch", latestBlockEpoch - 1);
+            }
+            else
+            {
+                jsonObject.Add("BlockEpoch", latestBlockEpoch);
+                jsonObject.Add("TxEpoch", latestBlockEpoch);
+            }
+
+            return JsonConvert.SerializeObject(jsonObject);
+        }
+
+        private void CleanStore(
+            string partitionSnapshotPath,
+            string stateSnapshotPath,
+            string fullSnapshotPath,
+            string storePath)
+        {
+            if (File.Exists(partitionSnapshotPath))
+            {
+                File.Delete(partitionSnapshotPath);
+            }
+
+            if (File.Exists(stateSnapshotPath))
+            {
+                File.Delete(stateSnapshotPath);
+            }
+
+            if (File.Exists(fullSnapshotPath))
+            {
+                File.Delete(fullSnapshotPath);
+            }
+
+            var cleanDirectories = new[]
+            {
+                Path.Combine(storePath, "blockpercept"),
+                Path.Combine(storePath, "stagedtx")
+            };
+
+#pragma warning disable S3267
+            foreach (var path in cleanDirectories)
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, true);
+                }
+            }
+#pragma warning restore S3267
+        }
+
+        private void CleanPartitionStore(string partitionDirectory)
+        {
+            var cleanDirectories = new[]
+            {
+                Path.Combine(partitionDirectory, "block", "blockindex"),
+                Path.Combine(partitionDirectory, "tx", "txindex"),
+            };
+
+#pragma warning disable S3267
+            foreach (var path in cleanDirectories)
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, true);
+                }
+            }
+#pragma warning restore S3267
+        }
+
+        private void CopyStateStore(string storePath, string stateDirectory)
+        {
+            var storeBlockIndexPath = Path.Combine(storePath, "block", "blockindex");
+            var storeTxIndexPath = Path.Combine(storePath, "tx", "txindex");
+            var storeTxBIndexPath = Path.Combine(storePath, "txbindex");
+            var storeStatesPath = Path.Combine(storePath, "states");
+            var storeChainPath = Path.Combine(storePath, "chain");
+            var stateDirBlockIndexPath = Path.Combine(stateDirectory, "block", "blockindex");
+            var stateDirTxIndexPath = Path.Combine(stateDirectory, "tx", "txindex");
+            var stateDirTxBIndexPath = Path.Combine(stateDirectory, "txbindex");
+            var stateDirStatesPath = Path.Combine(stateDirectory, "states");
+            var stateDirChainPath = Path.Combine(stateDirectory, "chain");
+            CopyDirectory(storeBlockIndexPath, stateDirBlockIndexPath, true);
+            CopyDirectory(storeTxIndexPath, stateDirTxIndexPath, true);
+            CopyDirectory(storeTxBIndexPath, stateDirTxBIndexPath, true);
+            CopyDirectory(storeStatesPath, stateDirStatesPath, true);
+            CopyDirectory(storeChainPath, stateDirChainPath, true);
+        }
+
+        private int GetMetaDataEpoch(
+            string outputDirectory,
+            string epochType)
+        {
+            try
+            {
+                string previousMetadata = Directory.GetFiles(outputDirectory)
+                    .Where(x => Path.GetExtension(x) == ".json")
+                    .OrderByDescending(File.GetLastWriteTime)
+                    .First();
+                var jsonObject = JObject.Parse(File.ReadAllText(previousMetadata)); 
+                return (int)jsonObject[epochType]!;
+            }
+            catch (InvalidOperationException e)
+            {
+                Console.Error.WriteLine(e.Message);
+                return 0;
+            }
+        }
+
+        private Block<T> GetLatestBlockWithTransaction<T>(Block<T> tip, IStore store)
+            where T : Utils.DummyAction, new()
+        {
+            var block = tip;
+            while(!block.Transactions.Any())
+            {
+                if (block.PreviousHash is { } newHash)
+                {
+                    block = store.GetBlock<T>(newHash);
+                }
+            }
+            return block;
+        }
+
+        private void CopyDirectory(string sourceDir, string destinationDir, bool recursive)
+        {
+            try
+            {
+                // Get information about the source directory
+                var dir = new DirectoryInfo(sourceDir);
+
+                // Check if the source directory exists
+                if (!dir.Exists)
+                {
+                    throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
+                }
+
+                // Cache directories before we start copying
+                DirectoryInfo[] dirs = dir.GetDirectories();
+
+                // Create the destination directory
+                Directory.CreateDirectory(destinationDir);
+
+                // Get the files in the source directory and copy to the destination directory
+                foreach (FileInfo file in dir.GetFiles())
+                {
+                    string targetFilePath = Path.Combine(destinationDir, file.Name);
+                    file.CopyTo(targetFilePath);
+                }
+
+                // If recursive and copying subdirectories, recursively call this method
+                if (recursive)
+                {
+                    foreach (DirectoryInfo subDir in dirs)
+                    {
+                        string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+                        CopyDirectory(subDir.FullName, newDestinationDir, true);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _console.Out.WriteLine(ex.Message);
+            }
+        }
+        
+        private void CleanEpoch(string path, int epochLimit)
+        {
+            string[] directories = Directory.GetDirectories(
+                path,
+                "epoch*",
+                SearchOption.AllDirectories);
+            try
+            {
+                foreach (string dir in directories)
+                {
+                    string dirName = new DirectoryInfo(dir).Name;
+                    int epoch = int.Parse(dirName.Substring(5));
+                    if (epoch < epochLimit)
+                    {
+                        Directory.Delete(dir, true);
+                    }
+                }
+            }
+            catch (FormatException)
+            {
+                throw new FormatException("Epoch value is not numeric.");
+            }
+        }
+
+        private JObject AddPreviousEpochs(
+            JObject jsonObject,
+            int currentMetadataEpoch,
+            int previousMetadataEpoch,
+            int latestEpoch,
+            string blockEpochName,
+            string txEpochName)
+        {
+            if (currentMetadataEpoch == latestEpoch)
+            {
+                jsonObject.Add(blockEpochName, previousMetadataEpoch);
+                jsonObject.Add(txEpochName, previousMetadataEpoch);
+            }
+            else
+            {
+                jsonObject.Add(blockEpochName, currentMetadataEpoch);
+                jsonObject.Add(txEpochName, currentMetadataEpoch);
+            }
+
+            return jsonObject;
+        }
+
         private void Fork(
             Guid src,
             Guid dest,
             BlockHash branchPointHash,
-            Block<NCAction> tip,
+            Block<Utils.DummyAction> tip,
             IStore store)
         {
             store.ForkBlockIndexes(src, dest, branchPointHash);
             store.ForkTxNonces(src, dest);
 
             for (
-                Block<NCAction> block = tip;
+                Block<Utils.DummyAction> block = tip;
                 block.PreviousHash is { } hash
                 && !block.Hash.Equals(branchPointHash);
-                block = store.GetBlock<NCAction>(hash))
+                block = store.GetBlock<Utils.DummyAction>(hash))
             {
                 IEnumerable<(Address, int)> signers = block
                     .Transactions

--- a/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ChainCommand.cs
@@ -384,17 +384,18 @@ namespace NineChronicles.Headless.Executable.Commands
                     "9c"
                 );
 
+                var metadataDirectory = Path.Combine(outputDirectory, "metadata");
+
                 Directory.CreateDirectory(outputDirectory);
                 Directory.CreateDirectory(Path.Combine(outputDirectory, "partition"));
                 Directory.CreateDirectory(Path.Combine(outputDirectory, "state"));
-                Directory.CreateDirectory(Path.Combine(outputDirectory, "metadata"));
+                Directory.CreateDirectory(metadataDirectory);
                 Directory.CreateDirectory(Path.Combine(outputDirectory, "full"));
 
                 outputDirectory = string.IsNullOrEmpty(outputDirectory)
                     ? Environment.CurrentDirectory
                     : outputDirectory;
 
-                var metadataDirectory = Path.Combine(outputDirectory, "metadata");
                 int currentMetadataBlockEpoch = GetMetaDataEpoch(metadataDirectory, "BlockEpoch");
                 int currentMetadataTxEpoch = GetMetaDataEpoch(metadataDirectory, "TxEpoch");
                 int previousMetadataBlockEpoch = GetMetaDataEpoch(metadataDirectory, "PreviousBlockEpoch");

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@
 $ dotnet run --project ./NineChronicles.Headless.Executable/ -- --help
 
 Usage: NineChronicles.Headless.Executable [command]
-Usage: NineChronicles.Headless.Executable [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <UInt16>] [--swarm-private-key <String>] [--workers <Int32>] [--no-miner] [--miner-count <Int32>] [--miner-private-key <String>] [--store-type <String>] [--store-path <String>] [--no-reduce-store] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...] [--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Int32>] [--rpc-remote-server] [--rpc-http-server] [--graphql-server] [--graphql-host <String>] [--graphql-port <Int32>] [--graphql-secret-token-path <String>] [--no-cors] [--confirmations <Int32>] [--nonblock-renderer] [--nonblock-renderer-queue <Int32>] [--strict-rendering] [--log-action-renders] [--network-type <NetworkType>] [--dev] [--dev.block-interval <Int32>] [--dev.reorg-interval <Int32>] [--aws-cognito-identity <String>] [--aws-access-key <String>] [--aws-secret-key <String>] [--aws-region <String>] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <Int32>] [--demand-buffer <Int32>] [--static-peer <String>...] [--skip-preload] [--minimum-broadcast-target <Int32>] [--bucket-size <Int32>] [--chain-tip-stale-behavior-type <String>] [--tx-quota-per-signer <Int32>] [--maximum-poll-peers <Int32>] [--config <String>] [--help] [--version]
+Usage: NineChronicles.Headless.Executable [--app-protocol-version <String>] [--genesis-block-path <String>] [--host <String>] [--port <UInt16>] [--swarm-private-key <String>] [--workers <Int32>] [--no-miner] [--miner-count <Int32>]
+[--miner-private-key <String>] [--miner.block-interval <Int32>] [--store-type <String>] [--store-path <String>] [--no-reduce-store] [--ice-server <String>...] [--peer <String>...] [--trusted-app-protocol-version-signer <String>...]
+[--rpc-server] [--rpc-listen-host <String>] [--rpc-listen-port <Int32>] [--rpc-remote-server] [--rpc-http-server] [--graphql-server] [--graphql-host <String>] [--graphql-port <Int32>] [--graphql-secret-token-path <String>] [--no-cor
+s] [--confirmations <Int32>] [--nonblock-renderer] [--nonblock-renderer-queue <Int32>] [--strict-rendering] [--log-action-renders] [--network-type <NetworkType>] [--tx-life-time <Int32>] [--message-timeout <Int32>] [--tip-timeout <I
+nt32>] [--demand-buffer <Int32>] [--static-peer <String>...] [--skip-preload] [--minimum-broadcast-target <Int32>] [--bucket-size <Int32>] [--chain-tip-stale-behavior-type <String>] [--tx-quota-per-signer <Int32>] [--maximum-poll-pe
+ers <Int32>] [--config <String>] [--sentry-dsn <String>] [--sentry-trace-sample-rate <Double>] [--help] [--version]
 
 NineChronicles.Headless.Executable
 
@@ -35,6 +40,7 @@ Commands:
   tx
   market
   genesis
+  replay
 
 Options:
   -V, --app-protocol-version <String>                      App protocol version token.
@@ -46,6 +52,7 @@ Options:
   --no-miner                                               Disable block mining.
   --miner-count <Int32>                                    The number of miner task(thread).
   --miner-private-key <String>                             The private key used for mining blocks. Must not be null if you want to turn on mining with libplanet-node.
+  --miner.block-interval <Int32>                           The miner's break time after mining a block. The unit is millisecond.
   --store-type <String>                                    The type of storage to store blockchain data. If not provided, "LiteDB" will be used as default. Available type: ["rocksdb", "memory"]
   --store-path <String>                                    Path of storage. This value is required if you use persistent storage e.g. "rocksdb"
   --no-reduce-store                                        Do not reduce storage. Enabling this option will use enormous disk spaces.
@@ -68,13 +75,6 @@ Options:
   --strict-rendering                                       Flag to turn on validating action renderer.
   --log-action-renders                                     Log action renders besides block renders. --rpc-server implies this.
   --network-type <NetworkType>                             Network type. (Allowed values: Main, Internal, Permanent, Test, Default)
-  --dev                                                    Flag to turn on the dev mode. false by default.
-  --dev.block-interval <Int32>                             The time interval between blocks. It's unit is milliseconds. Works only when dev mode is on.
-  --dev.reorg-interval <Int32>                             The size of reorg interval. Works only when dev mode is on.
-  --aws-cognito-identity <String>                          The Cognito identity for AWS CloudWatch logging.
-  --aws-access-key <String>                                The access key for AWS CloudWatch logging.
-  --aws-secret-key <String>                                The secret key for AWS CloudWatch logging.
-  --aws-region <String>                                    The AWS region for AWS CloudWatch (e.g., us-east-1, ap-northeast-2).
   --tx-life-time <Int32>                                   The lifetime of each transaction, which uses minute as its unit.
   --message-timeout <Int32>                                The grace period for new messages, which uses second as its unit.
   --tip-timeout <Int32>                                    The grace period for tip update, which uses second as its unit.
@@ -86,7 +86,9 @@ Options:
   --chain-tip-stale-behavior-type <String>                 Determines behavior when the chain's tip is stale. "reboot" and "preload" is available and "reboot" option is selected by default.
   --tx-quota-per-signer <Int32>                            The number of maximum transactions can be included in stage per signer.
   --maximum-poll-peers <Int32>                             The maximum number of peers to poll blocks. int.MaxValue by default.
-  -C, --config <String>                                    Path of "appsettings.json" file to provide headless configurations. (Default: appsettings.json)
+  -C, --config <String>                                    Absolute path of "appsettings.json" file to provide headless configurations. (Default: appsettings.json)
+  --sentry-dsn <String>                                    Sentry DSN
+  --sentry-trace-sample-rate <Double>                      Trace sample rate for sentry
   -h, --help                                               Show help message
   --version                                                Show version
 ```


### PR DESCRIPTION
This PR adds the `snapshot` feature to the `headless chain command`, mostly taken from https://github.com/planetarium/NineChronicles.Snapshot. This should make maintenance much easier.