### PR TITLE
Feat/grpc rate limit

### DIFF
--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -49,6 +49,9 @@ namespace NineChronicles.Headless.Executable
         public int? RpcListenPort { get; set; }
         public bool? RpcRemoteServer { get; set; }
         public bool? RpcHttpServer { get; set; }
+        public bool RpcRateLimiter { get; set; }
+        public int? RpcRateLimiterWindow { get; set; }
+        public int? RpcRateLimiterPermit { get; set; }
 
         // GraphQL Server
         public bool GraphQLServer { get; set; }
@@ -108,6 +111,9 @@ namespace NineChronicles.Headless.Executable
             int? rpcListenPort,
             bool? rpcRemoteServer,
             bool? rpcHttpServer,
+            bool? rpcRateLimiter,
+            int? rpcRateLimiterWindow,
+            int? rpcRateLimiterPermit,
             bool? graphQlServer,
             string? graphQLHost,
             int? graphQLPort,
@@ -157,6 +163,9 @@ namespace NineChronicles.Headless.Executable
             RpcListenPort = rpcListenPort ?? RpcListenPort;
             RpcRemoteServer = rpcRemoteServer ?? RpcRemoteServer;
             RpcHttpServer = rpcHttpServer ?? RpcHttpServer;
+            RpcRateLimiter = rpcRateLimiter ?? RpcRateLimiter;
+            RpcRateLimiterWindow = rpcRateLimiterWindow ?? RpcRateLimiterWindow;
+            RpcRateLimiterPermit = rpcRateLimiterPermit ?? RpcRateLimiterPermit;
             GraphQLServer = graphQlServer ?? GraphQLServer;
             GraphQLHost = graphQLHost ?? GraphQLHost;
             GraphQLPort = graphQLPort ?? GraphQLPort;

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -124,6 +124,15 @@ namespace NineChronicles.Headless.Executable
             [Option(Description = "If you enable this option with \"rpcRemoteServer\" option at the same time, " +
                                   "RPC server will use HTTP/1, not gRPC.")]
             bool? rpcHttpServer = null,
+            [Option(Description = "Use this option to enable rate limiting on the RPC server (fixed window)." +
+                                  "Rate limiting is only applied to tx staging. Turned off by default.")]
+            bool? rpcRateLimiter = null,
+            [Option(Description = "Use this option to set the window time(in seconds) on the RPC rate limiter" +
+                                  "(--rpc-rate-limiter option required). Set to 5 seconds by default.")]
+            int? rpcRateLimiterWindow = null,
+            [Option(Description = "Use this option to set the number of requests per window time on the RPC rate limiter" +
+                                  "(--rpc-rate-limiter option required). Set to 1 request by default.")]
+            int? rpcRateLimiterPermit = null,
             [Option("graphql-server",
                 Description = "Use this option if you want to enable GraphQL server to enable querying data.")]
             bool? graphQLServer = null,
@@ -240,9 +249,9 @@ namespace NineChronicles.Headless.Executable
                 appProtocolVersionToken, trustedAppProtocolVersionSigners, genesisBlockPath, host, port,
                 swarmPrivateKeyString, storeType, storePath, noReduceStore, noMiner, minerCount,
                 minerPrivateKeyString, minerBlockIntervalMilliseconds, networkType, iceServerStrings, peerStrings, rpcServer, rpcListenHost,
-                rpcListenPort, rpcRemoteServer, rpcHttpServer, graphQLServer, graphQLHost, graphQLPort,
-                graphQLSecretTokenPath, noCors, nonblockRenderer, nonblockRendererQueue, strictRendering,
-                logActionRenders, confirmations,
+                rpcListenPort, rpcRemoteServer, rpcHttpServer, rpcRateLimiter, rpcRateLimiterWindow, rpcRateLimiterPermit,
+                graphQLServer, graphQLHost, graphQLPort, graphQLSecretTokenPath, noCors,
+                nonblockRenderer, nonblockRendererQueue, strictRendering, logActionRenders, confirmations,
                 txLifeTime, messageTimeout, tipTimeout, demandBuffer, skipPreload,
                 minimumBroadcastTarget, bucketSize, chainTipStaleBehaviorType, txQuotaPerSigner, maximumPollPeers,
                 consensusPort, consensusPrivateKeyString, consensusSeedStrings,
