### PR TITLE
Intorduce configuration for `StaticActionTypeLoader`

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -71,9 +71,5 @@ namespace Libplanet.Headless.Hosting
         public string ChainTipStaleBehavior { get; set; } = "reboot";
 
         public int MaximumPollPeers { get; set; } = int.MaxValue;
-
-#nullable enable
-        public DynamicActionTypeLoaderConfiguration? DynamicActionTypeLoader { get; init; } = null;
-#nullable disable
     }
 }

--- a/NineChronicles.Headless.Executable/ActionTypeLoaderConfiguration.cs
+++ b/NineChronicles.Headless.Executable/ActionTypeLoaderConfiguration.cs
@@ -1,0 +1,9 @@
+using Libplanet.Headless;
+
+namespace NineChronicles.Headless.Executable;
+
+public record ActionTypeLoaderConfiguration
+{
+    public DynamicActionTypeLoaderConfiguration? DynamicActionTypeLoader { get; init; }
+    public StaticActionTypeLoaderConfiguration? StaticActionTypeLoader { get; init; }
+}

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -76,7 +76,7 @@ namespace NineChronicles.Headless.Executable
         public string ChainTipStaleBehaviorType { get; set; } = "reboot";
         public int TxQuotaPerSigner { get; set; } = 10;
         public int MaximumPollPeers { get; set; } = int.MaxValue;
-        public DynamicActionTypeLoaderConfiguration? DynamicActionTypeLoader { get; set; } = null;
+        public ActionTypeLoaderConfiguration? ActionTypeLoader { get; set; } = null;
 
         public string SentryDsn { get; set; } = "";
 

--- a/NineChronicles.Headless.Executable/StaticActionTypeLoaderConfiguration.cs
+++ b/NineChronicles.Headless.Executable/StaticActionTypeLoaderConfiguration.cs
@@ -1,0 +1,6 @@
+namespace NineChronicles.Headless.Executable;
+
+public class StaticActionTypeLoaderConfiguration
+{
+    public string[]? Assemblies { get; init; }
+}

--- a/NineChronicles.Headless.Executable/appsettings-schema.json
+++ b/NineChronicles.Headless.Executable/appsettings-schema.json
@@ -39,61 +39,94 @@
                     "type": "string",
                     "enum": ["reboot", "preload"]
                 },
-                "DynamicActionTypeLoader": {
+                "ActionTypeLoader": {
                     "type": "object",
-                    "description": "Optional configuration for using DynamicActionTypeLoader.  It requires to prepare dlls to load dynamically in the '<BasePath>/<VersionName>/<AssemblyFileName>' format.",
-                    "properties": {
-                        "BasePath": {
-                            "type": "string",
-                            "description": "Base path of dlls to load dynamically. It means '/tmp/dlls' in '/tmp/dlls/v100350/Lib9c.dll', assembly path."
-                        },
-                        "AssemblyFileName": {
-                            "type": "string",
-                            "description": "The name of assembly file. (e.g., Lib9c.dll)",
-                            "examples": [
-                                "Lib9c.dll"
-                            ]
-                        },
-                        "HardForks": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "SinceBlockIndex": {
-                                        "type": "integer",
-                                        "description": "The block index when the version started."
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "StaticActionTypeLoader": {
+                                    "type": "object",
+                                    "description": "Configuration for using StaticActionTypeLoader.",
+                                    "properties": {
+                                        "Assemblies": {
+                                            "type": "array",
+                                            "description": "Assemblies' paths to load.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1
+                                        }
                                     },
-                                    "VersionName": {
-                                        "type": "string",
-                                        "description": "The name of the version since 'SinceBlockIndex'. It means 'v100350' in '/tmp/dlls/v100350/Lib9c.dll', assembly path."
-                                    }
-                                },
-                                "required": ["SinceBlockIndex", "VersionName"],
-                                "additionalProperties": false
+                                    "required": ["Assemblies"],
+                                    "additionalProperties": false
+                                }
                             },
-                            "minItems": 1,
-                            "examples": [
-                                [
-                                    {
-                                        "SinceBlockIndex": 0,
-                                        "VersionName": "v100321"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "SinceBlockIndex": 0,
-                                        "VersionName": "v100321"
+                            "additionalProperties": false
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "DynamicActionTypeLoader": {
+                                    "type": "object",
+                                    "description": "Optional configuration for using DynamicActionTypeLoader.  It requires to prepare dlls to load dynamically in the '<BasePath>/<VersionName>/<AssemblyFileName>' format.",
+                                    "properties": {
+                                        "BasePath": {
+                                            "type": "string",
+                                            "description": "Base path of dlls to load dynamically. It means '/tmp/dlls' in '/tmp/dlls/v100350/Lib9c.dll', assembly path."
+                                        },
+                                        "AssemblyFileName": {
+                                            "type": "string",
+                                            "description": "The name of assembly file. (e.g., Lib9c.dll)",
+                                            "examples": [
+                                                "Lib9c.dll"
+                                            ]
+                                        },
+                                        "HardForks": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "SinceBlockIndex": {
+                                                        "type": "integer",
+                                                        "description": "The block index when the version started."
+                                                    },
+                                                    "VersionName": {
+                                                        "type": "string",
+                                                        "description": "The name of the version since 'SinceBlockIndex'. It means 'v100350' in '/tmp/dlls/v100350/Lib9c.dll', assembly path."
+                                                    }
+                                                },
+                                                "required": ["SinceBlockIndex", "VersionName"],
+                                                "additionalProperties": false
+                                            },
+                                            "minItems": 1,
+                                            "examples": [
+                                                [
+                                                    {
+                                                        "SinceBlockIndex": 0,
+                                                        "VersionName": "v100321"
+                                                    }
+                                                ],
+                                                [
+                                                    {
+                                                        "SinceBlockIndex": 0,
+                                                        "VersionName": "v100321"
+                                                    },
+                                                    {
+                                                        "SinceBlockIndex": 100,
+                                                        "VersionName": "v100330"
+                                                    }
+                                                ]
+                                            ]
+                                        }
                                     },
-                                    {
-                                        "SinceBlockIndex": 100,
-                                        "VersionName": "v100330"
-                                    }
-                                ]
-                            ]
+                                    "required": ["BasePath", "HardForks", "AssemblyFileName"],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
                         }
