### PR TITLE
Introduce script to build multiple Lib9c versions for pluggable lib9c

### DIFF
--- a/.versions.toml
+++ b/.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+v100370 = { ref = "v100370" }
+v100371 = { ref = "v100371" }
+
+[config]
+output_path = "/tmp/testdlls"
+repository_url = "https://github.com/planetarium/lib9c"

--- a/Docs/PLUGGABLE_LIB9C.md
+++ b/Docs/PLUGGABLE_LIB9C.md
@@ -1,0 +1,26 @@
+# Pluggable Lib9c
+
+## Prepare Lib9c dlls
+
+### Check .versions.toml configuration file
+
+```
+[versions]
+v100370 = { ref = "v100370" }
+v100371 = { ref = "v100371" }
+
+[config]
+output_path = "/tmp/testdlls"
+repository_url = "https://github.com/planetarium/lib9c"
+```
+
+### Run prepare-pluggable-lib9c.py
+
+
+```bash
+python --version  # Requires >=3.11
+python -m pip install GitPython
+python prepare-pluggable-lib9c.py
+
+ls /tmp/testdlls  # Check the `output_path` you configured.
+```

--- a/prepare-pluggable-lib9c.py
+++ b/prepare-pluggable-lib9c.py
@@ -1,0 +1,58 @@
+import tomllib
+import tempfile
+import os
+import subprocess
+import shutil
+
+from typing import TypedDict
+
+from git import Repo
+
+
+class VersionSpec(TypedDict):
+    ref: str
+
+
+class BuildConfiguration(TypedDict):
+    output_path: str
+    repository_url: str
+
+
+class Configuration(TypedDict):
+    versions: dict[str, VersionSpec]
+    config: BuildConfiguration
+
+
+conf: Configuration
+with open(".versions.toml", "rb") as f:
+    conf = tomllib.load(f)
+
+
+output_path = conf["config"]["output_path"]
+repository_url = conf["config"]["repository_url"]
+
+tmpdir = tempfile.mkdtemp()
+
+if os.path.exists(output_path):
+    shutil.rmtree(output_path)
+os.mkdir(output_path)
+
+repo = Repo.clone_from(repository_url, tmpdir, multi_options=["--recurse-submodules"])
+for version, spec in conf["versions"].items():
+    ref = spec["ref"]
+
+    repo.head.reset(ref)
+    publish_directory = os.path.join(output_path, version)
+    subprocess.run(
+        [
+            "dotnet",
+            "publish",
+            "Lib9c/Lib9c.csproj",
+            "-c",
+            "Release",
+            "-o",
+            publish_directory,
+        ],
+        cwd=tmpdir,
+        capture_output=True,
+    )


### PR DESCRIPTION
This pull request introduces a script to Lib9c DLLs of multiple versions easily with the configuration.

You can see the help message in `Docs/PLUGGABLE_LIB9C.md` file.

### Configuration

```
[versions]
$version_name = { ref = "$git_ref" }
// e.g. v100371 = { ref = "v100371" }

[config]
output_path = "$output_path"
repository_url = "$repository_url"  // URL to clone the Lib9c repository.
```