### PR TITLE
feat(cli): make `ConsensusReactorOption.TargetBlockInterval` configurable

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -233,7 +233,7 @@ namespace Libplanet.Headless.Hosting
                     ConsensusPort = (int)Properties.ConsensusPort,
                     ConsensusPrivateKey = Properties.ConsensusPrivateKey,
                     ConsensusWorkers = 500,
-                    TargetBlockInterval = TimeSpan.FromSeconds(7)
+                    TargetBlockInterval = TimeSpan.FromSeconds(Properties.ConsensusTargetBlockInterval ?? 7),
                 };
             }
 

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -233,7 +233,7 @@ namespace Libplanet.Headless.Hosting
                     ConsensusPort = (int)Properties.ConsensusPort,
                     ConsensusPrivateKey = Properties.ConsensusPrivateKey,
                     ConsensusWorkers = 500,
-                    TargetBlockInterval = TimeSpan.FromSeconds(Properties.ConsensusTargetBlockInterval ?? 7),
+                    TargetBlockInterval = TimeSpan.FromMilliseconds(Properties.ConsensusTargetBlockIntervalMilliseconds ?? 7000),
                 };
             }
 

--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -17,6 +17,8 @@ namespace Libplanet.Headless.Hosting
 
         public ushort? ConsensusPort { get; set; }
 
+        public double? ConsensusTargetBlockInterval { get; set; }
+
         public PrivateKey SwarmPrivateKey { get; set; }
 
         public PrivateKey ConsensusPrivateKey { get; set; }

--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Headless.Hosting
 
         public ushort? ConsensusPort { get; set; }
 
-        public double? ConsensusTargetBlockInterval { get; set; }
+        public double? ConsensusTargetBlockIntervalMilliseconds { get; set; }
 
         public PrivateKey SwarmPrivateKey { get; set; }
 

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -81,7 +81,7 @@ namespace NineChronicles.Headless.Executable
         public string? ConsensusPrivateKeyString { get; set; }
         public string[]? ConsensusSeedStrings { get; set; }
         public ushort? ConsensusPort { get; set; }
-        public double? ConsensusTargetBlockInterval { get; set; }
+        public double? ConsensusTargetBlockIntervalMilliseconds { get; set; }
 
         public string SentryDsn { get; set; } = "";
 
@@ -132,7 +132,7 @@ namespace NineChronicles.Headless.Executable
             ushort? consensusPort,
             string? consensusPrivateKeyString,
             string[]? consensusSeedStrings,
-            double? consensusTargetBlockInterval,
+            double? consensusTargetBlockIntervalMilliseconds,
             string? sentryDsn,
             double? sentryTraceSampleRate
         )
@@ -182,7 +182,7 @@ namespace NineChronicles.Headless.Executable
             ConsensusPort = consensusPort ?? ConsensusPort;
             ConsensusSeedStrings = consensusSeedStrings ?? ConsensusSeedStrings;
             ConsensusPrivateKeyString = consensusPrivateKeyString ?? ConsensusPrivateKeyString;
-            ConsensusTargetBlockInterval = consensusTargetBlockInterval ?? ConsensusTargetBlockInterval;
+            ConsensusTargetBlockIntervalMilliseconds = consensusTargetBlockIntervalMilliseconds ?? ConsensusTargetBlockIntervalMilliseconds;
             SentryDsn = sentryDsn ?? SentryDsn;
             SentryTraceSampleRate = sentryTraceSampleRate ?? SentryTraceSampleRate;
         }

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -81,6 +81,7 @@ namespace NineChronicles.Headless.Executable
         public string? ConsensusPrivateKeyString { get; set; }
         public string[]? ConsensusSeedStrings { get; set; }
         public ushort? ConsensusPort { get; set; }
+        public double? ConsensusTargetBlockInterval { get; set; }
 
         public string SentryDsn { get; set; } = "";
 
