### PR TITLE
Inject Swarm<T> to StandaloneContext

### DIFF
--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -268,6 +268,7 @@ namespace NineChronicles.Headless
             standaloneContext.NineChroniclesNodeService = this;
             standaloneContext.BlockChain = Swarm.BlockChain;
             standaloneContext.Store = Store;
+            standaloneContext.Swarm = Swarm;
             BootstrapEnded.WaitAsync().ContinueWith((task) =>
             {
                 standaloneContext.BootstrapEnded = true;


### PR DESCRIPTION
Since injection of `Swarm<T>` to `standaloneContext` is missing, queries `nodeState.peers` and `nodeState.validators` was broken.
Fixed it with `Swarm<T>` injection.