### PR TITLE
Track meter always

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -29,6 +29,8 @@ using Libplanet.Blocks;
 using Libplanet.Headless;
 using Libplanet.Net.Transports;
 using Nekoyume.Action;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
 
 namespace NineChronicles.Headless.Executable
 {
@@ -413,6 +415,13 @@ namespace NineChronicles.Headless.Executable
                 {
                     services.AddSingleton(_ => standaloneContext);
                     services.AddSingleton<ConcurrentDictionary<string, ITransaction>>();
+                    services.AddOpenTelemetry()
+                        .WithMetrics(
+                            builder => builder
+                                .AddMeter("NineChronicles")
+                                .AddRuntimeInstrumentation()
+                                .AddAspNetCoreInstrumentation()
+                                .AddPrometheusExporter());
                 });
                 hostBuilder.UseNineChroniclesNode(nineChroniclesProperties, standaloneContext);
                 if (headlessConfig.RpcServer)

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -15,8 +15,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Nekoyume.Action;
-using OpenTelemetry;
-using OpenTelemetry.Metrics;
 using Sentry;
 
 namespace NineChronicles.Headless
@@ -81,13 +79,6 @@ namespace NineChronicles.Headless
                         options.MaxReceiveMessageSize = null;
                     });
                     services.AddMagicOnion();
-                    services.AddOpenTelemetry()
-                        .WithMetrics(
-                            builder => builder
-                                .AddMeter("NineChronicles")
-                                .AddRuntimeInstrumentation()
-                                .AddAspNetCoreInstrumentation()
-                                .AddPrometheusExporter());
                     services.AddSingleton(provider =>
                     {
                         StandaloneContext? ctx = provider.GetRequiredService<StandaloneContext>();


### PR DESCRIPTION
Fix `OpenTelemetry` to be added not only on rpc, but also on non-rpc.