@@ -131,6 +132,7 @@ namespace NineChronicles.Headless.Executable
             ushort? consensusPort,
             string? consensusPrivateKeyString,
             string[]? consensusSeedStrings,
+            double? consensusTargetBlockInterval,
             string? sentryDsn,
             double? sentryTraceSampleRate
         )
@@ -180,6 +182,7 @@ namespace NineChronicles.Headless.Executable
             ConsensusPort = consensusPort ?? ConsensusPort;
             ConsensusSeedStrings = consensusSeedStrings ?? ConsensusSeedStrings;
             ConsensusPrivateKeyString = consensusPrivateKeyString ?? ConsensusPrivateKeyString;
+            ConsensusTargetBlockInterval = consensusTargetBlockInterval ?? ConsensusTargetBlockInterval;
             SentryDsn = sentryDsn ?? SentryDsn;
             SentryTraceSampleRate = sentryTraceSampleRate ?? SentryTraceSampleRate;
         }

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -193,6 +193,9 @@ namespace NineChronicles.Headless.Executable
             [Option("consensus-seed",
                 Description = "A list of seed peers to join the block consensus.")]
             string[]? consensusSeedStrings = null,
+            [Option("consensus-target-block-interval",
+                Description = "A target block interval used in consensus context.")]
+            double? consensusTargetBlockInterval = null,
             [Option("config", new[] { 'C' },
                 Description = "Absolute path of \"appsettings.json\" file to provide headless configurations.")]
             string? configPath = "appsettings.json",
@@ -280,7 +283,7 @@ namespace NineChronicles.Headless.Executable
                 logActionRenders, confirmations,
                 txLifeTime, messageTimeout, tipTimeout, demandBuffer, skipPreload,
                 minimumBroadcastTarget, bucketSize, chainTipStaleBehaviorType, txQuotaPerSigner, maximumPollPeers,
-                consensusPort, consensusPrivateKeyString, consensusSeedStrings,
+                consensusPort, consensusPrivateKeyString, consensusSeedStrings, consensusTargetBlockInterval,
                 sentryDsn, sentryTraceSampleRate
             );
 
@@ -397,6 +400,7 @@ namespace NineChronicles.Headless.Executable
                         consensusPort: headlessConfig.ConsensusPort,
                         consensusPrivateKeyString: headlessConfig.ConsensusPrivateKeyString,
                         consensusSeedStrings: headlessConfig.ConsensusSeedStrings,
+                        consensusTargetBlockInterval: headlessConfig.ConsensusTargetBlockInterval,
                         maximumPollPeers: headlessConfig.MaximumPollPeers,
                         actionEvaluatorConfiguration: actionEvaluatorConfiguration
                     );

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -194,8 +194,8 @@ namespace NineChronicles.Headless.Executable
                 Description = "A list of seed peers to join the block consensus.")]
             string[]? consensusSeedStrings = null,
             [Option("consensus-target-block-interval",
-                Description = "A target block interval used in consensus context.")]
-            double? consensusTargetBlockInterval = null,
+                Description = "A target block interval used in consensus context. The unit is millisecond.")]
+            double? consensusTargetBlockIntervalMilliseconds = null,
             [Option("config", new[] { 'C' },
                 Description = "Absolute path of \"appsettings.json\" file to provide headless configurations.")]
             string? configPath = "appsettings.json",
@@ -283,7 +283,7 @@ namespace NineChronicles.Headless.Executable
                 logActionRenders, confirmations,
                 txLifeTime, messageTimeout, tipTimeout, demandBuffer, skipPreload,
                 minimumBroadcastTarget, bucketSize, chainTipStaleBehaviorType, txQuotaPerSigner, maximumPollPeers,
-                consensusPort, consensusPrivateKeyString, consensusSeedStrings, consensusTargetBlockInterval,
+                consensusPort, consensusPrivateKeyString, consensusSeedStrings, consensusTargetBlockIntervalMilliseconds,
                 sentryDsn, sentryTraceSampleRate
             );
 
