### PR TITLE
feat: `PetEnhancement` graphQL query

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldTypeInheritor.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldTypeInheritor.cs
@@ -1,0 +1,26 @@
+using System;
+using GraphQL;
+using GraphQL.Types;
+using NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes
+{
+    public class ActionQueryFieldTypeInheritor : ActionQueryFieldType
+    {
+        public ActionQueryFieldTypeInheritor(
+            string name,
+            string description,
+            QueryArguments arguments,
+            Func<IResolveFieldContext, NCAction, byte[]> encoder,
+            string? deprecationReason = null) :
+            base(name, description, arguments, encoder, deprecationReason)
+        {
+        }
+
+        public override object? Resolve(IResolveFieldContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldTypeTest.cs
@@ -10,15 +10,9 @@ namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes
 {
     public class ActionQueryFieldTypeTest
     {
-        private static Codec _codec;
-
-        public ActionQueryFieldTypeTest()
-        {
-            _codec = new Codec();
-        }
+        private static readonly Codec Codec = new();
 
         [Theory]
-        [InlineData(null, null, false, null)]
         [InlineData("name", null, false, null)]
         [InlineData("name", "description", false, null)]
         [InlineData("name", "description", true, "deprecationReason")]
@@ -43,7 +37,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes
         }
 
         [Theory]
-        [InlineData(null, null, false)]
+        [InlineData(null, null, true)]
         [InlineData("name", null, false)]
         [InlineData("name", "description", false)]
         [InlineData("name", "description", true)]
@@ -73,14 +67,14 @@ namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes
         public static byte[] Encode(
             IResolveFieldContext context,
             NCAction action) =>
-            _codec.Encode(action.PlainValue);
+            Codec.Encode(action.PlainValue);
 
         public static NCAction Decode(byte[] bytes)
         {
 #pragma warning disable CS0612
             var action = new NCAction();
 #pragma warning restore CS0612
-            action.LoadPlainValue(_codec.Decode(bytes));
+            action.LoadPlainValue(Codec.Decode(bytes));
             return action;
         }
     }

--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldTypeTest.cs
@@ -1,0 +1,87 @@
+using System;
+using Bencodex;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
+using Xunit;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes
+{
+    public class ActionQueryFieldTypeTest
+    {
+        private static Codec _codec;
+
+        public ActionQueryFieldTypeTest()
+        {
+            _codec = new Codec();
+        }
+
+        [Theory]
+        [InlineData(null, null, false, null)]
+        [InlineData("name", null, false, null)]
+        [InlineData("name", "description", false, null)]
+        [InlineData("name", "description", true, "deprecationReason")]
+        public void Constructor(
+            string name,
+            string description,
+            bool newArguments,
+            string deprecationReason)
+        {
+            var arguments = newArguments ? new QueryArguments() : null;
+            var ft = new ActionQueryFieldTypeInheritor(
+                name,
+                description,
+                arguments,
+                Encode,
+                deprecationReason);
+            Assert.Equal(name, ft.Name);
+            Assert.Equal(description, ft.Description);
+            Assert.Equal(arguments, ft.Arguments);
+            Assert.Equal(deprecationReason, ft.DeprecationReason);
+            Assert.Equal(typeof(NonNullGraphType<ByteStringType>), ft.Type);
+        }
+
+        [Theory]
+        [InlineData(null, null, false)]
+        [InlineData("name", null, false)]
+        [InlineData("name", "description", false)]
+        [InlineData("name", "description", true)]
+        public void Constructor_Throw_ArgumentNullException(
+            string name,
+            string description,
+            bool newArguments)
+        {
+            Assert.Throws<ArgumentNullException>(() => new ActionQueryFieldTypeInheritor(
+                name,
+                description,
+                newArguments ? new QueryArguments() : null,
+                null));
+        }
+
+        [Fact]
+        public void Resolve_Throw_NotImplementedException()
+        {
+            var ft = new ActionQueryFieldTypeInheritor(
+                "name",
+                "description",
+                new QueryArguments(),
+                Encode);
+            Assert.Throws<NotImplementedException>(() => ft.Resolve(null));
+        }
+
+        public static byte[] Encode(
+            IResolveFieldContext context,
+            NCAction action) =>
+            _codec.Encode(action.PlainValue);
+
+        public static NCAction Decode(byte[] bytes)
+        {
+#pragma warning disable CS0612
+            var action = new NCAction();
+#pragma warning restore CS0612
+            action.LoadPlainValue(_codec.Decode(bytes));
+            return action;
+        }
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldTypeTest.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using GraphQL;
+using GraphQL.Execution;
+using Libplanet;
+using Libplanet.Crypto;
+using Nekoyume.Action;
+using NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes;
+using Xunit;
+
+namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes;
+
+public class PetEnhancementFieldTypeTest
+{
+    [Fact]
+    public void Constructor()
+    {
+        var ft = new PetEnhancementFieldType(
+            new StandaloneContext(),
+            ActionQueryFieldTypeTest.Encode);
+    }
+
+    [Fact]
+    public void Constructor_Throw_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new PetEnhancementFieldType(
+            null,
+            ActionQueryFieldTypeTest.Encode));
+    }
+
+    [Theory]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    public void Resolve(int petId, int targetLevel)
+    {
+        var avatarAddr = new PrivateKey().ToAddress();
+        var context = new ResolveFieldContext
+        {
+            Arguments = new Dictionary<string, ArgumentValue>
+            {
+                {
+                    "avatarAddress",
+                    new ArgumentValue(avatarAddr, ArgumentSource.Literal)
+                },
+                {
+                    "petId",
+                    new ArgumentValue(petId, ArgumentSource.Literal)
+                },
+                {
+                    "targetLevel",
+                    new ArgumentValue(targetLevel, ArgumentSource.Literal)
+                },
+            },
+            Errors = new ExecutionErrors(),
+            Extensions = new Dictionary<string, object?>(),
+        };
+        var ft = new PetEnhancementFieldType(
+            new StandaloneContext(),
+            ActionQueryFieldTypeTest.Encode);
+        var resolve = ft.Resolve(context);
+        var bytes = Assert.IsType<byte[]>(resolve);
+        var ncAction = ActionQueryFieldTypeTest.Decode(bytes);
+        var petEnhancement = Assert.IsType<PetEnhancement>(ncAction.InnerAction);
+        Assert.Equal(avatarAddr, petEnhancement.AvatarAddress);
+        Assert.Equal(petId, petEnhancement.PetId);
+        Assert.Equal(targetLevel, petEnhancement.TargetLevel);
+    }
+}

--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldTypeTest.cs
@@ -15,17 +15,7 @@ public class PetEnhancementFieldTypeTest
     [Fact]
     public void Constructor()
     {
-        var ft = new PetEnhancementFieldType(
-            new StandaloneContext(),
-            ActionQueryFieldTypeTest.Encode);
-    }
-
-    [Fact]
-    public void Constructor_Throw_ArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new PetEnhancementFieldType(
-            null,
-            ActionQueryFieldTypeTest.Encode));
+        var ft = new PetEnhancementFieldType(ActionQueryFieldTypeTest.Encode);
     }
 
     [Theory]
@@ -54,9 +44,7 @@ public class PetEnhancementFieldTypeTest
             Errors = new ExecutionErrors(),
             Extensions = new Dictionary<string, object?>(),
         };
