### PR TITLE
Introduce `ForkableActionEvaluator`

### DIFF
--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests/ActionEvaluationSerializerTest.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests/ActionEvaluationSerializerTest.cs
@@ -3,7 +3,7 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Crypto;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator.Tests;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests;
 
 public class ActionEvaluationSerializerTest
 {

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests/Usings.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/AccountStateDelta.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/AccountStateDelta.cs
@@ -6,7 +6,7 @@ using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Consensus;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 public class AccountStateDelta : IAccountStateDelta, IValidatorSupportStateDelta
 {
@@ -30,13 +30,13 @@ public class AccountStateDelta : IAccountStateDelta, IValidatorSupportStateDelta
     public IImmutableSet<Currency> TotalSupplyUpdatedCurrencies =>
         _totalSupplies.Keys.ToImmutableHashSet();
 
-    internal AccountStateGetter StateGetter { get; set; }
+    public AccountStateGetter StateGetter { get; set; }
 
-    internal AccountBalanceGetter BalanceGetter { get; set; }
+    public AccountBalanceGetter BalanceGetter { get; set; }
 
-    internal TotalSupplyGetter TotalSupplyGetter { get; set; }
+    public TotalSupplyGetter TotalSupplyGetter { get; set; }
 
-    internal ValidatorSetGetter ValidatorSetGetter { get; set; }
+    public ValidatorSetGetter ValidatorSetGetter { get; set; }
 
 
     public AccountStateDelta()

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/AccountStateDeltaMarshaller.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/AccountStateDeltaMarshaller.cs
@@ -4,7 +4,7 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Assets;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 public static class AccountStateDeltaMarshaller
 {

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/ActionContext.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/ActionContext.cs
@@ -4,7 +4,7 @@ using Libplanet.Assets;
 using Libplanet.Blocks;
 using Libplanet.Tx;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 public class ActionContext : IActionContext
 {

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/ActionContextMarshaller.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/ActionContextMarshaller.cs
@@ -6,7 +6,7 @@ using Libplanet.Blocks;
 using Libplanet.Tx;
 using Boolean = Bencodex.Types.Boolean;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 public static class ActionContextMarshaller
 {

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/ActionEvaluation.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/ActionEvaluation.cs
@@ -1,7 +1,7 @@
 using Bencodex.Types;
 using Libplanet.Action;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 public class ActionEvaluation : IActionEvaluation
 {

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/ActionEvaluationMarshaller.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/ActionEvaluationMarshaller.cs
@@ -2,7 +2,7 @@ using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 public static class ActionEvaluationMarshaller
 {

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/PreEvaluationBlockMarshaller.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/PreEvaluationBlockMarshaller.cs
@@ -2,7 +2,7 @@ using Bencodex;
 using Bencodex.Types;
 using Libplanet.Blocks;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 public static class PreEvaluationBlockMarshaller
 {

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/Random.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/Random.cs
@@ -1,8 +1,8 @@
 using Libplanet.Action;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
-internal class Random : System.Random, IRandom
+public class Random : System.Random, IRandom
 {
     public Random(int seed)
         : base(seed)

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/TransactionMarshaller.cs
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/TransactionMarshaller.cs
@@ -2,7 +2,7 @@ using Bencodex;
 using Bencodex.Types;
 using Libplanet.Tx;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 public static class TransactionMarshaller
 {

--- a/Libplanet.Extensions.ForkableActionEvaluator.Tests/ForkableActionEvaluatorTest.cs
+++ b/Libplanet.Extensions.ForkableActionEvaluator.Tests/ForkableActionEvaluatorTest.cs
@@ -1,0 +1,133 @@
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Extensions.ActionEvaluatorCommonComponents;
+using Libplanet.Tx;
+using ActionEvaluation = Libplanet.Extensions.ActionEvaluatorCommonComponents.ActionEvaluation;
+using ArgumentOutOfRangeException = System.ArgumentOutOfRangeException;
+using Random = Libplanet.Extensions.ActionEvaluatorCommonComponents.Random;
+
+namespace Libplanet.Extensions.ForkableActionEvaluator.Tests;
+
+public class ForkableActionEvaluatorTest
+{
+    [Fact]
+    public void ForkEvaluation()
+    {
+        var evaluator = new ForkableActionEvaluator(new ((long, long), IActionEvaluator)[]
+        {
+            ((0L, 100L), new PreActionEvaluator()),
+            ((101L, long.MaxValue), new PostActionEvaluator()),
+        });
+
+        Assert.Equal((Text)"PRE", Assert.Single(evaluator.Evaluate(new MockBlock(0))).Action);
+        Assert.Equal((Text)"PRE", Assert.Single(evaluator.Evaluate(new MockBlock(99))).Action);
+        Assert.Equal((Text)"PRE", Assert.Single(evaluator.Evaluate(new MockBlock(100))).Action);
+        Assert.Equal((Text)"POST", Assert.Single(evaluator.Evaluate(new MockBlock(101))).Action);
+        Assert.Equal((Text)"POST", Assert.Single(evaluator.Evaluate(new MockBlock(long.MaxValue))).Action);
+    }
+
+    [Fact]
+    public void CheckPairs()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ForkableActionEvaluator(
+            new ((long, long), IActionEvaluator)[]
+            {
+                ((0L, 100L), new PreActionEvaluator()),
+                ((99L, long.MaxValue), new PostActionEvaluator()),
+            }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ForkableActionEvaluator(
+            new ((long, long), IActionEvaluator)[]
+            {
+                ((0L, 100L), new PreActionEvaluator()),
+                ((100L, long.MaxValue), new PostActionEvaluator()),
+            }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ForkableActionEvaluator(
+            new ((long, long), IActionEvaluator)[]
+            {
+                ((50L, 100L), new PreActionEvaluator()),
+                ((101L, long.MaxValue), new PostActionEvaluator()),
+            }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ForkableActionEvaluator(
+            new ((long, long), IActionEvaluator)[]
+            {
+                ((0L, 100L), new PreActionEvaluator()),
+                ((101L, long.MaxValue - 1), new PostActionEvaluator()),
+            }));
+    }
+}
+
+class PostActionEvaluator : IActionEvaluator
+{
+    public IActionLoader ActionLoader => throw new NotSupportedException();
+    public IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block)
+    {
+        return new IActionEvaluation[]
+        {
+            new ActionEvaluation(
+                (Text)"POST",
+                new ActionContext(
+                    null,
+                    default,
+                    null,
+                    default,
+                    0,
+                    false,
+                    new AccountStateDelta(),
+                    new Random(0),
+                    null,
+                    false),
+                new AccountStateDelta(),
+                null,
+                new List<string>())
+        };
+    }
+}
+
+class PreActionEvaluator : IActionEvaluator
+{
+    public IActionLoader ActionLoader => throw new NotSupportedException();
+    public IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block)
+    {
+        return new IActionEvaluation[]
+        {
+            new ActionEvaluation(
+                (Text)"PRE",
+                new ActionContext(
+                    null,
+                    default,
+                    null,
+                    default,
+                    0,
+                    false,
+                    new AccountStateDelta(),
+                    new Random(0),
+                    null,
+                    false),
+                new AccountStateDelta(),
+                null,
+                new List<string>())
+        };
+    }
+}
+
+class MockBlock : IPreEvaluationBlock
+{
+    public MockBlock(long blockIndex)
+    {
+        Index = blockIndex;
+    }
+
+    public int ProtocolVersion { get; }
+    public long Index { get; }
+    public DateTimeOffset Timestamp { get; }
+    public Address Miner { get; }
+    public PublicKey? PublicKey { get; }
+    public BlockHash? PreviousHash { get; }
+    public HashDigest<SHA256>? TxHash { get; }
+    public BlockCommit? LastCommit { get; }
+    public IReadOnlyList<ITransaction> Transactions { get; }
+    public HashDigest<SHA256> PreEvaluationHash { get; }
+}

--- a/Libplanet.Extensions.ForkableActionEvaluator.Tests/Libplanet.Extensions.ForkableActionEvaluator.Tests.csproj
+++ b/Libplanet.Extensions.ForkableActionEvaluator.Tests/Libplanet.Extensions.ForkableActionEvaluator.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Libplanet.Extensions.ForkableActionEvaluator\Libplanet.Extensions.ForkableActionEvaluator.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libplanet.Extensions.ForkableActionEvaluator.Tests/Usings.cs
+++ b/Libplanet.Extensions.ForkableActionEvaluator.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Libplanet.Extensions.ForkableActionEvaluator/ForkableActionEvaluator.cs
+++ b/Libplanet.Extensions.ForkableActionEvaluator/ForkableActionEvaluator.cs
@@ -1,0 +1,22 @@
+using Libplanet.Action;
+using Libplanet.Blocks;
+
+namespace Libplanet.Extensions.ForkableActionEvaluator;
+
+public class ForkableActionEvaluator : IActionEvaluator
+{
+    private readonly HardForkRouter _router;
+
+    public ForkableActionEvaluator(IEnumerable<((long StartIndex, long EndIndex) Range, IActionEvaluator ActionEvaluator)> pairs)
+    {
+        _router = new HardForkRouter(pairs);
+    }
+
+    public IActionLoader ActionLoader => throw new NotSupportedException();
+
+    public IReadOnlyList<IActionEvaluation> Evaluate(IPreEvaluationBlock block)
+    {
+        var actionEvaluator = _router.GetEvaluator(block.Index);
+        return actionEvaluator.Evaluate(block);
+    }
+}

--- a/Libplanet.Extensions.ForkableActionEvaluator/HardForkRouter.cs
+++ b/Libplanet.Extensions.ForkableActionEvaluator/HardForkRouter.cs
@@ -1,0 +1,78 @@
+using System.Collections.Immutable;
+using Libplanet.Action;
+
+namespace Libplanet.Extensions.ForkableActionEvaluator;
+
+internal class HardForkRouter
+{
+    private readonly ImmutableArray<((long StartIndex, long EndIndex) Range, IActionEvaluator ActionEvaluator)>
+        _pairs;
+
+    public HardForkRouter(
+        IEnumerable<((long StartIndex, long EndIndex) Range, IActionEvaluator ActionEvaluator)>
+            rangeAndEvaluatorPairs
+    )
+    {
+        _pairs = rangeAndEvaluatorPairs.OrderBy(x => x.Range.StartIndex).ToImmutableArray();
+
+        CheckCollision(_pairs);
+    }
+
+    public IActionEvaluator GetEvaluator(long blockIndex)
+    {
+        foreach (var ((startIndex, endIndex), actionEvaluator) in _pairs)
+        {
+            if (startIndex <= blockIndex && blockIndex <= endIndex)
+            {
+                return actionEvaluator;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Unexpected situation occurred. {nameof(_pairs)} must cover " +
+            $"all range over blockchain if {nameof(CheckCollision)}() works well.");
+    }
+
+    private static void CheckCollision(
+        ImmutableArray<((long StartIndex, long EndIndex) Range, IActionEvaluator ActionEvaluator)> pairs)
+    {
+        if (pairs.Length == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pairs), "It must have one more paris at least.");
+        }
+
+        if (pairs[0].Range.StartIndex != 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pairs),
+                "The pairs must cover all range of blockchain. Its first element's start index wasn't 0.");
+        }
+
+        if (pairs.Last().Range.EndIndex != long.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pairs),
+                "The pairs must cover all range over blockchain. Its last element's start index wasn't 0.");
+        }
+
+        if (pairs.Length == 1)
+        {
+            return;
+        }
+
+        for (int i = 1; i < pairs.Length; ++i)
+        {
+            long previousPairEndIndex = pairs[i - 1].Range.EndIndex;
+            long startIndex = pairs[i].Range.StartIndex;
+
+            if (previousPairEndIndex + 1 != startIndex)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(pairs),
+                    "The pairs must cover all range over blockchain. " +
+                    "So Nth pair's end index + 1 must be same as N+1th pair's start index. " +
+                    $"But Nth pair's end index is {previousPairEndIndex} and N+1th pair's start index is {startIndex}");
+            }
+        }
+    }
+}

--- a/Libplanet.Extensions.ForkableActionEvaluator/Libplanet.Extensions.ForkableActionEvaluator.csproj
+++ b/Libplanet.Extensions.ForkableActionEvaluator/Libplanet.Extensions.ForkableActionEvaluator.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj
+++ b/Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj
@@ -8,6 +8,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
@@ -7,6 +7,7 @@ using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Consensus;
+using Libplanet.Extensions.ActionEvaluatorCommonComponents;
 
 namespace Libplanet.Extensions.RemoteActionEvaluator;
 

--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -60,6 +60,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.Remote
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.StateService", "Lib9c.StateService\Lib9c.StateService.csproj", "{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ForkableActionEvaluator", "Libplanet.Extensions.ForkableActionEvaluator\Libplanet.Extensions.ForkableActionEvaluator.csproj", "{8DBD6B71-1863-417A-8569-269300733496}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ForkableActionEvaluator.Tests", "Libplanet.Extensions.ForkableActionEvaluator.Tests\Libplanet.Extensions.ForkableActionEvaluator.Tests.csproj", "{490D20B6-FC0C-4459-8412-17777DB95931}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents", "Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj", "{F022D1F4-AE22-45C4-AE12-B821256B1700}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests", "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests\Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj", "{35E5F94A-5825-428B-AB4B-6CD1795A17A3}"
@@ -439,6 +443,34 @@ Global
 		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Release|x86.Build.0 = Release|Any CPU
 		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
 		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Debug|x64.Build.0 = Debug|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Debug|x86.Build.0 = Debug|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Release|x64.ActiveCfg = Release|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Release|x64.Build.0 = Release|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Release|x86.ActiveCfg = Release|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.Release|x86.Build.0 = Release|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DBD6B71-1863-417A-8569-269300733496}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Debug|x64.Build.0 = Debug|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Debug|x86.Build.0 = Debug|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Release|Any CPU.Build.0 = Release|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Release|x64.ActiveCfg = Release|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Release|x64.Build.0 = Release|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Release|x86.ActiveCfg = Release|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.Release|x86.Build.0 = Release|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{490D20B6-FC0C-4459-8412-17777DB95931}.DevEx|Any CPU.Build.0 = Debug|Any CPU
 		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -60,6 +60,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.Remote
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.StateService", "Lib9c.StateService\Lib9c.StateService.csproj", "{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents", "Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj", "{F022D1F4-AE22-45C4-AE12-B821256B1700}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests", "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests\Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj", "{35E5F94A-5825-428B-AB4B-6CD1795A17A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -435,6 +439,34 @@ Global
 		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.Release|x86.Build.0 = Release|Any CPU
 		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
 		{CE7AE7C8-1C77-4993-892C-31CE362E4BA7}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|x64.Build.0 = Debug|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Debug|x86.Build.0 = Debug|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Release|x64.ActiveCfg = Release|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Release|x64.Build.0 = Release|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Release|x86.ActiveCfg = Release|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.Release|x86.Build.0 = Release|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{F022D1F4-AE22-45C4-AE12-B821256B1700}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Debug|x64.Build.0 = Debug|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Debug|x86.Build.0 = Debug|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Release|x64.ActiveCfg = Release|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Release|x64.Build.0 = Release|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Release|x86.ActiveCfg = Release|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Release|x86.Build.0 = Release|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.DevEx|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request introduces `ForkableActionEvaluator`, a new `IActionEvaluator` implementation.
It receives `IActionEvaluator`s with the range of block index. The range is always presented as a closed interval[^1]. And the ranges must cover all long ranges (0 ~ 9223372036854775807).

[^1]: https://en.wikipedia.org/wiki/Interval_(mathematics)#Terminology