### PR TITLE
Add IP ban feature for abusers

### DIFF
--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -114,6 +114,13 @@
             "Content": "{{ \"message\": \"Whoa! Calm down, cowboy!\", \"details\": \"Quota exceeded. Maximum allowed: {0} per {1}. Please try again in {2} second(s).\" }}",
             "ContentType": "application/json",
             "StatusCode": 429
+        },
+        "IpBanThresholdCount": 10,
+        "IpBanMinute" : 60,
+        "IpBanResponse": {
+            "Content": "{ \"message\": \"Your Ip has been banned.\" }",
+            "ContentType": "application/json",
+            "StatusCode": 403
         }
     }
 }

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -99,7 +99,7 @@ namespace NineChronicles.Headless
                 {
                     services.AddOptions();
                     services.AddMemoryCache();
-                    services.Configure<IpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
+                    services.Configure<CustomIpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
                     services.AddInMemoryRateLimiting();
                     services.AddMvc(options => options.EnableEndpointRouting = false);
                     services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
@@ -171,6 +171,7 @@ namespace NineChronicles.Headless
                 if (Convert.ToBoolean(Configuration.GetSection("IpRateLimiting")["EnableEndpointRateLimiting"]))
                 {
                     app.UseMiddleware<CustomRateLimitMiddleware>();
+                    app.UseMiddleware<IpBanMiddleware>();
                     app.UseMvc();
                 }
 

--- a/NineChronicles.Headless/Middleware/CustomRateLimitMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/CustomRateLimitMiddleware.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using AspNetCoreRateLimit;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using NineChronicles.Headless.Properties;
 using Serilog;
 using ILogger = Serilog.ILogger;
 
@@ -12,15 +13,17 @@ namespace NineChronicles.Headless.Middleware
     {
         private readonly ILogger _logger;
         private readonly IRateLimitConfiguration _config;
+        private readonly IOptions<CustomIpRateLimitOptions> _options;
 
         public CustomRateLimitMiddleware(RequestDelegate next,
             IProcessingStrategy processingStrategy,
-            IOptions<IpRateLimitOptions> options,
+            IOptions<CustomIpRateLimitOptions> options,
             IIpPolicyStore policyStore,
             IRateLimitConfiguration config)
             : base(next, options?.Value, new CustomIpRateLimitProcessor(options?.Value!, policyStore, processingStrategy), config)
         {
             _config = config;
+            _options = options!;
             _logger = Log.Logger.ForContext<CustomRateLimitMiddleware>();
         }
 
@@ -29,6 +32,11 @@ namespace NineChronicles.Headless.Middleware
             _logger.Information($"[IP-RATE-LIMITER] Request {identity.HttpVerb}:{identity.Path} from IP {identity.ClientIp} has been blocked, " +
                                 $"quota {rule.Limit}/{rule.Period} exceeded by {counter.Count - rule.Limit}. Blocked by rule {rule.Endpoint}, " +
                                 $"TraceIdentifier {httpContext.TraceIdentifier}. MonitorMode: {rule.MonitorMode}");
+            if (counter.Count - rule.Limit >= _options.Value.IpBanThresholdCount)
+            {
+                _logger.Information($"[IP-RATE-LIMITER] Banning IP {identity.ClientIp}.");
+                IpBanMiddleware.BanIp(identity.ClientIp);
+            }
         }
 
         public override async Task<ClientRequestIdentity> ResolveIdentityAsync(HttpContext httpContext)

--- a/NineChronicles.Headless/Middleware/CustomRateLimitProcessor.cs
+++ b/NineChronicles.Headless/Middleware/CustomRateLimitProcessor.cs
@@ -1,14 +1,15 @@
 using System.Linq;
 using AspNetCoreRateLimit;
+using NineChronicles.Headless.Properties;
 
 namespace NineChronicles.Headless.Middleware
 {
     public class CustomIpRateLimitProcessor : IpRateLimitProcessor
     {
-        private readonly IpRateLimitOptions _options;
+        private readonly CustomIpRateLimitOptions _options;
 
         public CustomIpRateLimitProcessor(
-            IpRateLimitOptions options,
+            CustomIpRateLimitOptions options,
             IIpPolicyStore policyStore,
             IProcessingStrategy processingStrategy) : base(options, policyStore, processingStrategy)
         {

--- a/NineChronicles.Headless/Middleware/IpBanMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/IpBanMiddleware.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using NineChronicles.Headless.Properties;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace NineChronicles.Headless.Middleware
+{
+    public class IpBanMiddleware
+    {
+        private static Dictionary<string, DateTimeOffset> _bannedIps = new();
+        private readonly RequestDelegate _next;
+        private readonly ILogger _logger;
+        private readonly IOptions<CustomIpRateLimitOptions> _options;
+
+        public IpBanMiddleware(RequestDelegate next, IOptions<CustomIpRateLimitOptions> options)
+        {
+            _next = next;
+            _options = options;
+            _logger = Log.Logger.ForContext<IpBanMiddleware>();
+        }
+
+        public static void BanIp(string ip)
+        {
+            if (!_bannedIps.ContainsKey(ip))
+            {
+                _bannedIps.Add(ip, DateTimeOffset.Now);
+            }
+        }
+
+        public static void UnbanIp(string ip)
+        {
+            if (_bannedIps.ContainsKey(ip))
+            {
+                _bannedIps.Remove(ip);
+            }
+        }
+
+        public Task InvokeAsync(HttpContext context)
+        {
+            context.Request.EnableBuffering();
+            var remoteIp = context.Connection.RemoteIpAddress!.ToString();
+            if (_bannedIps.ContainsKey(remoteIp))
+            {
+                if ((DateTimeOffset.Now - _bannedIps[remoteIp]).Minutes >= _options.Value.IpBanMinute)
+                {
+                    _logger.Information($"[IP-RATE-LIMITER] Unbanning IP {remoteIp} after {_options.Value.IpBanMinute} minutes.");
+                    UnbanIp(remoteIp);
+                }
+                else
+                {
+                    _logger.Information($"[IP-RATE-LIMITER] IP {remoteIp} has been banned");
+                    var message = _options.Value.IpBanResponse!.Content!;
+                    context.Response.StatusCode = (int) _options.Value.IpBanResponse!.StatusCode!;
+                    context.Response.ContentType = _options.Value.IpBanResponse!.ContentType!;
+                    return context.Response.WriteAsync(message);
+                }
+            }
+
+            return _next(context);
+        }
+    }
+}

--- a/NineChronicles.Headless/Properties/CustomRateLimitOptions.cs
+++ b/NineChronicles.Headless/Properties/CustomRateLimitOptions.cs
@@ -1,0 +1,13 @@
+using AspNetCoreRateLimit;
+
+namespace NineChronicles.Headless.Properties
+{
+    public class CustomIpRateLimitOptions : IpRateLimitOptions
+    {
+        public int IpBanThresholdCount { get; set; } = 10;
+
+        public int IpBanMinute { get; set; } = 60;
+
+        public IpBanResponse? IpBanResponse { get; set; }
+    }
+}

--- a/NineChronicles.Headless/Properties/IpBanResponse.cs
+++ b/NineChronicles.Headless/Properties/IpBanResponse.cs
@@ -1,0 +1,12 @@
+namespace NineChronicles.Headless.Properties
+{
+    public class IpBanResponse
+    {
+        public string? ContentType { get; set; }
+
+        public string? Content { get; set; }
+
+        public int? StatusCode { get; set; } = 403;
+    }
+
+}


### PR DESCRIPTION
This PR bans IPs that send too many txs to the RPC nodes and works concurrently with the original rate-limiter.

Taking the default configuration(https://github.com/planetarium/NineChronicles.Headless/compare/development...area363:feat/add-ip-ban?expand=1#diff-e47fc585cf3ec48a24eabba8519cf4fcffbfc15f80cc907dec2379af8ebdf134R117-R123) as an example, the headless node will block IP's that send `10` more txs than the default rate-limit threshold(`12 transactions` per `60 seconds`) and it will block the IP for `60 minutes` (the IP will be unbanned after `60 minutes`).