-        var ft = new PetEnhancementFieldType(
-            new StandaloneContext(),
-            ActionQueryFieldTypeTest.Encode);
+        var ft = new PetEnhancementFieldType(ActionQueryFieldTypeTest.Encode);
         var resolve = ft.Resolve(context);
         var bytes = Assert.IsType<byte[]>(resolve);
         var ncAction = ActionQueryFieldTypeTest.Decode(bytes);

--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldTypeTest.cs
@@ -8,49 +8,95 @@ using Nekoyume.Action;
 using NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes;
 using Xunit;
 
-namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes;
-
-public class PetEnhancementFieldTypeTest
+namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes
 {
-    [Fact]
-    public void Constructor()
+    public class PetEnhancementFieldTypeTest
     {
-        var ft = new PetEnhancementFieldType(ActionQueryFieldTypeTest.Encode);
-    }
-
-    [Theory]
-    [InlineData(int.MinValue, int.MinValue)]
-    [InlineData(int.MaxValue, int.MaxValue)]
-    public void Resolve(int petId, int targetLevel)
-    {
-        var avatarAddr = new PrivateKey().ToAddress();
-        var context = new ResolveFieldContext
+        [Fact]
+        public void Constructor()
         {
-            Arguments = new Dictionary<string, ArgumentValue>
+            var ft = new PetEnhancementFieldType(ActionQueryFieldTypeTest.Encode);
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(int.MaxValue, int.MaxValue - 1)]
+        public void Resolve(int petId, int targetLevel)
+        {
+            var avatarAddr = new PrivateKey().ToAddress();
+            var context = new ResolveFieldContext
             {
+                Arguments = new Dictionary<string, ArgumentValue>
                 {
+                    {
+                        "avatarAddress",
+                        new ArgumentValue(avatarAddr, ArgumentSource.Literal)
+                    },
+                    {
+                        "petId",
+                        new ArgumentValue(petId, ArgumentSource.Literal)
+                    },
+                    {
+                        "targetLevel",
+                        new ArgumentValue(targetLevel, ArgumentSource.Literal)
+                    },
+                },
+                Errors = new ExecutionErrors(),
+                Extensions = new Dictionary<string, object?>(),
+            };
+            var ft = new PetEnhancementFieldType(ActionQueryFieldTypeTest.Encode);
+            var resolve = ft.Resolve(context);
+            var bytes = Assert.IsType<byte[]>(resolve);
+            var ncAction = ActionQueryFieldTypeTest.Decode(bytes);
+            var petEnhancement = Assert.IsType<PetEnhancement>(ncAction.InnerAction);
+            Assert.Equal(avatarAddr, petEnhancement.AvatarAddress);
+            Assert.Equal(petId, petEnhancement.PetId);
+            Assert.Equal(targetLevel, petEnhancement.TargetLevel);
+        }
+
+        [Theory]
+        [InlineData(null, 0, 1)]
+        [InlineData("0x0000000000000000000000000000000000000000", int.MinValue, 1)]
+        [InlineData("0x0000000000000000000000000000000000000000", -1, 1)]
+        [InlineData("0x0000000000000000000000000000000000000000", 0, int.MinValue)]
+        [InlineData("0x0000000000000000000000000000000000000000", 0, 0)]
+        public void Resolve_Throw_ExecutionError(
+            string? avatarAddressHex,
+            int? petId,
+            int? targetLevel)
+        {
+            var arguments = new Dictionary<string, ArgumentValue>();
+            if (avatarAddressHex != null)
+            {
+                arguments.Add(
                     "avatarAddress",
-                    new ArgumentValue(avatarAddr, ArgumentSource.Literal)
-                },
-                {
+                    new ArgumentValue(
+                        new Address(avatarAddressHex),
+                        ArgumentSource.Literal));
+            }
+
+            if (petId is { } id)
+            {
+                arguments.Add(
                     "petId",
-                    new ArgumentValue(petId, ArgumentSource.Literal)
-                },
-                {
+                    new ArgumentValue(id, ArgumentSource.Literal));
+            }
+
+            if (targetLevel is { } level)
+            {
+                arguments.Add(
                     "targetLevel",
-                    new ArgumentValue(targetLevel, ArgumentSource.Literal)
-                },
-            },
-            Errors = new ExecutionErrors(),
-            Extensions = new Dictionary<string, object?>(),
-        };
-        var ft = new PetEnhancementFieldType(ActionQueryFieldTypeTest.Encode);
-        var resolve = ft.Resolve(context);
-        var bytes = Assert.IsType<byte[]>(resolve);
-        var ncAction = ActionQueryFieldTypeTest.Decode(bytes);
-        var petEnhancement = Assert.IsType<PetEnhancement>(ncAction.InnerAction);
-        Assert.Equal(avatarAddr, petEnhancement.AvatarAddress);
-        Assert.Equal(petId, petEnhancement.PetId);
-        Assert.Equal(targetLevel, petEnhancement.TargetLevel);
+                    new ArgumentValue(level, ArgumentSource.Literal));
+            }
+
+            var context = new ResolveFieldContext
+            {
+                Arguments = arguments,
+                Errors = new ExecutionErrors(),
+                Extensions = new Dictionary<string, object?>(),
+            };
+            var ft = new PetEnhancementFieldType(ActionQueryFieldTypeTest.Encode);
+            Assert.Throws<ExecutionError>(() => ft.Resolve(context));
+        }
     }
 }

