### PR TITLE
Support `ActionEvaluator` configuration

### DIFF
--- a/Lib9c.StateService/Controllers/RemoteEvaluationController.cs
+++ b/Lib9c.StateService/Controllers/RemoteEvaluationController.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Extensions.ActionEvaluatorCommonComponents;
 using Libplanet.Extensions.RemoteActionEvaluator;
 using Microsoft.AspNetCore.Mvc;
 using Nekoyume.Action;

--- a/Libplanet.Headless/Hosting/ActionEvaluatorType.cs
+++ b/Libplanet.Headless/Hosting/ActionEvaluatorType.cs
@@ -1,0 +1,8 @@
+namespace Libplanet.Headless.Hosting;
+
+public enum ActionEvaluatorType
+{
+    Default,  // ActionEvaluator
+    ForkableActionEvaluator,
+    RemoteActionEvaluator,
+}

--- a/Libplanet.Headless/Hosting/DefaultActionEvaluatorConfiguration.cs
+++ b/Libplanet.Headless/Hosting/DefaultActionEvaluatorConfiguration.cs
@@ -1,0 +1,6 @@
+namespace Libplanet.Headless.Hosting;
+
+public class DefaultActionEvaluatorConfiguration : IActionEvaluatorConfiguration
+{
+    public ActionEvaluatorType Type => ActionEvaluatorType.Default;
+}

--- a/Libplanet.Headless/Hosting/ForkableActionEvaluatorConfiguration.cs
+++ b/Libplanet.Headless/Hosting/ForkableActionEvaluatorConfiguration.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Libplanet.Headless.Hosting;
+
+public class ForkableActionEvaluatorConfiguration : IActionEvaluatorConfiguration
+{
+    public ActionEvaluatorType Type => ActionEvaluatorType.ForkableActionEvaluator;
+
+    public ImmutableArray<(ForkableActionEvaluatorRange, IActionEvaluatorConfiguration)> Pairs { get; init; }
+}
+
+public class ForkableActionEvaluatorRange
+{
+    public long Start { get; }
+    public long End { get; }
+}

--- a/Libplanet.Headless/Hosting/IActionEvaluatorConfiguration.cs
+++ b/Libplanet.Headless/Hosting/IActionEvaluatorConfiguration.cs
@@ -1,0 +1,6 @@
+namespace Libplanet.Headless.Hosting;
+
+public interface IActionEvaluatorConfiguration
+{
+    ActionEvaluatorType Type { get; }
+}

--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -83,6 +83,9 @@ namespace Libplanet.Headless.Hosting
 
 #nullable enable
         public DynamicActionTypeLoaderConfiguration? DynamicActionTypeLoader { get; init; } = null;
+
+        public IActionEvaluatorConfiguration ActionEvaluatorConfiguration { get; init; } =
+            new DefaultActionEvaluatorConfiguration();
 #nullable disable
     }
 }

--- a/Libplanet.Headless/Hosting/RemoteActionEvaluatorConfiguration.cs
+++ b/Libplanet.Headless/Hosting/RemoteActionEvaluatorConfiguration.cs
@@ -1,0 +1,8 @@
+namespace Libplanet.Headless.Hosting;
+
+public class RemoteActionEvaluatorConfiguration : IActionEvaluatorConfiguration
+{
+    public ActionEvaluatorType Type => ActionEvaluatorType.RemoteActionEvaluator;
+
+    public string StateServiceEndpoint { get; init; }
+}

--- a/Libplanet.Headless/Libplanet.Headless.csproj
+++ b/Libplanet.Headless/Libplanet.Headless.csproj
@@ -24,5 +24,6 @@
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared\NineChronicles.RPC.Shared.csproj" />
     <ProjectReference Include="..\Libplanet.Extensions.RemoteActionEvaluator\Libplanet.Extensions.RemoteActionEvaluator.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.ForkableActionEvaluator\Libplanet.Extensions.ForkableActionEvaluator.csproj" />
   </ItemGroup>
 </Project>

