### PR TITLE
ci(gh-actions): build and test with DevEx configuration too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,15 @@ on: [push, pull_request]
 
 jobs:
   build-and-tests:
+    name: "build-and-tests (${{ matrix.configuration }})"
     strategy:
       matrix:
         os:
           - ubuntu-20.04
           - windows-latest
+        configuration:
+          - Release
+          - DevEx
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +26,7 @@ jobs:
         run: dotnet restore
       - name: Build and test
         run: |
-          dotnet test --configuration Release --no-restore
+          dotnet test --configuration ${{ matrix.configuration }} --no-restore
 
   build-and-test:
     needs: [build-and-tests]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.*
+          dotnet-version: 7.0.*
       - name: Install dependencies
         run: dotnet restore
       - name: Build and test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,3 @@ jobs:
       - name: Build and test
         run: |
           dotnet test --configuration ${{ matrix.configuration }} --no-restore
-
-  build-and-test:
-    needs: [build-and-tests]
-    runs-on: ubuntu-20.04
-    steps:
-      - run: echo done

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -416,7 +416,7 @@ namespace NineChronicles.Headless.Executable
                 {
                     var actionLoader = new SingleActionLoader(typeof(PolymorphicAction<ActionBase>));
 #if LIB9C_DEV_EXTENSIONS
-                    PolymorphicAction<ActionBase>.ReloadLoader(new[] { typeof(ActionBase).Assembly, typeof(Utils).Assembly });
+                    PolymorphicAction<ActionBase>.ReloadLoader(new[] { typeof(ActionBase).Assembly, typeof(Lib9c.DevExtensions.Utils).Assembly });
 #endif
                     return actionLoader;
                 }


### PR DESCRIPTION
Now, it changes the jobs' names but they are required jobs. When the `v200020-1` released, the branch rule should be updated.