--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldTypeTest.cs
@@ -20,7 +20,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.ActionQueryFieldTypes
 
         [Theory]
         [InlineData(0, 1)]
-        [InlineData(int.MaxValue, int.MaxValue - 1)]
+        [InlineData(int.MaxValue, int.MaxValue)]
         public void Resolve(int petId, int targetLevel)
         {
             var avatarAddr = new PrivateKey().ToAddress();

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -552,7 +552,7 @@ namespace NineChronicles.Headless.GraphTypes
                 resolve: context => new CraftQuery(standaloneContext)
             );
 
-            base.AddField(new PetEnhancementFieldType(Encode));
+            AddField(new PetEnhancementFieldType(Encode));
 
 #if LIB9C_DEV_EXTENSIONS
             RegisterFieldsForDevEx();

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -15,6 +15,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace NineChronicles.Headless.GraphTypes
@@ -544,6 +545,8 @@ namespace NineChronicles.Headless.GraphTypes
             RegisterItemEnhancement();
             RegisterRapidCombination();
             RegisterCombinationConsumable();
+
+            base.AddField(new PetEnhancementFieldType(standaloneContext, Encode));
 
 #if LIB9C_DEV_EXTENSIONS
             RegisterFieldsForDevEx();

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -546,7 +546,7 @@ namespace NineChronicles.Headless.GraphTypes
             RegisterRapidCombination();
             RegisterCombinationConsumable();
 
