### PR TITLE
Introduce JSON schema for appsettings.json

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,18 @@ jobs:
                   dotnet-version: 6.0.*
             - name: dotnet format
               run: dotnet format --exclude Lib9c --exclude NineChronicles.RPC.Shared -v=d --no-restore --verify-no-changes
+    validate-appsettings-json:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Install ajv-cli
+              run: yarn global add ajv-cli
+            - name: Validate appsettings.*.json
+              working-directory: NineChronicles.Headless.Executable
+              run: |
+                set -evx
+
+                FILES=(appsettings.mainnet.json appsettings.internal.json appsettings.previewnet.json appsettings.json)
+                for file in ${FILES[@]}; do
+                  ajv validate -s appsettings-schema.json -d "$file"
+                done

--- a/NineChronicles.Headless.Executable/appsettings-schema.json
+++ b/NineChronicles.Headless.Executable/appsettings-schema.json
@@ -1,0 +1,67 @@
+{
+    "type": "object",
+    "description": "appsettings.json to configure application.",
+    "properties": {
+        "Headless": {
+            "type": "object",
+            "properties": {
+                "DynamicActionTypeLoader": {
+                    "type": "object",
+                    "description": "Optional configuration for using DynamicActionTypeLoader.  It requires to prepare dlls to load dynamically in the '<BasePath>/<VersionName>/<AssemblyFileName>' format.",
+                    "properties": {
+                        "BasePath": {
+                            "type": "string",
+                            "description": "Base path of dlls to load dynamically. It means '/tmp/dlls' in '/tmp/dlls/v100350/Lib9c.dll', assembly path."
+                        },
+                        "AssemblyFileName": {
+                            "type": "string",
+                            "description": "The name of assembly file. (e.g., Lib9c.dll)",
+                            "examples": [
+                                "Lib9c.dll"
+                            ]
+                        },
+                        "HardForks": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "SinceBlockIndex": {
+                                        "type": "integer",
+                                        "description": "The block index when the version started."
+                                    },
+                                    "VersionName": {
+                                        "type": "string",
+                                        "description": "The name of the version since 'SinceBlockIndex'. It means 'v100350' in '/tmp/dlls/v100350/Lib9c.dll', assembly path."
+                                    }
+                                },
+                                "required": ["SinceBlockIndex", "VersionName"],
+                                "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "examples": [
+                                [
+                                    {
+                                        "SinceBlockIndex": 0,
+                                        "VersionName": "v100321"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "SinceBlockIndex": 0,
+                                        "VersionName": "v100321"
+                                    },
+                                    {
+                                        "SinceBlockIndex": 100,
+                                        "VersionName": "v100330"
+                                    }
+                                ]
+                            ]
+                        }
+                    },
+                    "required": ["BasePath", "HardForks", "AssemblyFileName"],
+                    "additionalProperties": false
+                }
+            }
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable/appsettings.internal.json
+++ b/NineChronicles.Headless.Executable/appsettings.internal.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "./appsettings-schema.json",
     "Serilog": {
         "Using": [
             "Serilog.Expressions",

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "./appsettings-schema.json",
     "Serilog": {
         "Using": [
             "Serilog.Expressions",

--- a/NineChronicles.Headless.Executable/appsettings.mainnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.mainnet.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "./appsettings-schema.json",
     "Serilog": {
         "Using": [
             "Serilog.Expressions",

--- a/NineChronicles.Headless.Executable/appsettings.previewnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.previewnet.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "./appsettings-schema.json",
     "Serilog": {
         "Using": [
             "Serilog.Expressions",


### PR DESCRIPTION
This pull request resolves #1820. There is [JSON Schema][json-schema-spec] to make available defining JSON's schema. With the schema, you can see the hint or error messages:

Hint:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/26626194/211773499-dc65c973-c4f5-4229-bd8d-c816a4108df8.png">

Error:
<img width="627" alt="image" src="https://user-images.githubusercontent.com/26626194/211773603-0d4d2a51-3e3a-44a8-a617-289b017ce419.png">

And it introduces the GitHub Actions workflow to make our configuration files follow the schema well.

Now, the schema supports only for `DynamicActionTypeLoader` feature.

[json-schema-spec]: https://json-schema.org