### PR TITLE
Provide metrics for NineChronicles node 

### DIFF
--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.Metrics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -65,6 +66,12 @@ namespace NineChronicles.Headless
             _port = port;
             _context = context;
             _sentryTraces = sentryTraces;
+
+            var meter = new Meter("NineChronicles");
+            meter.CreateObservableGauge(
+                "ninechronicles_rpc_clients_count",
+                () => this.GetClients().Count,
+                description: "Number of RPC clients connected.");
 
             ActionEvaluationHub.OnClientDisconnected += RemoveClient;
         }

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -194,6 +194,8 @@ namespace NineChronicles.Headless
                 // Prints 
                 app.UseMiddleware<GraphQLSchemaMiddleware<StandaloneSchema>>("/schema.graphql");
 
+                app.UseOpenTelemetryPrometheusScrapingEndpoint();
+
                 // /ui/playground 옵션을 통해서 Playground를 사용할 수 있습니다.
                 app.UseGraphQLPlayground();
             }

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -15,6 +15,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Nekoyume.Action;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
 using Sentry;
 
 namespace NineChronicles.Headless
@@ -79,6 +81,12 @@ namespace NineChronicles.Headless
                         options.MaxReceiveMessageSize = null;
                     });
                     services.AddMagicOnion();
+                    services.AddOpenTelemetry()
+                        .WithMetrics(
+                            builder => builder
+                                .AddRuntimeInstrumentation()
+                                .AddAspNetCoreInstrumentation()
+                                .AddPrometheusExporter());
                     services.AddSingleton(provider =>
                     {
                         StandaloneContext? ctx = provider.GetRequiredService<StandaloneContext>();

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -84,6 +84,7 @@ namespace NineChronicles.Headless
                     services.AddOpenTelemetry()
                         .WithMetrics(
                             builder => builder
+                                .AddMeter("NineChronicles")
                                 .AddRuntimeInstrumentation()
                                 .AddAspNetCoreInstrumentation()
                                 .AddPrometheusExporter());

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -41,6 +41,12 @@
     <PackageReference Include="Sentry.DiagnosticSource" Version="3.22.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="GraphQL" Version="4.7.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.4.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.11" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.1.0-beta.3" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.49.0.57237">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -21,6 +21,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.Metrics;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Threading;
@@ -278,6 +279,19 @@ namespace NineChronicles.Headless
                 txQuotaPerSigner: properties.TxQuotaPerSigner
             );
             service.ConfigureContext(context);
+            var meter = new Meter("NineChronicles");
+            meter.CreateObservableGauge(
+                "ninechronicles_tip_index",
+                () => service.BlockChain.Tip.Index,
+                description: "The tip block's index.");
+            meter.CreateObservableGauge(
+                "ninechronicles_staged_txids_count",
+                () => service.BlockChain.GetStagedTransactionIds().Count,
+                description: "Number of staged transactions.");
+            meter.CreateObservableGauge(
+                "ninechronicles_subscriber_addresses_count",
+                () => context.AgentAddresses.Count);
+
             return service;
         }
 


### PR DESCRIPTION
## Description

This pull request makes `NineChronicles.Headless` provide metrics, which `9c-headless-metric-gql-aggregator` has been providing.

You can fetch the metrics in the `http://localhost:5000/metrics` endpoint when you use `appsettings.development.json`.

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/26626194/216094612-6b5da022-b2a1-422a-9959-0329d05d49ec.png">

This pull request will close https://github.com/planetarium/9c-headless-metric-gql-aggregator/issues/3 and archive the project when applied successfully.

## Adding ndoes in your `scrape_configs`

You can add a job with nodes you want to gather metrics.

```yaml
      - job_name: ninechronicles-headless-metrics-aggregator
        metrics_path: /metrics
        scrape_interval: 10s
        scrape_timeout: 5s
        static_configs:
          - targets:
            - <ENDPOINT>
        tls_config:
          insecure_skip_verify: true
```

------

<img width="1452" alt="image" src="https://user-images.githubusercontent.com/26626194/216118525-dd02b770-1d31-4858-9e1c-b43f5ca289b5.png">