@@ -463,7 +472,10 @@ namespace NineChronicles.Headless.Executable
                             .GenerateRpcNodeServiceProperties(
                                 headlessConfig.RpcListenHost,
                                 headlessConfig.RpcListenPort,
-                                headlessConfig.RpcRemoteServer == true
+                                headlessConfig.RpcRemoteServer == true,
+                                headlessConfig.RpcRateLimiter,
+                                headlessConfig.RpcRateLimiterWindow,
+                                headlessConfig.RpcRateLimiterPermit
                             )
                     );
                 }

--- a/NineChronicles.Headless.Executable/appsettings.internal.json
+++ b/NineChronicles.Headless.Executable/appsettings.internal.json
@@ -66,6 +66,11 @@
             }
         ]
     },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "None"
+        }
+    },
     "Headless": {
         "AppProtocolVersionString": "1132/54684Ac4ee5B933e72144C4968BEa26056880d71/MEQCIHNl6d9J+118qp3gH0gGlZmuSo15a2CM8wtW+.eAglJTAiBoVWGkbXimRwft31VFpHL5qaqT3r752nLjK22PRJb5ng==/ZHU4OmxhdW5jaGVydTQyOjEvNDgwNmExOTNkNjBhMjlhYjI5ODgzNTAwZjJhNTY3Y2Q0MjUzOWY4YnU2OnBsYXllcnU0MjoxLzBmNmVjZDIwMGNhMzBjZTczY2M2ZjQ3MTc5ZjExMzQ2YzQ5MDhmMmF1OTp0aW1lc3RhbXB1MTA6MjAyMi0xMS0yNWU=",
         "GenesisBlockPath": "https://release.nine-chronicles.com/genesis-block-9c-main",

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -66,6 +66,11 @@
             }
         ]
     },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "None"
+        }
+    },
     "Headless": {
         "AppProtocolVersionString": "",
         "GenesisBlockPath": "",

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -96,7 +96,7 @@
         "EnableRateLimiting": false
     },
     "IpRateLimiting": {
-        "EnableEndpointRateLimiting": true,
+        "EnableRateLimiting": false,
         "StackBlockedRequests": true,
         "RealIpHeader": "X-Real-IP",
         "HttpStatusCode": 429,

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -92,6 +92,9 @@
         "Confirmations": 0,
         "ChainTipStaleBehaviorType": "reboot"
     },
+    "RpcRateLimiting": {
+        "EnableRateLimiting": false
+    },
     "IpRateLimiting": {
         "EnableEndpointRateLimiting": true,
         "StackBlockedRequests": true,

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -96,7 +96,7 @@
         "EnableRateLimiting": false
     },
     "IpRateLimiting": {
-        "EnableRateLimiting": false,
+        "EnableEndpointRateLimiting": false,
         "StackBlockedRequests": true,
         "RealIpHeader": "X-Real-IP",
         "HttpStatusCode": 429,

--- a/NineChronicles.Headless.Executable/appsettings.mainnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.mainnet.json
@@ -66,6 +66,11 @@
             }
         ]
     },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "None"
+        }
+    },
     "Headless": {
         "AppProtocolVersionString": "200000/AB2da648b9154F2cCcAFBD85e0Bc3d51f97330Fc/MEUCIQD4MxYR4lSu69b+TYUB91k.Ns5cJHlK0B6SzU60g16OOgIgUwg3wJNKSO7A68sKn.rDQiuHAjftT1fPOmwiLEZyvJE=/ZHU4OmxhdW5jaGVydTQyOjEvMDZmZmYwZGVlM2Q4NGIwNzhkMjNlZDgxZGRjODgxOWM4ZGU1ZmY5MHU2OnBsYXllcnU0MjoxLzhjYWI5NjYwYTk2MzIyMDk4MjU5OWZjYjc0MjMyNjI2MzA5ZTIwZmF1OTp0aW1lc3RhbXB1MTA6MjAyMy0wNC0wNWU=",
         "GenesisBlockPath": "https://release.nine-chronicles.com/genesis-block-9c-main",

--- a/NineChronicles.Headless.Executable/appsettings.previewnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.previewnet.json
@@ -90,6 +90,11 @@
             }
         ]
     },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "None"
