### PR TITLE
Add grpc rate limit middleware

### DIFF
--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -49,6 +49,7 @@ namespace NineChronicles.Headless.Executable
         public int? RpcListenPort { get; set; }
         public bool? RpcRemoteServer { get; set; }
         public bool? RpcHttpServer { get; set; }
+        public bool RpcRateLimiter { get; set; }
 
         // GraphQL Server
         public bool GraphQLServer { get; set; }
@@ -108,6 +109,7 @@ namespace NineChronicles.Headless.Executable
             int? rpcListenPort,
             bool? rpcRemoteServer,
             bool? rpcHttpServer,
+            bool? rpcRateLimiter,
             bool? graphQlServer,
             string? graphQLHost,
             int? graphQLPort,
@@ -157,6 +159,7 @@ namespace NineChronicles.Headless.Executable
             RpcListenPort = rpcListenPort ?? RpcListenPort;
             RpcRemoteServer = rpcRemoteServer ?? RpcRemoteServer;
             RpcHttpServer = rpcHttpServer ?? RpcHttpServer;
+            RpcRateLimiter = rpcRateLimiter ?? RpcRateLimiter;
             GraphQLServer = graphQlServer ?? GraphQLServer;
             GraphQLHost = graphQLHost ?? GraphQLHost;
             GraphQLPort = graphQLPort ?? GraphQLPort;

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -124,6 +124,9 @@ namespace NineChronicles.Headless.Executable
             [Option(Description = "If you enable this option with \"rpcRemoteServer\" option at the same time, " +
                                   "RPC server will use HTTP/1, not gRPC.")]
             bool? rpcHttpServer = null,
+            [Option(Description = "User this option to enable rate limiting on the RPC server." +
+                                  "Rate limiting is only applied to tx staging. Turned off by default.")]
+            bool? rpcRateLimiter = null,
             [Option("graphql-server",
                 Description = "Use this option if you want to enable GraphQL server to enable querying data.")]
             bool? graphQLServer = null,
@@ -240,7 +243,7 @@ namespace NineChronicles.Headless.Executable
                 appProtocolVersionToken, trustedAppProtocolVersionSigners, genesisBlockPath, host, port,
                 swarmPrivateKeyString, storeType, storePath, noReduceStore, noMiner, minerCount,
                 minerPrivateKeyString, minerBlockIntervalMilliseconds, networkType, iceServerStrings, peerStrings, rpcServer, rpcListenHost,
-                rpcListenPort, rpcRemoteServer, rpcHttpServer, graphQLServer, graphQLHost, graphQLPort,
+                rpcListenPort, rpcRemoteServer, rpcHttpServer, rpcRateLimiter, graphQLServer, graphQLHost, graphQLPort,
                 graphQLSecretTokenPath, noCors, nonblockRenderer, nonblockRendererQueue, strictRendering,
                 logActionRenders, confirmations,
                 txLifeTime, messageTimeout, tipTimeout, demandBuffer, skipPreload,
@@ -463,7 +466,8 @@ namespace NineChronicles.Headless.Executable
                             .GenerateRpcNodeServiceProperties(
                                 headlessConfig.RpcListenHost,
                                 headlessConfig.RpcListenPort,
-                                headlessConfig.RpcRemoteServer == true
+                                headlessConfig.RpcRemoteServer == true,
+                                headlessConfig.RpcRateLimiter
                             )
                     );
                 }

--- a/NineChronicles.Headless.Executable/appsettings.internal.json
+++ b/NineChronicles.Headless.Executable/appsettings.internal.json
@@ -66,6 +66,11 @@
             }
         ]
     },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "None"
+        }
+    },
     "Headless": {
         "AppProtocolVersionString": "1132/54684Ac4ee5B933e72144C4968BEa26056880d71/MEQCIHNl6d9J+118qp3gH0gGlZmuSo15a2CM8wtW+.eAglJTAiBoVWGkbXimRwft31VFpHL5qaqT3r752nLjK22PRJb5ng==/ZHU4OmxhdW5jaGVydTQyOjEvNDgwNmExOTNkNjBhMjlhYjI5ODgzNTAwZjJhNTY3Y2Q0MjUzOWY4YnU2OnBsYXllcnU0MjoxLzBmNmVjZDIwMGNhMzBjZTczY2M2ZjQ3MTc5ZjExMzQ2YzQ5MDhmMmF1OTp0aW1lc3RhbXB1MTA6MjAyMi0xMS0yNWU=",
         "GenesisBlockPath": "https://release.nine-chronicles.com/genesis-block-9c-main",

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -66,6 +66,11 @@
             }
         ]
     },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "None"
