### PR TITLE
Action should not be null

### DIFF
--- a/NineChronicles.Headless/GraphTypes/ActionQuery.DevEx.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.DevEx.cs
@@ -105,7 +105,7 @@ namespace NineChronicles.Headless.GraphTypes
                         throw exception;
                     }
 
-                    var action = (NCAction)(GameAction)result;
+                    var action = (NCAction)(GameAction)result!;
                     return Encode(context, action);
                 });
         }


### PR DESCRIPTION
DevEx function returns nullable but action must not be null.