+        }
+    },
     "Headless": {
         "AppProtocolVersionString": "1067/8c72600A23ed14026ab76d56B9A0edc339B305B0/MEUCIQDBsAhBgWjwg91M9miBpA+XjX2hQMdk8PvGa9ZN8QsskgIgJ73BV+Y0Lj+8aXZH.S36KC2tO2CdxdTOnMw6OvWbuHc=/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTY1Omh0dHBzOi8vZG93bmxvYWQubmluZS1jaHJvbmljbGVzLmNvbS9wcmV2aWV3bmV0L3YxMDY3L1dpbmRvd3MuemlwdTk6dGltZXN0YW1wdTEwOjIwMjItMDYtMTZl",
         "GenesisBlockPath": "https://9c-test.s3.ap-northeast-2.amazonaws.com/genesis-block-rune",

--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -26,6 +26,7 @@ using Serilog;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 using NodeExceptionType = Libplanet.Headless.NodeExceptionType;
 using Libplanet.Headless;
+using Microsoft.AspNetCore.RateLimiting;
 using Nekoyume.Model.State;
 using Sentry;
 
@@ -61,6 +62,7 @@ namespace NineChronicles.Headless
             _sentryTraces = sentryTraces;
         }
 
+        [EnableRateLimiting("GrpcRateLimiter")]
         public UnaryResult<bool> PutTransaction(byte[] txBytes)
         {
             try

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -173,7 +173,7 @@ namespace NineChronicles.Headless
                 app.UseAuthorization();
 
                 if (((IList)Environment.GetCommandLineArgs()).Contains("--rpc-rate-limiter") ||
-                    Convert.ToBoolean(Configuration.GetSection("RPCRateLimiting")["EnableRateLimiting"]))
+                    Convert.ToBoolean(Configuration.GetSection("RpcRateLimiting")["EnableRateLimiting"]))
                 {
                     app.UseRateLimiter();
                 }

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -178,7 +178,7 @@ namespace NineChronicles.Headless
                     app.UseRateLimiter();
                 }
 
