### PR TITLE
Update rate limit

### DIFF
--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -101,23 +101,13 @@
         "GeneralRules": [
             {
                 "Endpoint": "*:/IBlockChainService/PutTransaction",
-                "Period": "1s",
-                "Limit": 1
+                "Period": "60s",
+                "Limit": 12
             },
             {
                 "Endpoint": "*:/graphql/stagetransaction",
-                "Period": "1s",
-                "Limit": 1
-            },
-            {
-                "Endpoint": "*:/IBlockChainService/*",
-                "Period": "1s",
-                "Limit": 10
-            },
-            {
-                "Endpoint": "*:/graphql",
-                "Period": "1s",
-                "Limit": 15
+                "Period": "60s",
+                "Limit": 12
             }
         ],
         "QuotaExceededResponse": {

--- a/NineChronicles.Headless/Middleware/CustomRateLimitMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/CustomRateLimitMiddleware.cs
@@ -35,15 +35,8 @@ namespace NineChronicles.Headless.Middleware
         {
             var identity = await base.ResolveIdentityAsync(httpContext);
 
-            if (httpContext.Request.Protocol == "HTTP/2")
-            {
-                identity.ClientIp = identity.ClientIp + "/" + httpContext.Connection.RemotePort;
-                return identity;
-            }
-
             if (httpContext.Request.Protocol == "HTTP/1.1")
             {
-                identity.ClientIp = identity.ClientIp + "/" + httpContext.Connection.RemotePort;
                 httpContext.Request.EnableBuffering();
                 var body = await new StreamReader(httpContext.Request.Body).ReadToEndAsync();
                 httpContext.Request.Body.Seek(0, SeekOrigin.Begin);

--- a/NineChronicles.Headless/Middleware/CustomRateLimitProcessor.cs
+++ b/NineChronicles.Headless/Middleware/CustomRateLimitProcessor.cs
@@ -24,7 +24,7 @@ namespace NineChronicles.Headless.Middleware
 
             if (_options.IpWhitelist != null && IpParser.ContainsIp(
                     _options.IpWhitelist,
-                    requestIdentity.ClientIp.Split("/").FirstOrDefault()))
+                    requestIdentity.ClientIp))
             {
                 return true;
             }


### PR DESCRIPTION
This PR updates the rate-limiter to only use the IP value (not IP+port)  when managing gql/grpc requests.