-            base.AddField(new PetEnhancementFieldType(standaloneContext, Encode));
+            base.AddField(new PetEnhancementFieldType(Encode));
 
 #if LIB9C_DEV_EXTENSIONS
             RegisterFieldsForDevEx();

--- a/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldType.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldType.cs
@@ -1,0 +1,38 @@
+using System;
+using GraphQL;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
+{
+    public abstract class ActionQueryFieldType : FieldType, IFieldResolver
+    {
+        private readonly Func<IResolveFieldContext, NCAction, byte[]> _encoder;
+
+        protected ActionQueryFieldType(
+            string name,
+            string description,
+            QueryArguments arguments,
+            Func<IResolveFieldContext, NCAction, byte[]> encoder,
+            string? deprecationReason = null)
+        {
+            _encoder = encoder ?? throw new ArgumentNullException(
+                nameof(encoder),
+                "Encoder is required.");
+
+            Name = name;
+            Description = description;
+            Arguments = arguments;
+            Resolver = this;
+            DeprecationReason = deprecationReason;
+            Type = typeof(NonNullGraphType<ByteStringType>);
+        }
+
+        public abstract object? Resolve(IResolveFieldContext context);
+
+        protected byte[] Encode(IResolveFieldContext context, NCAction action) =>
+            _encoder(context, action);
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldType.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/ActionQueryFieldType.cs
@@ -22,7 +22,9 @@ namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
                 nameof(encoder),
                 "Encoder is required.");
 
-            Name = name;
+            Name = name ?? throw new ArgumentNullException(
+                nameof(name),
+                "Name is required.");
             Description = description;
             Arguments = arguments;
             Resolver = this;

--- a/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
@@ -20,7 +20,7 @@ namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
                         Name = "avatarAddress",
                         Description = "Address of avatar.",
                     },
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
                     {
                         Name = "petId",
                         Description = "Id of pet.",
@@ -36,12 +36,28 @@ namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
 
         public override object? Resolve(IResolveFieldContext context)
         {
-            var avatarAddress = context.GetArgument<Address>("avatarAddress");
+            var avatarAddr = context.GetArgument<Address>("avatarAddress");
+            if (avatarAddr == default)
+            {
+                throw new ExecutionError("Invalid avatarAddress.");
+            }
+
             var petId = context.GetArgument<int>("petId");
+            if (petId < 0)
+            {
+                throw new ExecutionError("Invalid petId.");
+            }
+
             var targetLevel = context.GetArgument<int>("targetLevel");
+            if (targetLevel < 1 ||
+                targetLevel == int.MaxValue)
+            {
+                throw new ExecutionError("Invalid targetLevel.");
+            }
+
             var action = new PetEnhancement
             {
-                AvatarAddress = avatarAddress,
+                AvatarAddress = avatarAddr,
                 PetId = petId,
                 TargetLevel = targetLevel,
             };

--- a/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
@@ -1,0 +1,59 @@
+using System;
+using GraphQL;
+using GraphQL.Types;
+using Libplanet;
+using Libplanet.Explorer.GraphTypes;
+using Nekoyume.Action;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
+{
+    public class PetEnhancementFieldType : ActionQueryFieldType
+    {
+        private StandaloneContext _standaloneContext;
+
+        public PetEnhancementFieldType(
+            StandaloneContext standaloneContext,
+            Func<IResolveFieldContext, NCAction, byte[]> encoder) :
+            base(
+                "petEnhancement",
+                "This query returns the action `PetEnhancement`.",
+                new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "avatarAddress",
+                        Description = "Address of avatar.",
+                    },
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Name = "petId",
+                        Description = "Id of pet.",
+                    },
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
+                    {
+                        Name = "targetLevel",
+                        Description = "Target enhancement level.",
+                    }),
+                encoder)
+        {
+            _standaloneContext = standaloneContext ?? throw new ArgumentNullException(
+                nameof(standaloneContext),
+                "StandaloneContext is required.");
+        }
+
+        public override object? Resolve(IResolveFieldContext context)
+        {
+            var avatarAddress = context.GetArgument<Address>("avatarAddress");
+            var petId = context.GetArgument<int>("petId");
+            var targetLevel = context.GetArgument<int>("targetLevel");
+            var action = new PetEnhancement
+            {
+                AvatarAddress = avatarAddress,
+                PetId = petId,
+                TargetLevel = targetLevel,
+            };
+
+            return Encode(context, action);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
@@ -45,14 +45,15 @@ namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
             var petId = context.GetArgument<int>("petId");
             if (petId < 0)
             {
-                throw new ExecutionError("Invalid petId.");
+                throw new ExecutionError(
+                    "Invalid petId. petId must greater than or equal to 0");
             }
 
             var targetLevel = context.GetArgument<int>("targetLevel");
-            if (targetLevel < 1 ||
-                targetLevel == int.MaxValue)
+            if (targetLevel < 1)
             {
-                throw new ExecutionError("Invalid targetLevel.");
+                throw new ExecutionError(
+                    "Invalid targetLevel. targetLevel must greater than or equal to 1");
             }
 
             var action = new PetEnhancement

--- a/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
@@ -10,11 +10,7 @@ namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
 {
     public class PetEnhancementFieldType : ActionQueryFieldType
     {
-        private StandaloneContext _standaloneContext;
-
-        public PetEnhancementFieldType(
-            StandaloneContext standaloneContext,
-            Func<IResolveFieldContext, NCAction, byte[]> encoder) :
+        public PetEnhancementFieldType(Func<IResolveFieldContext, NCAction, byte[]> encoder) :
             base(
                 "petEnhancement",
                 "This query returns the action `PetEnhancement`.",
@@ -36,9 +32,6 @@ namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
                     }),
                 encoder)
         {
-            _standaloneContext = standaloneContext ?? throw new ArgumentNullException(
-                nameof(standaloneContext),
-                "StandaloneContext is required.");
         }
 
         public override object? Resolve(IResolveFieldContext context)

--- a/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQueryFieldTypes/PetEnhancementFieldType.cs
@@ -46,14 +46,14 @@ namespace NineChronicles.Headless.GraphTypes.ActionQueryFieldTypes
             if (petId < 0)
             {
                 throw new ExecutionError(
-                    "Invalid petId. petId must greater than or equal to 0");
+                    "Invalid petId. petId must be greater than or equal to 0.");
             }
 
             var targetLevel = context.GetArgument<int>("targetLevel");
             if (targetLevel < 1)
             {
                 throw new ExecutionError(
-                    "Invalid targetLevel. targetLevel must greater than or equal to 1");
+                    "Invalid targetLevel. targetLevel must be greater than 0.");
             }
 
             var action = new PetEnhancement

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <NoWarn>$(NoWarn);SA1100</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'DevEx' ">

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>
+    <NoWarn>$(NoWarn);SA1100</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'DevEx' ">