-                if (Convert.ToBoolean(Configuration.GetSection("IpRateLimiting")["EnableRateLimiting"]))
+                if (Convert.ToBoolean(Configuration.GetSection("IpRateLimiting")["EnableEndpointRateLimiting"]))
                 {
                     app.UseIpRateLimiting();
                     app.UseMvc();

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using AspNetCoreRateLimit;
 using GraphQL.Server;
@@ -170,6 +171,12 @@ namespace NineChronicles.Headless
 
                 app.UseRouting();
                 app.UseAuthorization();
+
+                if (((IList)Environment.GetCommandLineArgs()).Contains("--rpc-rate-limiter"))
+                {
+                    app.UseRateLimiter();
+                }
+
                 if (Convert.ToBoolean(Configuration.GetSection("IpRateLimiting")["EnableRateLimiting"]))
                 {
                     app.UseIpRateLimiting();

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -172,7 +172,8 @@ namespace NineChronicles.Headless
                 app.UseRouting();
                 app.UseAuthorization();
 
-                if (((IList)Environment.GetCommandLineArgs()).Contains("--rpc-rate-limiter"))
+                if (((IList)Environment.GetCommandLineArgs()).Contains("--rpc-rate-limiter") ||
+                    Convert.ToBoolean(Configuration.GetSection("RPCRateLimiting")["EnableRateLimiting"]))
                 {
                     app.UseRateLimiter();
                 }

--- a/NineChronicles.Headless/GrpcRateLimiterPolicy.cs
+++ b/NineChronicles.Headless/GrpcRateLimiterPolicy.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.RateLimiting;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+using NineChronicles.Headless.Properties;
+using Serilog;
+
+namespace NineChronicles.Headless
+{
+    public class GrpcRateLimiterPolicy : IRateLimiterPolicy<string>
+    {
+        private readonly GrpcRateLimitOptions _options;
+
+        public GrpcRateLimiterPolicy(
+            IOptions<GrpcRateLimitOptions> options)
+        {
+            var logger = Log.Logger.ForContext<GrpcRateLimiterPolicy>();
+            OnRejected = (ctx, _) =>
+            {
+                ctx.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                var ipAddress = GetUserEndPoint(ctx.HttpContext);
+                logger.Information($"[GRPC-REQUEST-CAPTURE] Rate limit exceeded. IP: {ipAddress} Method: {ctx.HttpContext.Request.Path}");
+                return ValueTask.CompletedTask;
+            };
+            _options = options.Value;
+        }
+
+        public Func<OnRejectedContext, CancellationToken, ValueTask>? OnRejected { get; }
+
+        public RateLimitPartition<string> GetPartition(HttpContext httpContext)
+        {
+            var ipAddress = GetUserEndPoint(httpContext);
+            return RateLimitPartition.GetFixedWindowLimiter(ipAddress,
+                _ => new FixedWindowRateLimiterOptions()
+                {
+                    PermitLimit = _options.PermitLimit,
+                    QueueLimit = _options.QueueLimit,
+                    Window = TimeSpan.FromSeconds(_options.Window),
+                    AutoReplenishment = _options.AutoReplenishment
+                });
+        }
+
+        static string GetUserEndPoint(HttpContext context) =>
+            context.Connection.RemoteIpAddress + ":" + context.Connection.RemotePort;
+    }
+}

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Nekoyume.Action;
+using NineChronicles.Headless.Middleware;
 using Sentry;
 
 namespace NineChronicles.Headless
@@ -77,7 +78,23 @@ namespace NineChronicles.Headless
                     services.AddGrpc(options =>
                     {
                         options.MaxReceiveMessageSize = null;
+                        options.Interceptors.Add<GrpcCaptureMiddleware>();
                     });
+
+                    if (properties.RpcRateLimiter)
+                    {
+                        services.Configure<GrpcRateLimitOptions>(options =>
+                        {
+                            options.Window = properties.RpcRateLimiterWindow;
+                            options.PermitLimit = properties.RpcRateLimiterPermit;
+                        });
+
+                        services.AddRateLimiter(limiterOptions =>
+                        {
+                            limiterOptions.AddPolicy<string, GrpcRateLimiterPolicy>("GrpcRateLimiter");
+                        });
+                    }
+
                     services.AddMagicOnion();
                     services.AddSingleton(provider =>
                     {

--- a/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
@@ -1,0 +1,32 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace NineChronicles.Headless.Middleware
+{
+    public class GrpcCaptureMiddleware : Interceptor
+    {
+        private readonly ILogger _logger;
+
+        public GrpcCaptureMiddleware()
+        {
+            _logger = Log.Logger.ForContext<GrpcCaptureMiddleware>();
+        }
+
+        public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+            TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
+        {
+            if (context.Method is "/IBlockChainService/AddClient" or "/IBlockChainService/PutTransaction")
+            {
+                var httpContext = context.GetHttpContext();
+                var ipAddress = httpContext.Connection.RemoteIpAddress + ":" + httpContext.Connection.RemotePort;
+                _logger.Information(
+                    "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Request: {Request}",
+                    ipAddress, context.Method, request);
+            }
+
+            return await base.UnaryServerHandler(request, context, continuation);
+        }
+    }
+}

--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -25,7 +25,8 @@ namespace NineChronicles.Headless.Middleware
                 context.Request.EnableBuffering();
                 var remoteIp = context.Connection.RemoteIpAddress;
                 var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
-                _logger.Information("[REQUEST-CAPTURE] Ip: {IP} Method: {Method} Endpoint: {Path}\n{Body}", remoteIp, context.Request.Method, context.Request.Path, body);
+                _logger.Information("[REQUEST-CAPTURE] IP: {IP} Method: {Method} Endpoint: {Path} Request: {Body}",
+                    remoteIp, context.Request.Method, context.Request.Path, body);
                 context.Request.Body.Seek(0, SeekOrigin.Begin);
             }
 

--- a/NineChronicles.Headless/Properties/GrpcRateLimitOptions.cs
+++ b/NineChronicles.Headless/Properties/GrpcRateLimitOptions.cs
@@ -1,0 +1,11 @@
+namespace NineChronicles.Headless.Properties
+{
+    public class GrpcRateLimitOptions
+    {
+        public const string GrpcRateLimit = "GrpcRateLimit";
+        public int PermitLimit { get; set; } = 1;
+        public int Window { get; set; } = 5;
+        public int QueueLimit { get; set; } = 0;
+        public bool AutoReplenishment { get; set; } = true;
+    }
+}

--- a/NineChronicles.Headless/Properties/GrpcRateLimitOptions.cs
+++ b/NineChronicles.Headless/Properties/GrpcRateLimitOptions.cs
@@ -2,7 +2,6 @@ namespace NineChronicles.Headless.Properties
 {
     public class GrpcRateLimitOptions
     {
-        public const string GrpcRateLimit = "GrpcRateLimit";
         public int PermitLimit { get; set; } = 1;
         public int Window { get; set; } = 5;
         public int QueueLimit { get; set; } = 0;

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -136,7 +136,10 @@ namespace NineChronicles.Headless.Properties
         public static RpcNodeServiceProperties GenerateRpcNodeServiceProperties(
             string rpcListenHost = "0.0.0.0",
             int? rpcListenPort = null,
-            bool rpcRemoteServer = false)
+            bool rpcRemoteServer = false,
+            bool rpcRateLimiter = false,
+            int? rpcRateLimiterWindow = 5,
+            int? rpcRateLimiterPermit = 1)
         {
 
             if (string.IsNullOrEmpty(rpcListenHost))
@@ -156,6 +159,9 @@ namespace NineChronicles.Headless.Properties
                 RpcListenHost = rpcListenHost,
                 RpcListenPort = rpcPortValue,
                 RpcRemoteServer = rpcRemoteServer,
+                RpcRateLimiter = rpcRateLimiter,
+                RpcRateLimiterWindow = rpcRateLimiterWindow ?? 5,
+                RpcRateLimiterPermit = rpcRateLimiterPermit ?? 1
             };
         }
     }

--- a/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/RpcNodeServiceProperties.cs
@@ -7,5 +7,11 @@ namespace NineChronicles.Headless.Properties
         public int RpcListenPort { get; set; }
 
         public bool RpcRemoteServer { get; set; }
+
+        public bool RpcRateLimiter { get; set; }
+
+        public int RpcRateLimiterWindow { get; set; }
+
+        public int RpcRateLimiterPermit { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Usage: NineChronicles.Headless.Executable
 [--rpc-listen-port <Int32>] 
 [--rpc-remote-server]
 [--rpc-http-server]
+[--rpc-rate-limiter]
+[--rpc-rate-limiter-window <Int32>]
+[--rpc-rate-limiter-permit <Int32>]
 
 // GraphQL
 [--graphql-server] 
@@ -131,6 +134,9 @@ Options:
   --rpc-listen-port <Int32>                                RPC listen port
   --rpc-remote-server                                      Do a role as RPC remote server? If you enable this option, multiple Unity clients can connect to your RPC server.
   --rpc-http-server                                        If you enable this option with "rpcRemoteServer" option at the same time, RPC server will use HTTP/1, not gRPC.
+  --rpc-rate-limiter                                       Use this option to enable rate limiting on the RPC server (fixed window).Rate limiting is only applied to tx staging. Turned off by default.
+  --rpc-rate-limiter-window <Int32>                        Use this option to set the window time(in seconds) on the RPC rate limiter(--rpc-rate-limiter option required). Set to 5 seconds by default.
+  --rpc-rate-limiter-permit <Int32>                        Use this option to set the number of requests per window time on the RPC rate limiter(--rpc-rate-limiter option required). Set to 1 request by default.
   --graphql-server                                         Use this option if you want to enable GraphQL server to enable querying data.
   --graphql-host <String>                                  GraphQL listen host
   --graphql-port <Int32>                                   GraphQL listen port


### PR DESCRIPTION
This PR adds a RPC rate limiting feature for tx staging. The added options are:

- `--rpc-rate-limiter`: Enables rate limiting on the RPC server (turned off by default).
- `--rpc-rate-limiter-window`: Sets the interval(in seconds) in the rate limiter (set to 5 seconds by default).
- `--rpc-rate-limiter-permit`: Sets the max number of requests in the rate limiter (set to 1 request by default).

**Note**: `--rpc-rate-limiter-window` and `--rpc-rate-limiter-permit` options require the `--rpc-rate-limiter` option to be enabled.