@@ -400,7 +400,7 @@ namespace NineChronicles.Headless.Executable
                         consensusPort: headlessConfig.ConsensusPort,
                         consensusPrivateKeyString: headlessConfig.ConsensusPrivateKeyString,
                         consensusSeedStrings: headlessConfig.ConsensusSeedStrings,
-                        consensusTargetBlockInterval: headlessConfig.ConsensusTargetBlockInterval,
+                        consensusTargetBlockIntervalMilliseconds: headlessConfig.ConsensusTargetBlockIntervalMilliseconds,
                         maximumPollPeers: headlessConfig.MaximumPollPeers,
                         actionEvaluatorConfiguration: actionEvaluatorConfiguration
                     );

--- a/NineChronicles.Headless.Executable/appsettings-schema.json
+++ b/NineChronicles.Headless.Executable/appsettings-schema.json
@@ -143,7 +143,7 @@
                     "maximum": 65535
                 },
                 "ConsensusTargetBlockInterval": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "ActionEvaluator": {
                     "$ref": "#/definitions/action-evaluator"

--- a/NineChronicles.Headless.Executable/appsettings-schema.json
+++ b/NineChronicles.Headless.Executable/appsettings-schema.json
@@ -142,6 +142,9 @@
                     "minimum": 0,
                     "maximum": 65535
                 },
+                "ConsensusTargetBlockInterval": {
+                    "type": "number"
+                },
                 "ActionEvaluator": {
                     "$ref": "#/definitions/action-evaluator"
                 }

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -82,6 +82,7 @@ namespace NineChronicles.Headless.Properties
                 ushort? consensusPort = null,
                 string? consensusPrivateKeyString = null,
                 string[]? consensusSeedStrings = null,
+                double? consensusTargetBlockInterval = null,
                 IActionEvaluatorConfiguration? actionEvaluatorConfiguration = null)
         {
             var swarmPrivateKey = string.IsNullOrEmpty(swarmPrivateKeyString)
@@ -130,6 +131,7 @@ namespace NineChronicles.Headless.Properties
                 ConsensusPort = consensusPort,
                 ConsensusSeeds = consensusSeeds,
                 ConsensusPrivateKey = consensusPrivateKey,
+                ConsensusTargetBlockInterval = consensusTargetBlockInterval,
                 ActionEvaluatorConfiguration = actionEvaluatorConfiguration ?? new DefaultActionEvaluatorConfiguration(),
             };
         }

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -82,7 +82,7 @@ namespace NineChronicles.Headless.Properties
                 ushort? consensusPort = null,
                 string? consensusPrivateKeyString = null,
                 string[]? consensusSeedStrings = null,
-                double? consensusTargetBlockInterval = null,
+                double? consensusTargetBlockIntervalMilliseconds = null,
                 IActionEvaluatorConfiguration? actionEvaluatorConfiguration = null)
         {
             var swarmPrivateKey = string.IsNullOrEmpty(swarmPrivateKeyString)
@@ -131,7 +131,7 @@ namespace NineChronicles.Headless.Properties
                 ConsensusPort = consensusPort,
                 ConsensusSeeds = consensusSeeds,
                 ConsensusPrivateKey = consensusPrivateKey,
-                ConsensusTargetBlockInterval = consensusTargetBlockInterval,
+                ConsensusTargetBlockIntervalMilliseconds = consensusTargetBlockIntervalMilliseconds,
                 ActionEvaluatorConfiguration = actionEvaluatorConfiguration ?? new DefaultActionEvaluatorConfiguration(),
             };
         }


### PR DESCRIPTION
## Description

After this pull request, it can configure `ConsensusReactorOption.TargetBlockInterval` with `appsettings.json` or with command line option `--consensus-target-block-interval`. If it was an intention to use the target block interval as constant, this pull request may be closed.

## Usecase

 - Local testing with `--consensus-target-block-index=1000`.
 - Update `TargetBlockIndex` without source updating. cc @planetarium/devops 