-                    },
-                    "required": ["BasePath", "HardForks", "AssemblyFileName"],
-                    "additionalProperties": false
+                    ]
                 }
             }
         }

--- a/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
+++ b/NineChronicles.Headless.Tests/Common/ServiceBuilder.cs
@@ -47,7 +47,12 @@ namespace NineChronicles.Headless.Tests.Common
                 StaticPeers = ImmutableHashSet<BoundPeer>.Empty,
                 IceServers = ImmutableList<IceServer>.Empty,
             };
-            return new NineChroniclesNodeService(privateKey, properties, BlockPolicy, NetworkType.Test);
+            return new NineChroniclesNodeService(
+                privateKey,
+                properties,
+                BlockPolicy,
+                NetworkType.Test,
+                StaticActionTypeLoaderSingleton.Instance);
         }
     }
 }

--- a/NineChronicles.Headless.Tests/Common/StaticActionTypeLoaderSingleton.cs
+++ b/NineChronicles.Headless.Tests/Common/StaticActionTypeLoaderSingleton.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+using Libplanet.Action;
+using Nekoyume.Action;
+
+namespace NineChronicles.Headless.Tests.Common;
+
+public static class StaticActionTypeLoaderSingleton
+{
+    public static readonly StaticActionTypeLoader Instance = new StaticActionTypeLoader(
+        Assembly.GetEntryAssembly() is { } entryAssembly
+            ? new[] { typeof(ActionBase).Assembly, entryAssembly }
+            : new[] { typeof(ActionBase).Assembly },
+        typeof(ActionBase)
+    );
+}

--- a/NineChronicles.Headless.Tests/Controllers/GraphQLControllerTest.cs
+++ b/NineChronicles.Headless.Tests/Controllers/GraphQLControllerTest.cs
@@ -24,6 +24,7 @@ using NineChronicles.Headless.Controllers;
 using NineChronicles.Headless.GraphTypes;
 using NineChronicles.Headless.Properties;
 using NineChronicles.Headless.Requests;
+using NineChronicles.Headless.Tests.Common;
 using Xunit;
 using IPAddress = System.Net.IPAddress;
 
@@ -192,8 +193,9 @@ namespace NineChronicles.Headless.Tests.Controllers
                     Host = IPAddress.Loopback.ToString(),
                     IceServers = new List<IceServer>(),
                 },
-                NineChroniclesNodeService.GetBlockPolicy(NetworkType.Test),
-                NetworkType.Test);
+                NineChroniclesNodeService.GetBlockPolicy(NetworkType.Test, StaticActionTypeLoaderSingleton.Instance),
+                NetworkType.Test,
+                StaticActionTypeLoaderSingleton.Instance);
         }
     }
 }

--- a/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/GraphQLTestBase.cs
@@ -192,7 +192,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 minerLoopAction: (chain, swarm, privateKey, _) => Task.CompletedTask,
                 preloadProgress: preloadProgress,
                 exceptionHandlerAction: (code, msg) => throw new Exception($"{code}, {msg}"),
