### PR TITLE
Implement `RemoteActionEvaluator`

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -60,6 +60,12 @@ jobs:
             --amend $DOCKER_REPO:git-${{ github.sha }}-amd64 \
             --amend $DOCKER_REPO:git-${{ github.sha }}-arm64v8
           docker manifest push $DOCKER_REPO:git-${{ github.sha }}
+      - name: build-and-push for lib9c-stateservice
+        run: |
+          docker build . \
+            -f Dockerfile.lib9c-stateservice \
+            -t planetariumhq/lib9c-stateservice:git-${{ github.sha }}
+          docker push planetariumhq/lib9c-stateservice:git-${{ github.sha }}
 
   tag:
     if: github.ref_type == 'tag' || github.event.inputs.imageTag != ''

--- a/Dockerfile.lib9c-stateservice
+++ b/Dockerfile.lib9c-stateservice
@@ -1,0 +1,32 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build-env
+WORKDIR /app
+
+# Copy csproj and restore as distinct layers
+COPY ./Lib9c/Lib9c/Lib9c.csproj ./Lib9c/
+COPY ./Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj ./Libplanet.Extensions.RemoteActionEvaluator/
+RUN dotnet restore Lib9c
+RUN dotnet restore Libplanet.Extensions.RemoteActionEvaluator
+
+# Copy everything else and build
+COPY . ./
+RUN dotnet publish Lib9c.StateService/Lib9c.StateService.csproj \
+    -c Release \
+    -r linux-x64 \
+    -o out \
+    --self-contained
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
+WORKDIR /app
+RUN apt-get update && apt-get install -y libc6-dev
+COPY --from=build-env /app/out .
+
+# Install native deps & utilities for production
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+        libc6-dev jq curl \
+     && rm -rf /var/lib/apt/lists/*
+
+VOLUME /data
+
+ENTRYPOINT ["dotnet", "Lib9c.StateService.dll"]

--- a/Lib9c.StateService/Controllers/RemoteEvaluationController.cs
+++ b/Lib9c.StateService/Controllers/RemoteEvaluationController.cs
@@ -1,0 +1,51 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Extensions.RemoteActionEvaluator;
+using Microsoft.AspNetCore.Mvc;
+using Nekoyume.Action;
+
+namespace Lib9c.StateService.Controllers;
+
+[ApiController]
+[Route("/evaluation")]
+public class RemoteEvaluationController : ControllerBase
+{
+    private readonly ILogger<RemoteEvaluationController> _logger;
+    private readonly Codec _codec;
+
+    public RemoteEvaluationController(ILogger<RemoteEvaluationController> logger, Codec codec)
+    {
+        _logger = logger;
+        _codec = codec;
+    }
+
+    [HttpPost]
+    public ActionResult<RemoteEvaluationResponse> GetEvaluation([FromBody] RemoteEvaluationRequest request)
+    {
+        var decoded = _codec.Decode(request.PreEvaluationBlock);
+        if (decoded is not Dictionary dictionary)
+        {
+            return StatusCode(StatusCodes.Status400BadRequest);
+        }
+
+        var preEvaluationBlock = PreEvaluationBlockMarshaller.Unmarshal(dictionary);
+        var blockChainStates = new RemoteBlockChainStates(new Uri("http://localhost:31280/graphql/explorer"));
+        var actionEvaluator =
+            new ActionEvaluator(
+                context => new RewardGold(),
+                blockChainStates,
+                null,
+                null,
+                _ => false,
+                new StaticActionTypeLoader(ImmutableHashSet<Assembly>.Empty.Add(typeof(ActionBase).Assembly), typeof(ActionBase)),
+                null);
+        return Ok(new RemoteEvaluationResponse
+        {
+            Evaluations = actionEvaluator.Evaluate(preEvaluationBlock).Select(ActionEvaluationMarshaller.Serialize)
+                .ToArray(),
+        });
+    }
+}

--- a/Lib9c.StateService/Lib9c.StateService.csproj
+++ b/Lib9c.StateService/Lib9c.StateService.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Libplanet.Extensions.RemoteActionEvaluator\Libplanet.Extensions.RemoteActionEvaluator.csproj" />
+    <ProjectReference Include="..\Lib9c\Lib9c\Lib9c.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Lib9c.StateService/Program.cs
+++ b/Lib9c.StateService/Program.cs
@@ -1,0 +1,29 @@
+using Bencodex;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddSingleton<Codec>();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/Lib9c.StateService/Properties/launchSettings.json
+++ b/Lib9c.StateService/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:25712",
+      "sslPort": 44330
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5157",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7140;http://localhost:5157",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Lib9c.StateService/appsettings.Development.json
+++ b/Lib9c.StateService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/Lib9c.StateService/appsettings.json
+++ b/Lib9c.StateService/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator.Tests/ActionEvaluationSerializerTest.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator.Tests/ActionEvaluationSerializerTest.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Crypto;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator.Tests;
+
+public class ActionEvaluationSerializerTest
+{
+    [Fact]
+    public void Serialization()
+    {
+        var addresses = Enumerable.Repeat(0, 4).Select(_ => new PrivateKey().ToAddress()).ToImmutableList();
+        IAccountStateDelta outputStates = new AccountStateDelta()
+            .SetState(addresses[0], Null.Value)
+            .SetState(addresses[1], (Text)"foo")
+            .SetState(addresses[2], new List((Text)"bar"));
+        var actionEvaluation = new ActionEvaluation(
+            Null.Value,
+            new ActionContext(null,
+                addresses[0],
+                null,
+                addresses[1],
+                0,
+                false,
+                new AccountStateDelta(),
+                new Random(123),
+                null,
+                true),
+            outputStates,
+            new Libplanet.Action.UnexpectedlyTerminatedActionException("", null, null, null, null, new NullAction(), null),
+            new List<string> { "one", "two" });
+        var serialized = ActionEvaluationMarshaller.Serialize(actionEvaluation);
+        var deserialized = ActionEvaluationMarshaller.Deserialize(serialized);
+
+        Assert.Equal(Null.Value, deserialized.Action);
+        Assert.Equal(123, deserialized.InputContext.Random.Seed);
+        Assert.Equal(0, deserialized.InputContext.BlockIndex);
+        Assert.Equal(new[] { "one", "two" }, deserialized.Logs);
+        Assert.Equal(addresses[0], deserialized.InputContext.Signer);
+        Assert.Equal(addresses[1], deserialized.InputContext.Miner);
+        Assert.Equal(Null.Value, deserialized.OutputStates.GetState(addresses[0]));
+        Assert.Equal((Text)"foo", deserialized.OutputStates.GetState(addresses[1]));
+        Assert.Equal(new List((Text)"bar"), deserialized.OutputStates.GetState(addresses[2]));
+    }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator.Tests/Libplanet.Extensions.RemoteActionEvaluator.Tests.csproj
+++ b/Libplanet.Extensions.RemoteActionEvaluator.Tests/Libplanet.Extensions.RemoteActionEvaluator.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.RemoteActionEvaluator\Libplanet.Extensions.RemoteActionEvaluator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libplanet.Extensions.RemoteActionEvaluator.Tests/Usings.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Libplanet.Extensions.RemoteActionEvaluator/AccountStateDelta.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/AccountStateDelta.cs
@@ -1,0 +1,308 @@
+using System.Collections.Immutable;
+using System.Numerics;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Consensus;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public class AccountStateDelta : IAccountStateDelta, IValidatorSupportStateDelta
+{
+    private IImmutableDictionary<Address, IValue> _states;
+    private IImmutableDictionary<(Address, Currency), BigInteger> _balances;
+    private IImmutableDictionary<Currency, BigInteger> _totalSupplies;
+    private ValidatorSet? _validatorSet;
+
+    public IImmutableSet<Address> UpdatedAddresses => _states.Keys.ToImmutableHashSet();
+
+    public IImmutableSet<Address> StateUpdatedAddresses => _states.Keys.ToImmutableHashSet();
+
+#pragma warning disable LAA1002
+    public IImmutableDictionary<Address, IImmutableSet<Currency>> UpdatedFungibleAssets =>
+        _balances.GroupBy(kv => kv.Key.Item1).ToImmutableDictionary(
+            g => g.Key,
+            g => (IImmutableSet<Currency>)g.Select(kv => kv.Key.Item2).ToImmutableHashSet()
+        );
+#pragma warning restore LAA1002
+
+    public IImmutableSet<Currency> TotalSupplyUpdatedCurrencies =>
+        _totalSupplies.Keys.ToImmutableHashSet();
+
+    internal AccountStateGetter StateGetter { get; set; }
+
+    internal AccountBalanceGetter BalanceGetter { get; set; }
+
+    internal TotalSupplyGetter TotalSupplyGetter { get; set; }
+
+    internal ValidatorSetGetter ValidatorSetGetter { get; set; }
+
+
+    public AccountStateDelta()
+        : this(
+            ImmutableDictionary<Address, IValue>.Empty,
+            ImmutableDictionary<(Address, Currency), BigInteger>.Empty,
+            ImmutableDictionary<Currency, BigInteger>.Empty,
+            null)
+    {
+    }
+
+    public AccountStateDelta(
+        IImmutableDictionary<Address, IValue> states,
+        IImmutableDictionary<(Address, Currency), BigInteger> balances,
+        IImmutableDictionary<Currency, BigInteger> totalSupplies,
+        ValidatorSet? validatorSet
+    )
+    {
+        _states = states;
+        _balances = balances;
+        _totalSupplies = totalSupplies;
+        _validatorSet = validatorSet;
+    }
+
+    public AccountStateDelta(Dictionary states, List balances, Dictionary totalSupplies, IValue validatorSet)
+    {
+        // This assumes `states` consists of only Binary keys:
+        _states = states.ToImmutableDictionary(
+            kv => new Address(kv.Key),
+            kv => kv.Value
+        );
+
+        _balances = balances.Cast<Dictionary>().ToImmutableDictionary(
+            record => (new Address(((Binary)record["address"]).ByteArray),
+                new Currency((Dictionary)record["currency"])),
+            record => (BigInteger)(Integer)record["amount"]
+        );
+
+        // This assumes `totalSupplies` consists of only Binary keys:
+        _totalSupplies = totalSupplies.ToImmutableDictionary(
+            kv => new Currency(new Codec().Decode((Binary)kv.Key)),
+            kv => (BigInteger)(Integer)kv.Value
+        );
+
+        _validatorSet = new ValidatorSet(validatorSet);
+    }
+
+    public AccountStateDelta(IValue serialized)
+        : this(
+            (Dictionary)((Dictionary)serialized)["states"],
+            (List)((Dictionary)serialized)["balances"],
+            (Dictionary)((Dictionary)serialized)["totalSupplies"],
+            ((Dictionary)serialized)["validatorSet"]
+        )
+    {
+    }
+
+    public AccountStateDelta(byte[] bytes)
+        : this((Dictionary)new Codec().Decode(bytes))
+    {
+    }
+
+    public IValue? GetState(Address address) =>
+        _states.ContainsKey(address)
+            ? _states[address]
+            : StateGetter(new[] { address })[0];
+
+    public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses) =>
+        addresses.Select(GetState).ToArray();
+
+    public IAccountStateDelta SetState(Address address, IValue state) =>
+        new AccountStateDelta(_states.SetItem(address, state), _balances, _totalSupplies, _validatorSet)
+        {
+            StateGetter = StateGetter,
+            BalanceGetter = BalanceGetter,
+            ValidatorSetGetter = ValidatorSetGetter,
+            TotalSupplyGetter = TotalSupplyGetter,
+        };
+
+    public FungibleAssetValue GetBalance(Address address, Currency currency)
+    {
+        if (!_balances.TryGetValue((address, currency), out BigInteger rawValue))
+        {
+            return BalanceGetter(address, currency);
+        }
+
+        return FungibleAssetValue.FromRawValue(currency, rawValue);
+    }
+
+    public FungibleAssetValue GetTotalSupply(Currency currency)
+    {
+        if (!currency.TotalSupplyTrackable)
+        {
+            var msg =
+                $"The total supply value of the currency {currency} is not trackable"
+                + " because it is a legacy untracked currency which might have been"
+                + " established before the introduction of total supply tracking support.";
+            throw new TotalSupplyNotTrackableException(msg, currency);
+        }
+
+        // Return dirty state if it exists.
+        if (_totalSupplies.TryGetValue(currency, out var totalSupplyValue))
+        {
+            return FungibleAssetValue.FromRawValue(currency, totalSupplyValue);
+        }
+
+        return TotalSupplyGetter(currency);
+    }
+
+    public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
+    {
+        // FIXME: 트랜잭션 서명자를 알아내 currency.AllowsToMint() 확인해서 CurrencyPermissionException
+        // 던지는 처리를 해야하는데 여기서 트랜잭션 서명자를 무슨 수로 가져올지 잘 모르겠음.
+
+        var currency = value.Currency;
+
+        if (value <= currency * 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        var nextAmount = GetBalance(recipient, value.Currency) + value;
+
+        if (currency.TotalSupplyTrackable)
+        {
+            var currentTotalSupply = GetTotalSupply(currency);
+            if (currency.MaximumSupply < currentTotalSupply + value)
+            {
+                var msg = $"The amount {value} attempted to be minted added to the current"
+                          + $" total supply of {currentTotalSupply} exceeds the"
+                          + $" maximum allowed supply of {currency.MaximumSupply}.";
+                throw new SupplyOverflowException(msg, value);
+            }
+
+            return new AccountStateDelta(
+                _states,
+                _balances.SetItem(
+                    (recipient, value.Currency),
+                    nextAmount.RawValue
+                ),
+                _totalSupplies.SetItem(currency, (currentTotalSupply + value).RawValue),
+                _validatorSet
+            )
+            {
+                StateGetter = StateGetter,
+                BalanceGetter = BalanceGetter,
+                ValidatorSetGetter = ValidatorSetGetter,
+                TotalSupplyGetter = TotalSupplyGetter,
+            };
+        }
+
+        return new AccountStateDelta(
+            _states,
+            _balances.SetItem(
+                (recipient, value.Currency),
+                nextAmount.RawValue
+            ),
+            _totalSupplies,
+            _validatorSet
+        )
+        {
+            StateGetter = StateGetter,
+            BalanceGetter = BalanceGetter,
+            ValidatorSetGetter = ValidatorSetGetter,
+            TotalSupplyGetter = TotalSupplyGetter,
+        };
+    }
+
+    public IAccountStateDelta TransferAsset(
+        Address sender,
+        Address recipient,
+        FungibleAssetValue value,
+        bool allowNegativeBalance = false)
+    {
+        if (value.Sign <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        FungibleAssetValue senderBalance = GetBalance(sender, value.Currency);
+        if (senderBalance < value)
+        {
+            throw new InsufficientBalanceException(
+                $"There is no sufficient balance for {sender}: {senderBalance} < {value}",
+                sender,
+                senderBalance
+            );
+        }
+
+        Currency currency = value.Currency;
+        FungibleAssetValue senderRemains = senderBalance - value;
+        FungibleAssetValue recipientRemains = GetBalance(recipient, currency) + value;
+        var balances = _balances
+            .SetItem((sender, currency), senderRemains.RawValue)
+            .SetItem((recipient, currency), recipientRemains.RawValue);
+        return new AccountStateDelta(_states, balances, _totalSupplies, _validatorSet)
+        {
+            StateGetter = StateGetter,
+            BalanceGetter = BalanceGetter,
+            ValidatorSetGetter = ValidatorSetGetter,
+            TotalSupplyGetter = TotalSupplyGetter,
+        };
+    }
+
+    public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
+    {
+        // FIXME: 트랜잭션 서명자를 알아내 currency.AllowsToMint() 확인해서 CurrencyPermissionException
+        // 던지는 처리를 해야하는데 여기서 트랜잭션 서명자를 무슨 수로 가져올지 잘 모르겠음.
+
+        var currency = value.Currency;
+
+        if (value <= currency * 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        FungibleAssetValue balance = GetBalance(owner, currency);
+        if (balance < value)
+        {
+            throw new InsufficientBalanceException(
+                $"There is no sufficient balance for {owner}: {balance} < {value}",
+                owner,
+                value
+            );
+        }
+
+        FungibleAssetValue nextValue = balance - value;
+        return new AccountStateDelta(
+            _states,
+            _balances.SetItem(
+                (owner, currency),
+                nextValue.RawValue
+            ),
+            currency.TotalSupplyTrackable
+                ? _totalSupplies.SetItem(
+                    currency,
+                    (GetTotalSupply(currency) - value).RawValue)
+                : _totalSupplies,
+            _validatorSet
+        )
+        {
+            StateGetter = StateGetter,
+            BalanceGetter = BalanceGetter,
+            ValidatorSetGetter = ValidatorSetGetter,
+            TotalSupplyGetter = TotalSupplyGetter,
+        };
+    }
+
+    public ValidatorSet GetValidatorSet()
+    {
+        return _validatorSet ?? ValidatorSetGetter();
+    }
+
+    public IAccountStateDelta SetValidator(Validator validator)
+    {
+        return new AccountStateDelta(
+            _states,
+            _balances,
+            _totalSupplies,
+            GetValidatorSet().Update(validator)
+        )
+        {
+            StateGetter = StateGetter,
+            BalanceGetter = BalanceGetter,
+            ValidatorSetGetter = ValidatorSetGetter,
+            TotalSupplyGetter = TotalSupplyGetter,
+        };
+    }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/AccountStateDeltaMarshaller.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/AccountStateDeltaMarshaller.cs
@@ -1,0 +1,119 @@
+using System.Collections.Immutable;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Assets;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public static class AccountStateDeltaMarshaller
+{
+    private static readonly Codec Codec = new Codec();
+
+    public static byte[] Serialize(this IAccountStateDelta value)
+    {
+        return Codec.Encode(Marshal(value));
+    }
+
+    public static IEnumerable<Dictionary> Marshal(IEnumerable<IAccountStateDelta> deltas)
+    {
+        IImmutableDictionary<Address, IValue> updatedStates = ImmutableDictionary<Address, IValue>.Empty;
+        IImmutableDictionary<Address, IImmutableSet<Currency>> updatedFungibleAssets = ImmutableDictionary<Address, IImmutableSet<Currency>>.Empty;
+        IImmutableSet<Currency> totalSupplyUpdatedCurrencies = ImmutableHashSet<Currency>.Empty;
+        foreach (var value in deltas)
+        {
+            updatedStates = updatedStates.SetItems(value.StateUpdatedAddresses.Select(addr =>
+                new KeyValuePair<Address, IValue>(addr, value.GetState(addr))));
+            updatedFungibleAssets = updatedFungibleAssets.SetItems(value.UpdatedFungibleAssets);
+            totalSupplyUpdatedCurrencies = totalSupplyUpdatedCurrencies.Union(value.TotalSupplyUpdatedCurrencies);
+            var state = new Dictionary(
+                updatedStates.Select(pair => new KeyValuePair<IKey, IValue>((Binary)pair.Key.ByteArray, pair.Value))
+            );
+            var balance = new Bencodex.Types.List(
+#pragma warning disable LAA1002
+                updatedFungibleAssets.SelectMany(ua =>
+#pragma warning restore LAA1002
+                    ua.Value.Select(c =>
+                        {
+                            FungibleAssetValue b = value.GetBalance(ua.Key, c);
+                            return new Bencodex.Types.Dictionary(new[]
+                            {
+                                new KeyValuePair<IKey, IValue>((Text) "address", (Binary) ua.Key.ByteArray),
+                                new KeyValuePair<IKey, IValue>((Text) "currency", c.Serialize()),
+                                new KeyValuePair<IKey, IValue>((Text) "amount", (Integer) b.RawValue),
+                            });
+                        }
+                    )
+                ).Cast<IValue>()
+            );
+            var totalSupply = new Dictionary(
+                totalSupplyUpdatedCurrencies.Select(currency =>
+                    new KeyValuePair<IKey, IValue>(
+                        (Binary)Codec.Encode(currency.Serialize()),
+                        (Integer)value.GetTotalSupply(currency).RawValue)));
+
+            var bdict = new Dictionary(new[]
+            {
+                new KeyValuePair<IKey, IValue>((Text) "states", state),
+                new KeyValuePair<IKey, IValue>((Text) "balances", balance),
+                new KeyValuePair<IKey, IValue>((Text) "totalSupplies", totalSupply),
+                new KeyValuePair<IKey, IValue>((Text) "validatorSet", value.GetValidatorSet().Bencoded),
+            });
+
+            yield return bdict;
+        }
+    }
+
+    public static Dictionary Marshal(IAccountStateDelta value)
+    {
+        var state = new Dictionary(
+            value.UpdatedAddresses.Where(addr => value.GetState(addr) is not null).Select(addr => new KeyValuePair<IKey, IValue>(
+                (Binary)addr.ToByteArray(),
+                value.GetState(addr)
+            ))
+        );
+        var balance = new Bencodex.Types.List(
+#pragma warning disable LAA1002
+            value.UpdatedFungibleAssets.SelectMany(ua =>
+#pragma warning restore LAA1002
+                ua.Value.Select(c =>
+                    {
+                        FungibleAssetValue b = value.GetBalance(ua.Key, c);
+                        return new Bencodex.Types.Dictionary(new[]
+                        {
+                            new KeyValuePair<IKey, IValue>((Text) "address", (Binary) ua.Key.ByteArray),
+                            new KeyValuePair<IKey, IValue>((Text) "currency", c.Serialize()),
+                            new KeyValuePair<IKey, IValue>((Text) "amount", (Integer) b.RawValue),
+                        });
+                    }
+                )
+            ).Cast<IValue>()
+        );
+        var totalSupply = new Dictionary(
+            value.TotalSupplyUpdatedCurrencies.Select(currency =>
+                new KeyValuePair<IKey, IValue>(
+                    (Binary)new Codec().Encode(currency.Serialize()),
+                    (Integer)value.GetTotalSupply(currency).RawValue)));
+
+        var bdict = new Dictionary(new[]
+        {
+            new KeyValuePair<IKey, IValue>((Text) "states", state),
+            new KeyValuePair<IKey, IValue>((Text) "balances", balance),
+            new KeyValuePair<IKey, IValue>((Text) "totalSupplies", totalSupply),
+            new KeyValuePair<IKey, IValue>((Text) "validatorSet", value.GetValidatorSet().Bencoded),
+        });
+
+        return bdict;
+    }
+
+    public static AccountStateDelta Unmarshal(IValue marshalled)
+    {
+        return new AccountStateDelta(marshalled);
+    }
+
+    public static AccountStateDelta Deserialize(byte[] serialized)
+    {
+        var decoded = Codec.Decode(serialized);
+        return Unmarshal(decoded);
+    }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/ActionContext.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/ActionContext.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blocks;
+using Libplanet.Tx;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public class ActionContext : IActionContext
+{
+    public ActionContext(BlockHash? genesisHash, Address signer, TxId? txId, Address miner, long blockIndex,
+        bool rehearsal, AccountStateDelta previousStates, IRandom random, HashDigest<SHA256>? previousStateRootHash,
+        bool blockAction)
+    {
+        GenesisHash = genesisHash;
+        Signer = signer;
+        TxId = txId;
+        Miner = miner;
+        BlockIndex = blockIndex;
+        Rehearsal = rehearsal;
+        PreviousStates = previousStates;
+        Random = random;
+        PreviousStateRootHash = previousStateRootHash;
+        BlockAction = blockAction;
+    }
+
+    public BlockHash? GenesisHash { get; }
+    public Address Signer { get; init; }
+    public TxId? TxId { get; }
+    public Address Miner { get; init; }
+    public long BlockIndex { get; init; }
+    public bool Rehearsal { get; init; }
+    public AccountStateDelta PreviousStates { get; init; }
+    IAccountStateDelta IActionContext.PreviousStates => PreviousStates;
+    public IRandom Random { get; init; }
+    public HashDigest<SHA256>? PreviousStateRootHash { get; init; }
+    public bool BlockAction { get; init; }
+
+    public void PutLog(string log)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool IsNativeToken(Currency currency)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IActionContext GetUnconsumedContext()
+    {
+        return new ActionContext(GenesisHash, Signer, TxId, Miner, BlockIndex, Rehearsal, PreviousStates,
+            new Random(Random.Seed), PreviousStateRootHash, BlockAction);
+    }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/ActionContextMarshaller.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/ActionContextMarshaller.cs
@@ -1,0 +1,83 @@
+using System.Security.Cryptography;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Tx;
+using Boolean = Bencodex.Types.Boolean;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public static class ActionContextMarshaller
+{
+    private static readonly Codec Codec = new Codec();
+
+    public static byte[] Serialize(this IActionContext actionContext)
+    {
+        return Codec.Encode(Marshal(actionContext));
+    }
+
+    public static Dictionary Marshal(this IActionContext actionContext)
+    {
+        var dictionary = Bencodex.Types.Dictionary.Empty
+            .Add("block_action", actionContext.BlockAction)
+            .Add("miner", actionContext.Miner.ToHex())
+            .Add("rehearsal", actionContext.Rehearsal)
+            .Add("block_index", actionContext.BlockIndex)
+            .Add("random_seed", actionContext.Random.Seed)
+            .Add("signer", actionContext.Signer.ToHex())
+            .Add("previous_states", AccountStateDeltaMarshaller.Marshal(actionContext.PreviousStates));
+
+        if (actionContext.GenesisHash is { } genesisHash)
+        {
+            dictionary = dictionary.Add("genesis_hash", genesisHash.ByteArray);
+        }
+
+        if (actionContext.TxId is { } txId)
+        {
+            dictionary = dictionary.Add("tx_id", txId.ByteArray);
+        }
+
+        if (actionContext.PreviousStateRootHash is { } previousStateRootHash)
+        {
+            dictionary = dictionary.Add("previous_state_root_hash", previousStateRootHash.ByteArray);
+        }
+
+        return dictionary;
+    }
+
+    public static ActionContext Unmarshal(Dictionary dictionary)
+    {
+        return new ActionContext(
+            genesisHash: dictionary.TryGetValue((Text)"genesis_hash", out IValue genesisHashValue) &&
+                         genesisHashValue is Binary genesisHashBinaryValue
+                ? new BlockHash(genesisHashBinaryValue.ByteArray)
+                : null,
+            blockIndex: (Integer)dictionary["block_index"],
+            signer: new Address(((Text)dictionary["signer"]).Value),
+            txId: dictionary.TryGetValue((Text)"tx_id", out IValue txIdValue) &&
+                  txIdValue is Binary txIdBinaryValue
+                ? new TxId(txIdBinaryValue.ByteArray)
+                : null,
+            blockAction: (Boolean)dictionary["block_action"],
+            miner: new Address(((Text)dictionary["miner"]).Value),
+            rehearsal: (Boolean)dictionary["rehearsal"],
+            previousStateRootHash: dictionary.ContainsKey("previous_state_root_hash")
+                ? new HashDigest<SHA256>(((Binary)dictionary["previous_state_root_hash"]).ByteArray)
+                : null,
+            previousStates: AccountStateDeltaMarshaller.Unmarshal(dictionary["previous_states"]),
+            random: new Random((Integer)dictionary["random_seed"])
+        );
+    }
+
+    public static ActionContext Deserialize(byte[] serialized)
+    {
+        var decoded = Codec.Decode(serialized);
+        if (!(decoded is Dictionary dictionary))
+        {
+            throw new ArgumentException($"Expected 'Dictionary' but {decoded.GetType().Name}", nameof(serialized));
+        }
+
+        return Unmarshal(dictionary);
+    }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/ActionEvaluation.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/ActionEvaluation.cs
@@ -1,0 +1,29 @@
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public class ActionEvaluation : IActionEvaluation
+{
+    public ActionEvaluation(
+        IValue action,
+        ActionContext inputContext,
+        AccountStateDelta outputStates,
+        Exception? exception,
+        List<string> logs)
+    {
+        Action = action;
+        InputContext = inputContext;
+        OutputStates = outputStates;
+        Exception = exception;
+        Logs = logs;
+    }
+
+    public IValue Action { get; }
+    public ActionContext InputContext { get; }
+    IActionContext IActionEvaluation.InputContext => InputContext;
+    public AccountStateDelta OutputStates { get; }
+    IAccountStateDelta IActionEvaluation.OutputStates => OutputStates;
+    public Exception? Exception { get; }
+    public List<string> Logs { get; }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/ActionEvaluationMarshaller.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/ActionEvaluationMarshaller.cs
@@ -1,0 +1,63 @@
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Action;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public static class ActionEvaluationMarshaller
+{
+    private static readonly Codec Codec = new Codec();
+
+    public static byte[] Serialize(this IActionEvaluation actionEvaluation)
+    {
+        return Codec.Encode(Marshal(actionEvaluation));
+    }
+
+    public static IEnumerable<Dictionary> Marshal(this IEnumerable<IActionEvaluation> actionEvaluations)
+    {
+        var actionEvaluationsArray = actionEvaluations.ToArray();
+        var outputStates = AccountStateDeltaMarshaller.Marshal(actionEvaluationsArray.Select(aev => aev.OutputStates));
+        var previousStates = AccountStateDeltaMarshaller.Marshal(actionEvaluationsArray.Select(aev => aev.InputContext.PreviousStates));
+        foreach (var actionEvaluation in actionEvaluationsArray)
+        {
+            yield return Dictionary.Empty
+                .Add("action", actionEvaluation.Action)
+                .Add("logs", new List(actionEvaluation.Logs))
+                .Add("output_states", AccountStateDeltaMarshaller.Marshal(actionEvaluation.OutputStates))
+                .Add("input_context", ActionContextMarshaller.Marshal(actionEvaluation.InputContext))
+                .Add("exception", actionEvaluation.Exception?.GetType().FullName is { } typeName ? (Text)typeName : Null.Value);
+        }
+    }
+
+    public static Dictionary Marshal(this IActionEvaluation actionEvaluation)
+    {
+        return Dictionary.Empty
+            .Add("action", actionEvaluation.Action)
+            .Add("logs", new List(actionEvaluation.Logs))
+            .Add("output_states", AccountStateDeltaMarshaller.Marshal(actionEvaluation.OutputStates))
+            .Add("input_context", ActionContextMarshaller.Marshal(actionEvaluation.InputContext))
+            .Add("exception", actionEvaluation.Exception?.GetType().FullName is { } typeName ? (Text)typeName : Null.Value);
+    }
+
+    public static ActionEvaluation Unmarshal(IValue value)
+    {
+        if (value is not Dictionary dictionary)
+        {
+            throw new ArgumentException(nameof(value));
+        }
+
+        return new ActionEvaluation(
+            dictionary["action"],
+            ActionContextMarshaller.Unmarshal((Dictionary)dictionary["input_context"]),
+            AccountStateDeltaMarshaller.Unmarshal(dictionary["output_states"]),
+            dictionary["exception"] is Text typeName ? new Exception(typeName) : null,
+            ((List)dictionary["logs"]).Cast<Text>().Select(t => t.Value).ToList()
+        );
+    }
+
+    public static ActionEvaluation Deserialize(byte[] serialized)
+    {
+        var decoded = Codec.Decode(serialized);
+        return Unmarshal(decoded);
+    }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/AssemblyInfo.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Libplanet.Extensions.RemoteActionEvaluator.Tests")]

--- a/Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj
+++ b/Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Client" Version="5.1.1"/>
-    <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="5.1.1"/>
+    <PackageReference Include="GraphQL.Client" Version="5.1.1" />
+    <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="5.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Libplanet.Extensions.RemoteActionEvaluator/PreEvaluationBlockMarshaller.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/PreEvaluationBlockMarshaller.cs
@@ -1,0 +1,39 @@
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Blocks;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public static class PreEvaluationBlockMarshaller
+{
+    private static readonly Codec Codec = new Codec();
+
+    // Copied form Libplanet/Blocks/BlockMarshaler.cs
+    // Block fields:
+    private static readonly byte[] HeaderKey = { 0x48 }; // 'H'
+    private static readonly byte[] TransactionsKey = { 0x54 }; // 'T'
+
+    public static Dictionary Marshal(this IPreEvaluationBlock block)
+    {
+        return Dictionary.Empty
+            .Add(HeaderKey, BlockMarshaler.MarshalPreEvaluationBlockHeader(block))
+            .Add(TransactionsKey, new List(block.Transactions.Select(TransactionMarshaller.Serialize)));
+    }
+
+    public static IPreEvaluationBlock Unmarshal(Dictionary dictionary)
+    {
+        return new PreEvaluationBlock(
+            BlockMarshaler.UnmarshalPreEvaluationBlockHeader((Dictionary)dictionary[HeaderKey]),
+            BlockMarshaler.UnmarshalBlockTransactions(dictionary));
+    }
+
+    public static byte[] Serialize(this IPreEvaluationBlock block)
+    {
+        return Codec.Encode(Marshal(block));
+    }
+
+    public static IPreEvaluationBlock Deserialize(byte[] serialized)
+    {
+        return Unmarshal((Dictionary)Codec.Decode(serialized));
+    }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/Random.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/Random.cs
@@ -1,0 +1,14 @@
+using Libplanet.Action;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+internal class Random : System.Random, IRandom
+{
+    public Random(int seed)
+        : base(seed)
+    {
+        Seed = seed;
+    }
+
+    public int Seed { get; private set; }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
@@ -21,6 +21,8 @@ public class RemoteActionEvaluator : IActionEvaluator
         _blockChainStates = blockChainStates;
     }
 
+    public IActionLoader ActionLoader => throw new NotSupportedException();
+
     public IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block)
     {
         using var httpClient = new HttpClient();

--- a/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
@@ -1,0 +1,148 @@
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Net.Http.Json;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blockchain;
+using Libplanet.Blocks;
+using Libplanet.Consensus;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public class RemoteActionEvaluator : IActionEvaluator
+{
+    private readonly Uri _endpoint;
+    private readonly IBlockChainStates _blockChainStates;
+
+    public RemoteActionEvaluator(Uri endpoint, IBlockChainStates blockChainStates)
+    {
+        _endpoint = endpoint;
+        _blockChainStates = blockChainStates;
+    }
+
+    public IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block)
+    {
+        using var httpClient = new HttpClient();
+        var response = httpClient.PostAsJsonAsync(_endpoint, new RemoteEvaluationRequest
+        {
+            PreEvaluationBlock = PreEvaluationBlockMarshaller.Serialize(block),
+        }).Result;
+        var evaluationResponse = response.Content.ReadFromJsonAsync<RemoteEvaluationResponse>().Result;
+
+        var actionEvaluations = evaluationResponse.Evaluations.Select(ActionEvaluationMarshaller.Deserialize)
+            .ToImmutableList();
+
+        for (var i = 0; i < actionEvaluations.Count; ++i)
+        {
+            if (i > 0)
+            {
+                actionEvaluations[i].InputContext.PreviousStates.StateGetter =
+                    actionEvaluations[i - 1].OutputStates.GetStates;
+                actionEvaluations[i].InputContext.PreviousStates.BalanceGetter =
+                    actionEvaluations[i - 1].OutputStates.GetBalance;
+                actionEvaluations[i].InputContext.PreviousStates.TotalSupplyGetter =
+                    actionEvaluations[i - 1].OutputStates.GetTotalSupply;
+                actionEvaluations[i].InputContext.PreviousStates.ValidatorSetGetter =
+                    actionEvaluations[i - 1].OutputStates.GetValidatorSet;
+            }
+            else
+            {
+                (
+                    actionEvaluations[i].InputContext.PreviousStates.StateGetter,
+                    actionEvaluations[i].InputContext.PreviousStates.BalanceGetter,
+                    actionEvaluations[i].InputContext.PreviousStates.TotalSupplyGetter,
+                    actionEvaluations[i].InputContext.PreviousStates.ValidatorSetGetter
+                ) = InitializeAccountGettersPair(block);
+            }
+
+            actionEvaluations[i].OutputStates.StateGetter =
+                actionEvaluations[i].InputContext.PreviousStates.GetStates;
+            actionEvaluations[i].OutputStates.BalanceGetter =
+                actionEvaluations[i].InputContext.PreviousStates.GetBalance;
+            actionEvaluations[i].OutputStates.TotalSupplyGetter =
+                actionEvaluations[i].InputContext.PreviousStates.GetTotalSupply;
+            actionEvaluations[i].OutputStates.ValidatorSetGetter =
+                actionEvaluations[i].InputContext.PreviousStates.GetValidatorSet;
+        }
+
+        return actionEvaluations;
+    }
+
+    private (AccountStateGetter, AccountBalanceGetter, TotalSupplyGetter, ValidatorSetGetter)
+        InitializeAccountGettersPair(
+            IPreEvaluationBlockHeader blockHeader)
+    {
+        AccountStateGetter accountStateGetter;
+        AccountBalanceGetter accountBalanceGetter;
+        TotalSupplyGetter totalSupplyGetter;
+        ValidatorSetGetter validatorSetGetter;
+
+        if (blockHeader.PreviousHash is { } previousHash)
+        {
+            accountStateGetter = addresses => _blockChainStates.GetStates(
+                addresses,
+                previousHash
+            );
+            accountBalanceGetter = (address, currency) => _blockChainStates.GetBalance(
+                address,
+                currency,
+                previousHash
+            );
+            totalSupplyGetter = currency => _blockChainStates.GetTotalSupply(
+                currency,
+                previousHash
+            );
+            validatorSetGetter = () => _blockChainStates.GetValidatorSet(previousHash);
+        }
+        else
+        {
+            accountStateGetter = NullAccountStateGetter;
+            accountBalanceGetter = NullAccountBalanceGetter;
+            totalSupplyGetter = NullTotalSupplyGetter;
+            validatorSetGetter = NullValidatorSetGetter;
+        }
+
+        return (accountStateGetter, accountBalanceGetter, totalSupplyGetter,
+            validatorSetGetter);
+    }
+
+    [Pure]
+    private static IReadOnlyList<IValue?> NullAccountStateGetter(
+        IReadOnlyList<Address> addresses
+    ) =>
+        new IValue?[addresses.Count];
+
+    [Pure]
+    private static FungibleAssetValue NullAccountBalanceGetter(
+        Address address,
+        Currency currency
+    ) =>
+        currency * 0;
+
+    [Pure]
+    private static FungibleAssetValue NullTotalSupplyGetter(Currency currency)
+    {
+        if (!currency.TotalSupplyTrackable)
+        {
+            throw WithDefaultMessage(currency);
+        }
+
+        return currency * 0;
+    }
+
+    [Pure]
+    private static ValidatorSet NullValidatorSetGetter()
+    {
+        return new ValidatorSet();
+    }
+
+    private static TotalSupplyNotTrackableException WithDefaultMessage(Currency currency)
+    {
+        var msg =
+            $"The total supply value of the currency {currency} is not trackable because it"
+            + " is a legacy untracked currency which might have been established before"
+            + " the introduction of total supply tracking support.";
+        return new TotalSupplyNotTrackableException(msg, currency);
+    }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/RemoteBlockChainStates.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/RemoteBlockChainStates.cs
@@ -41,7 +41,8 @@ namespace Libplanet.Extensions.RemoteActionEvaluator
                         offsetBlockHash = ByteUtil.Hex(offset.ByteArray),
                     })).Result;
             var codec = new Codec();
-            return response.Data.StateQuery.States.Select(codec.Decode).ToList();
+            return response.Data.StateQuery.States
+                .Select(nullableState => nullableState is { } state ? codec.Decode(state) : null).ToList();
         }
 
         public FungibleAssetValue GetBalance(Address address, Currency currency, BlockHash offset)
@@ -50,7 +51,7 @@ namespace Libplanet.Extensions.RemoteActionEvaluator
             {
                 ticker = currency.Ticker,
                 decimalPlaces = currency.DecimalPlaces,
-                minters = currency.Minters.Select(addr => addr.ToString()).ToArray(),
+                minters = currency.Minters?.Select(addr => addr.ToString()).ToArray(),
                 totalSupplyTrackable = currency.TotalSupplyTrackable,
                 maximumSupplyMajorUnit = currency.MaximumSupply.Value.MajorUnit,
                 maximumSupplyMinorUnit = currency.MaximumSupply.Value.MinorUnit,
@@ -58,7 +59,7 @@ namespace Libplanet.Extensions.RemoteActionEvaluator
             {
                 ticker = currency.Ticker,
                 decimalPlaces = currency.DecimalPlaces,
-                minters = currency.Minters.Select(addr => addr.ToString()).ToArray(),
+                minters = currency.Minters?.Select(addr => addr.ToString()).ToArray(),
                 totalSupplyTrackable = currency.TotalSupplyTrackable,
             };
             var response = _graphQlHttpClient.SendQueryAsync<GetBalanceResponseType>(

--- a/Libplanet.Extensions.RemoteActionEvaluator/RemoteEvaluationRequest.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/RemoteEvaluationRequest.cs
@@ -1,0 +1,6 @@
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public class RemoteEvaluationRequest
+{
+    public byte[] PreEvaluationBlock { get; set; }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/RemoteEvaluationResponse.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/RemoteEvaluationResponse.cs
@@ -1,0 +1,6 @@
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public class RemoteEvaluationResponse
+{
+    public byte[][] Evaluations { get; set; }
+}

--- a/Libplanet.Extensions.RemoteActionEvaluator/TransactionMarshaller.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/TransactionMarshaller.cs
@@ -1,0 +1,23 @@
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Tx;
+
+namespace Libplanet.Extensions.RemoteActionEvaluator;
+
+public static class TransactionMarshaller
+{
+    private static readonly Codec Codec = new Codec();
+
+    // Copied from Libplanet/Tx/TxMarshaler.cs
+    private static readonly Binary SignatureKey = new byte[] { 0x53 }; // 'S'
+
+    public static Dictionary Marshal(this ITransaction transaction)
+    {
+        return transaction.MarshalUnsignedTx().Add(SignatureKey, transaction.Signature);
+    }
+
+    public static byte[] Serialize(this ITransaction transaction)
+    {
+        return Codec.Encode(Marshal(transaction));
+    }
+}

--- a/Libplanet.Headless/Libplanet.Headless.csproj
+++ b/Libplanet.Headless/Libplanet.Headless.csproj
@@ -23,5 +23,6 @@
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.RemoteActionEvaluator\Libplanet.Extensions.RemoteActionEvaluator.csproj" />
   </ItemGroup>
 </Project>

--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -56,6 +56,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.Utils", "Lib9c\Lib9c.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.RemoteActionEvaluator", "Libplanet.Extensions.RemoteActionEvaluator\Libplanet.Extensions.RemoteActionEvaluator.csproj", "{7617A5B2-FFE7-4A3E-B80C-1C69786AFE9C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.RemoteActionEvaluator.Tests", "Libplanet.Extensions.RemoteActionEvaluator.Tests\Libplanet.Extensions.RemoteActionEvaluator.Tests.csproj", "{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.StateService", "Lib9c.StateService\Lib9c.StateService.csproj", "{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -403,6 +407,34 @@ Global
 		{7617A5B2-FFE7-4A3E-B80C-1C69786AFE9C}.Release|x86.Build.0 = Release|Any CPU
 		{7617A5B2-FFE7-4A3E-B80C-1C69786AFE9C}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
 		{7617A5B2-FFE7-4A3E-B80C-1C69786AFE9C}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Debug|x64.Build.0 = Debug|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Debug|x86.Build.0 = Debug|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Release|x64.ActiveCfg = Release|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Release|x64.Build.0 = Release|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Release|x86.ActiveCfg = Release|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.Release|x86.Build.0 = Release|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5BF02AD-5E4E-4CA7-BD1E-1F8C72CBDFE2}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Debug|x64.Build.0 = Debug|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Debug|x86.Build.0 = Debug|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Release|x64.ActiveCfg = Release|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Release|x64.Build.0 = Release|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Release|x86.ActiveCfg = Release|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Release|x86.Build.0 = Release|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.DevEx|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The `RemoteActionEvaluator` implements the `Libplanet.Action.IActionEvaluator` interface. It is to assume the situation that Libplanet cannot access Lib9c's DLL directly. extremely.