### PR TITLE
add additional json log output for loki

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -215,11 +215,12 @@ namespace NineChronicles.Headless.Executable
             var configuration = configurationBuilder.Build();
             var loggerConf = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
-                .WriteTo.RollingFile(
+                .WriteTo.File(
                     new RenderedCompactJsonFormatter(),
-                    pathFormat: Environment.GetEnvironmentVariable("JSON_LOG_PATH") ?? "remote-headless_9c-network_remote-headless-{Hour}.json",
+                    path: Environment.GetEnvironmentVariable("JSON_LOG_PATH") ?? "remote-headless_9c-network_remote-headless.json",
                     retainedFileCountLimit: 5,
-                    fileSizeLimitBytes: 524_288_000 )
+                    rollOnFileSizeLimit: true,
+                    fileSizeLimitBytes: 524_288_000)
                 .Destructure.UsingAttributes();
             var headlessConfig = new Configuration();
             configuration.Bind("Headless", headlessConfig);

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -215,6 +215,11 @@ namespace NineChronicles.Headless.Executable
             var configuration = configurationBuilder.Build();
             var loggerConf = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
+                .WriteTo.RollingFile(
+                    new RenderedCompactJsonFormatter(),
+                    pathFormat: Environment.GetEnvironmentVariable("JSON_LOG_PATH") ?? "remote-headless_9c-network_remote-headless-{Hour}.json",
+                    retainedFileCountLimit: 5,
+                    fileSizeLimitBytes: 524_288_000 )
                 .Destructure.UsingAttributes();
             var headlessConfig = new Configuration();
             configuration.Bind("Headless", headlessConfig);

--- a/NineChronicles.Headless.Executable/appsettings.internal.json
+++ b/NineChronicles.Headless.Executable/appsettings.internal.json
@@ -55,23 +55,6 @@
                         ]
                     }
                 }
-            },
-            {
-                "Name": "Logger",
-                "Args": {
-                    "configureLogger": {
-                        "WriteTo": [
-                            {
-                                "Name": "RollingFile",
-                                "Args": {
-                                    "pathFormat": "./logs/log-{Hour}.json",
-                                    "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact",
-                                    "retainedFileCountLimit": 5
-                                }
-                            }
-                        ]
-                    }
-                }
             }
         ],
         "Filter": [

--- a/NineChronicles.Headless.Executable/appsettings.internal.json
+++ b/NineChronicles.Headless.Executable/appsettings.internal.json
@@ -64,16 +64,9 @@
                             {
                                 "Name": "RollingFile",
                                 "Args": {
-                                    "pathFormat": "./logs/metric-{Hour}.json",
-                                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
-                                }
-                            }
-                        ],
-                        "Filter": [
-                            {
-                                "Name": "ByIncludingOnly",
-                                "Args": {
-                                    "expression": "Tag = 'Metric'"
+                                    "pathFormat": "./logs/log-{Hour}.json",
+                                    "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact",
+                                    "retainedFileCountLimit": 5
                                 }
                             }
                         ]

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -112,16 +112,9 @@
                             {
                                 "Name": "RollingFile",
                                 "Args": {
-                                    "pathFormat": "./logs/metric-{Hour}.json",
-                                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
-                                }
-                            }
-                        ],
-                        "Filter": [
-                            {
-                                "Name": "ByIncludingOnly",
-                                "Args": {
-                                    "expression": "Tag = 'Metric'"
+                                    "pathFormat": "./logs/log-{Hour}.json",
+                                    "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact",
+                                    "retainedFileCountLimit": 5
                                 }
                             }
                         ]

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -103,23 +103,6 @@
                         ]
                     }
                 }
-            },
-            {
-                "Name": "Logger",
-                "Args": {
-                    "configureLogger": {
-                        "WriteTo": [
-                            {
-                                "Name": "RollingFile",
-                                "Args": {
-                                    "pathFormat": "./logs/log-{Hour}.json",
-                                    "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact",
-                                    "retainedFileCountLimit": 5
-                                }
-                            }
-                        ]
-                    }
-                }
             }
         ],
         "Filter": [

--- a/NineChronicles.Headless.Executable/appsettings.mainnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.mainnet.json
@@ -55,23 +55,6 @@
                         ]
                     }
                 }
-            },
-            {
-                "Name": "Logger",
-                "Args": {
-                    "configureLogger": {
-                        "WriteTo": [
-                            {
-                                "Name": "RollingFile",
-                                "Args": {
-                                    "pathFormat": "./logs/log-{Hour}.json",
-                                    "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact",
-                                    "retainedFileCountLimit": 5
-                                }
-                            }
-                        ]
-                    }
-                }
             }
         ],
         "Filter": [

--- a/NineChronicles.Headless.Executable/appsettings.mainnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.mainnet.json
@@ -64,16 +64,9 @@
                             {
                                 "Name": "RollingFile",
                                 "Args": {
-                                    "pathFormat": "./logs/metric-{Hour}.json",
-                                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
-                                }
-                            }
-                        ],
-                        "Filter": [
-                            {
-                                "Name": "ByIncludingOnly",
-                                "Args": {
-                                    "expression": "Tag = 'Metric'"
+                                    "pathFormat": "./logs/log-{Hour}.json",
+                                    "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact",
+                                    "retainedFileCountLimit": 5
                                 }
                             }
                         ]


### PR DESCRIPTION
Deprecate metrics log and add rendered json log for loki
- mount this path from k8s
- fluentbit will fetch json logs and export to loki

ref) https://github.com/planetarium/9c-k8s-config/pull/307/files#diff-7727ff4c04d5feffdcda5409ff8c421d4873185b7be7ede8c03371d11f1fbe92