+        }
+    },
     "Headless": {
         "AppProtocolVersionString": "",
         "GenesisBlockPath": "",

--- a/NineChronicles.Headless.Executable/appsettings.mainnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.mainnet.json
@@ -66,6 +66,11 @@
             }
         ]
     },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "None"
+        }
+    },
     "Headless": {
         "AppProtocolVersionString": "200000/AB2da648b9154F2cCcAFBD85e0Bc3d51f97330Fc/MEUCIQD4MxYR4lSu69b+TYUB91k.Ns5cJHlK0B6SzU60g16OOgIgUwg3wJNKSO7A68sKn.rDQiuHAjftT1fPOmwiLEZyvJE=/ZHU4OmxhdW5jaGVydTQyOjEvMDZmZmYwZGVlM2Q4NGIwNzhkMjNlZDgxZGRjODgxOWM4ZGU1ZmY5MHU2OnBsYXllcnU0MjoxLzhjYWI5NjYwYTk2MzIyMDk4MjU5OWZjYjc0MjMyNjI2MzA5ZTIwZmF1OTp0aW1lc3RhbXB1MTA6MjAyMy0wNC0wNWU=",
         "GenesisBlockPath": "https://release.nine-chronicles.com/genesis-block-9c-main",

--- a/NineChronicles.Headless.Executable/appsettings.previewnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.previewnet.json
@@ -90,6 +90,11 @@
             }
         ]
     },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "None"
+        }
+    },
     "Headless": {
         "AppProtocolVersionString": "1067/8c72600A23ed14026ab76d56B9A0edc339B305B0/MEUCIQDBsAhBgWjwg91M9miBpA+XjX2hQMdk8PvGa9ZN8QsskgIgJ73BV+Y0Lj+8aXZH.S36KC2tO2CdxdTOnMw6OvWbuHc=/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTY1Omh0dHBzOi8vZG93bmxvYWQubmluZS1jaHJvbmljbGVzLmNvbS9wcmV2aWV3bmV0L3YxMDY3L1dpbmRvd3MuemlwdTk6dGltZXN0YW1wdTEwOjIwMjItMDYtMTZl",
         "GenesisBlockPath": "https://9c-test.s3.ap-northeast-2.amazonaws.com/genesis-block-rune",

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -15,6 +16,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Nekoyume.Action;
+using NineChronicles.Headless.Middleware;
 using Sentry;
 
 namespace NineChronicles.Headless
@@ -77,6 +79,7 @@ namespace NineChronicles.Headless
                     services.AddGrpc(options =>
                     {
                         options.MaxReceiveMessageSize = null;
+                        options.Interceptors.Add<RateLimitInterceptor>();
                     });
                     services.AddMagicOnion();
                     services.AddSingleton(provider =>
@@ -93,6 +96,7 @@ namespace NineChronicles.Headless
                             provider.GetRequiredService<ConcurrentDictionary<string, ITransaction>>()
                         );
                     });
+                    services.AddSingleton(new RateLimitInterceptor(1, TimeSpan.FromSeconds(5)));
                     var resolver = MessagePack.Resolvers.CompositeResolver.Create(
                         NineChroniclesResolver.Instance,
                         StandardResolver.Instance

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -79,7 +79,10 @@ namespace NineChronicles.Headless
                     services.AddGrpc(options =>
                     {
                         options.MaxReceiveMessageSize = null;
-                        options.Interceptors.Add<RateLimitInterceptor>();
+                        if (properties.RpcRateLimiter)
+                        {
+                            options.Interceptors.Add<RateLimitInterceptor>();
+                        }
                     });
                     services.AddMagicOnion();
                     services.AddSingleton(provider =>
@@ -96,7 +99,11 @@ namespace NineChronicles.Headless
                             provider.GetRequiredService<ConcurrentDictionary<string, ITransaction>>()
                         );
                     });
