### PR TITLE
update TrustedAppProtocolVersionSignerStrings

### DIFF
--- a/NineChronicles.Headless.Executable/appsettings.mainnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.mainnet.json
@@ -106,7 +106,7 @@
             "0247e289aa332260b99dfd50e578f779df9e6702d67e50848bb68f3e0737d9b9a5,9c-main-tcp-seed-3.planetarium.dev,31234"
         ],
         "TrustedAppProtocolVersionSignerStrings": [
-            "03eeedcd574708681afb3f02fb2aef7c643583089267d17af35e978ecaf2a1184e"
+            "030ffa9bd579ee1503ce008394f687c182279da913bfaec12baca34e79698a7cd1"
         ],
         "NoMiner": true,
         "RpcServer": true,


### PR DESCRIPTION
Updating the `TrustedAppProtocolVersionSignerStrings` value based on https://github.com/planetarium/9c-k8s-config/blob/main/9c-main/remote-headless-1.yaml#L37