### PR DESCRIPTION
- Add `ActionQueryFieldType`
- Add `PetEnhancementFieldType`
- Apply `petEnhancement` action query

## Playground

### Doc
<img width="632" alt="image" src="https://user-images.githubusercontent.com/6128868/216037421-cf072e45-bf9b-404b-ad34-9be07a431d65.png">

### Query

```graphql
query {
  actionQuery {
    petEnhancement(
      avatarAddress: "0xe56d432da2032f6C851943b76C4a41815baaBB54",
      petId: 1,
      targetLevel: 1)
  }
}
```

```json
{
  "data": {
    "actionQuery": {
      "petEnhancement": "6475373a747970655f69647531353a7065745f656e68616e63656d656e7475363a76616c7565736475313a6132303ae56d432da2032f6c851943b76c4a41815baabb5475323a696431363acd57608e9f06b34f9f279651d9ba9aa675313a7075313a3175313a7475313a316565"
    }
  },
  "extensions": {}
}
```

```python
>>> bytes.fromhex("6475373a747970655f69647531353a7065745f656e68616e63656d656e7475363a76616c7565736475313a6132303ae56d432da2032f6c851943b76c4a41815baabb5475323a696431363acd57608e9f06b34f9f279651d9ba9aa675313a7075313a3175313a7475313a316565")
b"du7:type_idu15:pet_enhancementu6:valuesdu1:a20:\xe5mC-\xa2\x03/l\x85\x19C\xb7lJA\x81[\xaa\xbbTu2:id16:\xcdW`\x8e\x9f\x06\xb3O\x9f'\x96Q\xd9\xba\x9a\xa6u1:pu1:1u1:tu1:1ee"
>>> loads(_)
{'type_id': 'pet_enhancement', 'values': {'a': b'\xe5mC-\xa2\x03/l\x85\x19C\xb7lJA\x81[\xaa\xbbT', 'id': b"\xcdW`\x8e\x9f\x06\xb3O\x9f'\x96Q\xd9\xba\x9a\xa6", 'p': '1', 't': '1'}}
```