--- a/NineChronicles.Headless.Executable/appsettings-schema.json
+++ b/NineChronicles.Headless.Executable/appsettings-schema.json
@@ -141,8 +141,78 @@
                     "type": "number",
                     "minimum": 0,
                     "maximum": 65535
+                },
+                "ActionEvaluator": {
+                    "$ref": "#/definitions/action-evaluator"
                 }
             }
+        }
+    },
+    "definitions": {
+        "range": {
+            "type": "object",
+            "properties": {
+                "start": {
+                    "type": "integer"
+                },
+                "end": {
+                    "type": "integer"
+                }
+            },
+            "required": ["start", "end"],
+            "additionalProperties": false
+        },
+        "action-evaluator": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "Default"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "RemoteActionEvaluator"
+                        },
+                        "stateServiceEndpoint": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["stateServiceEndpoint"],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "ForkableActionEvaluator"
+                        },
+                        "pairs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "range": {
+                                        "$ref": "#/definitions/range"
+                                    },
+                                    "actionEvaluator": {
+                                        "$ref": "#/definitions/action-evaluator"
+                                    }
+                                },
+                                "required": ["range", "actionEvaluator"],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
         }
     }
 }

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -81,7 +81,8 @@ namespace NineChronicles.Headless.Properties
                 int maximumPollPeers = int.MaxValue,
                 ushort? consensusPort = null,
                 string? consensusPrivateKeyString = null,
-                string[]? consensusSeedStrings = null)
+                string[]? consensusSeedStrings = null,
+                IActionEvaluatorConfiguration? actionEvaluatorConfiguration = null)
         {
             var swarmPrivateKey = string.IsNullOrEmpty(swarmPrivateKeyString)
                 ? new PrivateKey()
@@ -129,6 +130,7 @@ namespace NineChronicles.Headless.Properties
                 ConsensusPort = consensusPort,
                 ConsensusSeeds = consensusSeeds,
                 ConsensusPrivateKey = consensusPrivateKey,
+                ActionEvaluatorConfiguration = actionEvaluatorConfiguration ?? new DefaultActionEvaluatorConfiguration(),
             };
         }
 


### PR DESCRIPTION
This pull request's purpose is to provide a way to configure `ActionEvaluator` with `appsettings.json` configuration file. If you want to run `ForkableActionEvaluator` with `ActionEvaluator` (0 ~ 7M blocks) and `RemoteActionEvaluator` (7000001 ~ `long.MaxValue`), you can write the configuration like below:

```json
"ActionEvaluator": {
    "type": "ForkableActionEvaluator",
    "pairs": [
        {
            "range": {
                "start": 0,
                "end": 7000000
            },
            "actionEvaluator": {
                "type": "Default"
            }
        },
        {
            "range": {
                "start": 0,
                "end": 7000000
            },
            "actionEvaluator": {
                "type": "RemoteActionEvaluator",
                "stateServiceEndpoint": "http://localhost:5157/evaluation"
            }
        }
    ]
}
```

Or, if you want to organize Pluggable Lib9c with `ForkableActionEvaluator` and `RemoteActionEvaluator`, it will be like the below:

```json
"ActionEvaluator": {
    "type": "ForkableActionEvaluator",
    "pairs": [
        {
            "range": {
                "start": 0,
                "end": 7000000
            },
            "actionEvaluator": {
                "type": "RemoteActionEvaluator",
                "stateServiceEndpoint": "http://v200000-eval.planetarium.dev:5157/evaluation"
            }
        },
        {
            "range": {
                "start": 7000001,
                "end": 8000000
            },
            "actionEvaluator": {
                "type": "RemoteActionEvaluator",
                "stateServiceEndpoint": "http://v200010-eval.planetarium.dev:5157/evaluation"
            }
        },
        {
            "range": {
                "start": 8000001,
                "end": 9000000
            },
            "actionEvaluator": {
                "type": "RemoteActionEvaluator",
                "stateServiceEndpoint": "http://v200020-eval.planetarium.dev:5157/evaluation"
            }
        }
    ]
}
```