### PR TITLE
Reorganize projects related to `Lib9c.StateService`

### DIFF
--- a/Lib9c.StateService/Controllers/RemoteEvaluationController.cs
+++ b/Lib9c.StateService/Controllers/RemoteEvaluationController.cs
@@ -6,7 +6,6 @@ using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Blockchain;
 using Libplanet.Extensions.ActionEvaluatorCommonComponents;
-using Libplanet.Extensions.RemoteActionEvaluator;
 using Microsoft.AspNetCore.Mvc;
 using Nekoyume.Action;
 

--- a/Lib9c.StateService/Lib9c.StateService.csproj
+++ b/Lib9c.StateService/Lib9c.StateService.csproj
@@ -12,7 +12,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\Libplanet.Extensions.RemoteActionEvaluator\Libplanet.Extensions.RemoteActionEvaluator.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.RemoteBlockChainStates\Libplanet.Extensions.RemoteBlockChainStates.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj" />
     <ProjectReference Include="..\Lib9c\Lib9c\Lib9c.csproj" />
   </ItemGroup>
 

--- a/Lib9c.StateService/Program.cs
+++ b/Lib9c.StateService/Program.cs
@@ -1,6 +1,6 @@
 using Bencodex;
 using Libplanet.Blockchain;
-using Libplanet.Extensions.RemoteActionEvaluator;
+using Libplanet.Extensions.RemoteBlockChainStates;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/Lib9c.StateService/RemoteEvaluationRequest.cs
+++ b/Lib9c.StateService/RemoteEvaluationRequest.cs
@@ -1,4 +1,4 @@
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Lib9c.StateService;
 
 public class RemoteEvaluationRequest
 {

--- a/Lib9c.StateService/RemoteEvaluationResponse.cs
+++ b/Lib9c.StateService/RemoteEvaluationResponse.cs
@@ -1,4 +1,4 @@
-namespace Libplanet.Extensions.RemoteActionEvaluator;
+namespace Lib9c.StateService;
 
 public class RemoteEvaluationResponse
 {

--- a/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Net.Http.Json;
 using Bencodex.Types;
+using Lib9c.StateService;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Assets;

--- a/Libplanet.Extensions.RemoteBlockChainStates/Libplanet.Extensions.RemoteBlockChainStates.csproj
+++ b/Libplanet.Extensions.RemoteBlockChainStates/Libplanet.Extensions.RemoteBlockChainStates.csproj
@@ -5,10 +5,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
-    <ProjectReference Include="..\Lib9c.StateService\Lib9c.StateService.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GraphQL.Client" Version="5.1.1" />
+    <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="5.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Libplanet.Extensions.RemoteBlockChainStates/RemoteBlockChainStates.cs
+++ b/Libplanet.Extensions.RemoteBlockChainStates/RemoteBlockChainStates.cs
@@ -10,7 +10,7 @@ using Libplanet.Consensus;
 using Libplanet.Crypto;
 using Libplanet.Store.Trie;
 
-namespace Libplanet.Extensions.RemoteActionEvaluator
+namespace Libplanet.Extensions.RemoteBlockChainStates
 {
     public class RemoteBlockChainStates : IBlockChainStates
     {

--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -68,6 +68,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.Action
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests", "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests\Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj", "{35E5F94A-5825-428B-AB4B-6CD1795A17A3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.RemoteBlockChainStates", "Libplanet.Extensions.RemoteBlockChainStates\Libplanet.Extensions.RemoteBlockChainStates.csproj", "{E7DDB668-6BD3-479C-AE22-CA59308412C3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -499,6 +501,20 @@ Global
 		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.Release|x86.Build.0 = Release|Any CPU
 		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
 		{35E5F94A-5825-428B-AB4B-6CD1795A17A3}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Debug|x64.Build.0 = Debug|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Debug|x86.Build.0 = Debug|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Release|x64.ActiveCfg = Release|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Release|x64.Build.0 = Release|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Release|x86.ActiveCfg = Release|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Release|x86.Build.0 = Release|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.DevEx|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
 - Separate `RemoteBlockChainStates` implementation.
 - Move requests and response model to `Lib9c.StateService` project.