### PR TITLE
update gql logger level

### DIFF
--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -25,7 +25,7 @@ namespace NineChronicles.Headless.Middleware
                 context.Request.EnableBuffering();
                 var remoteIp = context.Connection.RemoteIpAddress;
                 var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
-                _logger.Debug("[REQUEST-CAPTURE] Ip: {IP} Method: {Method} Endpoint: {Path}\n{Body}", remoteIp, context.Request.Method, context.Request.Path, body);
+                _logger.Information("[REQUEST-CAPTURE] Ip: {IP} Method: {Method} Endpoint: {Path}\n{Body}", remoteIp, context.Request.Method, context.Request.Path, body);
                 context.Request.Body.Seek(0, SeekOrigin.Begin);
             }
 


### PR DESCRIPTION
Updating gql logger level to `Information` to pull metrics in Cloudwatch.