### PR TITLE
Separate shared classes as a new project

### DIFF
--- a/Lib9c.StateService.Shared/Lib9c.StateService.Shared.csproj
+++ b/Lib9c.StateService.Shared/Lib9c.StateService.Shared.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Lib9c.StateService.Shared/RemoteEvaluationRequest.cs
+++ b/Lib9c.StateService.Shared/RemoteEvaluationRequest.cs
@@ -1,4 +1,4 @@
-namespace Lib9c.StateService;
+namespace Lib9c.StateService.Shared;
 
 public class RemoteEvaluationRequest
 {

--- a/Lib9c.StateService.Shared/RemoteEvaluationResponse.cs
+++ b/Lib9c.StateService.Shared/RemoteEvaluationResponse.cs
@@ -1,4 +1,4 @@
-namespace Lib9c.StateService;
+namespace Lib9c.StateService.Shared;
 
 public class RemoteEvaluationResponse
 {

--- a/Lib9c.StateService/Controllers/RemoteEvaluationController.cs
+++ b/Lib9c.StateService/Controllers/RemoteEvaluationController.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reflection;
 using Bencodex;
 using Bencodex.Types;
+using Lib9c.StateService.Shared;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Blockchain;

--- a/Lib9c.StateService/Lib9c.StateService.csproj
+++ b/Lib9c.StateService/Lib9c.StateService.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Libplanet.Extensions.RemoteBlockChainStates\Libplanet.Extensions.RemoteBlockChainStates.csproj" />
     <ProjectReference Include="..\Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj" />
+    <ProjectReference Include="..\Lib9c.StateService.Shared\Lib9c.StateService.Shared.csproj" />
     <ProjectReference Include="..\Lib9c\Lib9c\Lib9c.csproj" />
   </ItemGroup>
 

--- a/Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj
+++ b/Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj
@@ -8,7 +8,8 @@
   
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\.Libplanet\Libplanet\Libplanet.csproj" />
-    <ProjectReference Include="..\Lib9c.StateService\Lib9c.StateService.csproj" />
+    <ProjectReference Include="..\Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj" />
+    <ProjectReference Include="..\Lib9c.StateService.Shared\Lib9c.StateService.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
+++ b/Libplanet.Extensions.RemoteActionEvaluator/RemoteActionEvaluator.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Contracts;
 using System.Net.Http.Json;
 using Bencodex.Types;
 using Lib9c.StateService;
+using Lib9c.StateService.Shared;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Assets;

--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -70,6 +70,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.Action
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.RemoteBlockChainStates", "Libplanet.Extensions.RemoteBlockChainStates\Libplanet.Extensions.RemoteBlockChainStates.csproj", "{E7DDB668-6BD3-479C-AE22-CA59308412C3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.StateService.Shared", "Lib9c.StateService.Shared\Lib9c.StateService.Shared.csproj", "{31922990-E81C-4161-80AB-0F4B5AD77516}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -515,6 +517,20 @@ Global
 		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.Release|x86.Build.0 = Release|Any CPU
 		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
 		{E7DDB668-6BD3-479C-AE22-CA59308412C3}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Debug|x64.Build.0 = Debug|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Debug|x86.Build.0 = Debug|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Release|x64.ActiveCfg = Release|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Release|x64.Build.0 = Release|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Release|x86.ActiveCfg = Release|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.Release|x86.Build.0 = Release|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{31922990-E81C-4161-80AB-0F4B5AD77516}.DevEx|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request extracts request classes and response classes from `Lib9c.StateService`, as a new project `Lib9c.StateService.Shared`. I think it will resolve [the Docker image build failure](https://github.com/planetarium/NineChronicles.Headless/actions/runs/5041875226/jobs/9041960520)