### PR TITLE
Fix gql error format to follow global Logger

### DIFF
--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -127,8 +127,8 @@ namespace NineChronicles.Headless
                             options.EnableMetrics = true;
                             options.UnhandledExceptionDelegate = context =>
                             {
-                                Console.Error.WriteLine(context.Exception.ToString());
-                                Console.Error.WriteLine(context.ErrorMessage);
+                                Log.Error(context.Exception.ToString());
+                                Log.Error(context.ErrorMessage);
                             };
                         })
                     .AddSystemTextJson()


### PR DESCRIPTION
as we parse every logs using JSON parser from fluentbit, we should make stderr logs follow global Logging config.