-                preloadStatusHandlerAction: isPreloadStart => { }
+                preloadStatusHandlerAction: isPreloadStart => { },
+                actionTypeLoader: StaticActionTypeLoaderSingleton.Instance
             );
         }
     }

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -27,6 +27,7 @@ using Nekoyume.Model;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using NineChronicles.Headless.Properties;
+using NineChronicles.Headless.Tests.Common;
 using NineChronicles.Headless.Tests.Common.Actions;
 using Xunit;
 using Xunit.Abstractions;
@@ -468,7 +469,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             var blockPolicy = NineChroniclesNodeService.GetTestBlockPolicy();
 
-            var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, NetworkType.Test);
+            var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, NetworkType.Test, StaticActionTypeLoaderSingleton.Instance);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm?.BlockChain;
 
@@ -806,8 +807,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 IceServers = ImmutableList<IceServer>.Empty,
             };
 
-            var blockPolicy = NineChroniclesNodeService.GetBlockPolicy(NetworkType.Test);
-            var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, NetworkType.Test);
+            var blockPolicy = NineChroniclesNodeService.GetBlockPolicy(NetworkType.Test, StaticActionTypeLoaderSingleton.Instance);
+            var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, NetworkType.Test, StaticActionTypeLoaderSingleton.Instance);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm?.BlockChain;
 
@@ -882,7 +883,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             var blockPolicy = NineChroniclesNodeService.GetTestBlockPolicy();
 
-            var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, NetworkType.Test);
+            var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, NetworkType.Test, StaticActionTypeLoaderSingleton.Instance);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm?.BlockChain;
 
@@ -949,7 +950,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             };
             var blockPolicy = NineChroniclesNodeService.GetTestBlockPolicy();
 
-            var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, NetworkType.Test);
+            var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, NetworkType.Test, StaticActionTypeLoaderSingleton.Instance);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm?.BlockChain;
 
@@ -1029,7 +1030,7 @@ decimalPlaces
                 IceServers = ImmutableList<IceServer>.Empty,
             };
 
-            return new NineChroniclesNodeService(privateKey, properties, blockPolicy, NetworkType.Test);
+            return new NineChroniclesNodeService(privateKey, properties, blockPolicy, NetworkType.Test, StaticActionTypeLoaderSingleton.Instance);
         }
 
         private (ProtectedPrivateKey, string) CreateProtectedPrivateKey()

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Libplanet;
+using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Headless.Hosting;
@@ -12,6 +13,11 @@ namespace NineChronicles.Headless.Properties
 {
     public class NineChroniclesNodeServiceProperties
     {
+        public NineChroniclesNodeServiceProperties(IActionTypeLoader actionTypeLoader)
+        {
+            ActionTypeLoader = actionTypeLoader;
+        }
+
         /// <summary>
         /// Gets or sets a private key that is used in mining and signing transactions,
         /// which is different with the private key used in swarm to sign messages.
@@ -44,6 +50,7 @@ namespace NineChronicles.Headless.Properties
 
         public int TxQuotaPerSigner { get; set; }
 
+        public IActionTypeLoader ActionTypeLoader { get; init; }
 
         public static LibplanetNodeServiceProperties<NineChroniclesActionType>
             GenerateLibplanetNodeServiceProperties(
@@ -73,8 +80,7 @@ namespace NineChronicles.Headless.Properties
                 int minimumBroadcastTarget = 10,
                 int bucketSize = 16,
                 string chainTipStaleBehaviorType = "reboot",
-                int maximumPollPeers = int.MaxValue,
-                DynamicActionTypeLoaderConfiguration? dynamicActionTypeLoader = null)
+                int maximumPollPeers = int.MaxValue)
         {
             var swarmPrivateKey = string.IsNullOrEmpty(swarmPrivateKeyString)
                 ? new PrivateKey()
@@ -118,7 +124,6 @@ namespace NineChronicles.Headless.Properties
                 BucketSize = bucketSize,
                 ChainTipStaleBehavior = chainTipStaleBehaviorType,
                 MaximumPollPeers = maximumPollPeers,
-                DynamicActionTypeLoader = dynamicActionTypeLoader,
             };
         }
 


### PR DESCRIPTION
This pull request introduces a new configuration for `StaticActionTypeLoader`. You can reference `appsettings-schema.json` and try these changes by editing `appsettings.mainnet.json` in the environment to support JSON schema (e.g., vscode).


For StaticActionTypeLoader
```json
{
  "Headless": {
    "ActionTypeLoader": {
      "StaticActionTypeLoader": {
        "Assemblies": ["/path/to/dllA", "/path/to/dllB"]
      }
    }
  }
}
```