### PR TITLE
downgrade headless to `.NET6`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.*
+          dotnet-version: 6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build and test

--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         name: Set up .NET Core SDK
         with:
-          dotnet-version: 6.0.*
+          dotnet-version: 6.0.x
       - name: Build GraphQL Schema
         run: |
           dotnet restore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
             - name: Setup .NET Core
               uses: actions/setup-dotnet@v3
               with:
-                  dotnet-version: 6.0.*
+                  dotnet-version: 6.0.x
             - name: dotnet format
               run: dotnet format --exclude Lib9c --exclude NineChronicles.RPC.Shared -v=d --no-restore --verify-no-changes
     validate-appsettings-json:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS build-env
 WORKDIR /app
 ARG COMMIT
 
@@ -29,7 +29,7 @@ RUN python3.11 -m pip install GitPython
 RUN python3.11 prepare-pluggable-lib9c.py
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
 RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
 ARG COMMIT
 
@@ -24,7 +24,7 @@ RUN dotnet publish NineChronicles.Headless.Executable/NineChronicles.Headless.Ex
     --version-suffix $COMMIT
 
 # Build runtime image
-FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
 ARG COMMIT
 
@@ -24,7 +24,7 @@ RUN dotnet publish NineChronicles.Headless.Executable/NineChronicles.Headless.Ex
     --version-suffix $COMMIT
 
 # Build runtime image
-FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim-arm64v8
+FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim-arm64v8
 WORKDIR /app
 RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .

--- a/Dockerfile.lib9c-stateservice.amd64
+++ b/Dockerfile.lib9c-stateservice.amd64
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -16,7 +16,7 @@ RUN dotnet publish Lib9c.StateService/Lib9c.StateService.csproj \
     --self-contained
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
 RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .

--- a/Dockerfile.lib9c-stateservice.arm64v8
+++ b/Dockerfile.lib9c-stateservice.arm64v8
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -16,7 +16,7 @@ RUN dotnet publish Lib9c.StateService/Lib9c.StateService.csproj \
     --self-contained
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim-arm64v8
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim-arm64v8
 WORKDIR /app
 RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .

--- a/Lib9c.StateService.Shared/Lib9c.StateService.Shared.csproj
+++ b/Lib9c.StateService.Shared/Lib9c.StateService.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Lib9c.StateService/Lib9c.StateService.csproj
+++ b/Lib9c.StateService/Lib9c.StateService.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
   

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests/Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
+++ b/Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Libplanet.Extensions.ForkableActionEvaluator.Tests/Libplanet.Extensions.ForkableActionEvaluator.Tests.csproj
+++ b/Libplanet.Extensions.ForkableActionEvaluator.Tests/Libplanet.Extensions.ForkableActionEvaluator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Libplanet.Extensions.ForkableActionEvaluator/Libplanet.Extensions.ForkableActionEvaluator.csproj
+++ b/Libplanet.Extensions.ForkableActionEvaluator/Libplanet.Extensions.ForkableActionEvaluator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Libplanet.Extensions.RemoteActionEvaluator.Tests/Libplanet.Extensions.RemoteActionEvaluator.Tests.csproj
+++ b/Libplanet.Extensions.RemoteActionEvaluator.Tests/Libplanet.Extensions.RemoteActionEvaluator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj
+++ b/Libplanet.Extensions.RemoteActionEvaluator/Libplanet.Extensions.RemoteActionEvaluator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Libplanet.Extensions.RemoteBlockChainStates/Libplanet.Extensions.RemoteBlockChainStates.csproj
+++ b/Libplanet.Extensions.RemoteBlockChainStates/Libplanet.Extensions.RemoteBlockChainStates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
+++ b/Libplanet.Headless.Tests/Libplanet.Headless.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/Libplanet.Headless/Libplanet.Headless.csproj
+++ b/Libplanet.Headless/Libplanet.Headless.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
@@ -100,7 +100,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             }
             else
             {
-                Assert.Contains("System.FormatException: The input string '0x' was not in a correct format.", _console.Error.ToString());
+                Assert.Contains("System.FormatException: Input string was not in a correct format.", _console.Error.ToString());
             }
         }
 
@@ -140,7 +140,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             }
             else
             {
-                Assert.Contains("System.FormatException: The input string '0x' was not in a correct format.", _console.Error.ToString());
+                Assert.Contains("System.FormatException: Input string was not in a correct format.", _console.Error.ToString());
             }
         }
 
@@ -182,7 +182,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             }
             else
             {
-                Assert.Contains("System.FormatException: The input string '0x' was not in a correct format.", _console.Error.ToString());
+                Assert.Contains("System.FormatException: Input string was not in a correct format.", _console.Error.ToString());
             }
         }
 
@@ -270,7 +270,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
             }
             else
             {
-                Assert.Contains("System.FormatException: The input string '0x' was not in a correct format.", _console.Error.ToString());
+                Assert.Contains("System.FormatException: Input string was not in a correct format.", _console.Error.ToString());
             }
         }
     }

--- a/NineChronicles.Headless.Executable.Tests/NineChronicles.Headless.Executable.Tests.csproj
+++ b/NineChronicles.Headless.Executable.Tests/NineChronicles.Headless.Executable.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7</TargetFramework>
+        <TargetFramework>net6</TargetFramework>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>

--- a/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
+++ b/NineChronicles.Headless.Tests/NineChronicles.Headless.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
     <Nullable>enable</Nullable>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "6.0.0",
+        "rollForward": "minor"
+    }
+}


### PR DESCRIPTION
This PR downgrades the headless target framework to `.NET6` because we've found that the `.NET7` version occasionally results in a segmentation fault(https://github.com/dotnet/runtime/issues/72365) which degrades our live RPC service quality. `.NET6` headless doesn't have this issue.

According to https://github.com/dotnet/runtime/issues/72365, this issue is fixed from `v7.0.7` so I will do another test when `v7.0.7` is officially released(not yet released).

@moreal Would it be ok to remove `Microsoft.AspNetCore.OpenApi` in `Lib9c.StateService` because this nuget package is only available starting from `.NET7`? It build successfully but I'm not sure if removing it would affect `Lib9c.StateService`'s feature. 🤔 