-                    services.AddSingleton(new RateLimitInterceptor(1, TimeSpan.FromSeconds(5)));
+                    if (properties.RpcRateLimiter)
+                    {
+                        services.AddSingleton(new RateLimitInterceptor(1, TimeSpan.FromSeconds(5)));
+                    }
+
                     var resolver = MessagePack.Resolvers.CompositeResolver.Create(
                         NineChroniclesResolver.Instance,
                         StandardResolver.Instance

--- a/NineChronicles.Headless/Middleware/GrpcRateLimitMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcRateLimitMiddleware.cs
@@ -1,0 +1,73 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace NineChronicles.Headless.Middleware
+{
+    public class RateLimitInterceptor : Interceptor
+    {
+        private readonly int _limit;
+        private readonly TimeSpan _interval;
+        private readonly ConcurrentDictionary<string, ConcurrentQueue<DateTime>> _requestsByIp;
+        private readonly ILogger _logger;
+
+        public RateLimitInterceptor(int limit, TimeSpan interval)
+        {
+            _limit = limit;
+            _interval = interval;
+            _requestsByIp = new ConcurrentDictionary<string, ConcurrentQueue<DateTime>>();
+            _logger = Log.Logger.ForContext<RateLimitInterceptor>();
+        }
+
+        public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+            TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
+        {
+            var httpContext = context.GetHttpContext();
+            var ipAddress = httpContext.Connection.RemoteIpAddress + ":" + httpContext.Connection.RemotePort;
+            if (context.Method == "/IBlockChainService/AddClient")
+            {
+                _logger.Information(
+                    "[GRPC-REQUEST-CAPTURE] Add client. IP: {IP} Method: {Method} Request: {Request}",
+                    ipAddress, context.Method, request);
+            }
+
+            if (context.Method == "/IBlockChainService/PutTransaction" && !TryAcquire(ipAddress))
+            {
+                _logger.Information(
+                    "[GRPC-REQUEST-CAPTURE] Rate limit exceeded. IP: {IP} Method: {Method} Request: {Request}",
+                    ipAddress, context.Method, request);
+                throw new RpcException(new Status(StatusCode.ResourceExhausted, "Rate limit exceeded."));
+            }
+
+            return await base.UnaryServerHandler(request, context, continuation);
+        }
+
+        private bool TryAcquire(string ipAddress)
+        {
+            var requests = _requestsByIp.GetOrAdd(ipAddress, new ConcurrentQueue<DateTime>());
+            while (requests.TryPeek(out DateTime requestTime))
+            {
+                if (DateTime.UtcNow - requestTime > _interval)
+                {
+                    requests.TryDequeue(out requestTime);
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (requests.Count < _limit)
+            {
+                requests.Enqueue(DateTime.UtcNow);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -136,7 +136,8 @@ namespace NineChronicles.Headless.Properties
         public static RpcNodeServiceProperties GenerateRpcNodeServiceProperties(
             string rpcListenHost = "0.0.0.0",
             int? rpcListenPort = null,
-            bool rpcRemoteServer = false)
+            bool rpcRemoteServer = false,
+            bool rpcRateLimiter = false)
         {
 
             if (string.IsNullOrEmpty(rpcListenHost))
@@ -156,6 +157,7 @@ namespace NineChronicles.Headless.Properties
                 RpcListenHost = rpcListenHost,
                 RpcListenPort = rpcPortValue,
                 RpcRemoteServer = rpcRemoteServer,
+                RpcRateLimiter = rpcRateLimiter,
             };
         }
     }

--- a/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
@@ -7,5 +7,7 @@ namespace NineChronicles.Headless.Properties
         public int RpcListenPort { get; set; }
 
         public bool RpcRemoteServer { get; set; }
+
+        public bool RpcRateLimiter { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Usage: NineChronicles.Headless.Executable
 [--rpc-listen-port <Int32>] 
 [--rpc-remote-server]
 [--rpc-http-server]
+[--rpc-rate-limiter]
 
 // GraphQL
 [--graphql-server] 
@@ -131,6 +132,7 @@ Options:
   --rpc-listen-port <Int32>                                RPC listen port
   --rpc-remote-server                                      Do a role as RPC remote server? If you enable this option, multiple Unity clients can connect to your RPC server.
   --rpc-http-server                                        If you enable this option with "rpcRemoteServer" option at the same time, RPC server will use HTTP/1, not gRPC.
+  --rpc-rate-limiter                                       User this option to enable rate limiting on the RPC server.Rate limiting is only applied to tx staging. Turned off by default.
   --graphql-server                                         Use this option if you want to enable GraphQL server to enable querying data.
   --graphql-host <String>                                  GraphQL listen host
   --graphql-port <Int32>                                   GraphQL listen port


### PR DESCRIPTION
This PR limits clients to 1 `PutTransaction` request every 5 seconds.

Although this middleware might not be completely robust, it appears to work fine in the mainnet to be used for now.

After this PR, I will be working on https://github.com/planetarium/NineChronicles.Headless/issues/1986 to utilize the [built-in rate limiting feature](https://devblogs.microsoft.com/dotnet/announcing-rate-limiting-for-dotnet/) in `.NET 7`