### PR TITLE
Add CombinationSlot query in AvatarStateType

### DIFF
--- a/NineChronicles.Headless.Tests/Common/Fixtures.cs
+++ b/NineChronicles.Headless.Tests/Common/Fixtures.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Lib9c.Model.Order;
 using Lib9c.Tests;
 using Libplanet;
@@ -64,6 +65,12 @@ namespace NineChronicles.Headless.Tests
             }
             return shopState;
         }
+
+        public static readonly Address CombinationSlotAddress = AvatarStateFX.combinationSlotAddresses.First();
+        public static readonly CombinationSlotState CombinationSlotStateFx = new(
+            CombinationSlotAddress,
+            1
+        );
 
         public static ShardedShopStateV2 ShardedWeapon0ShopStateV2FX()
         {

--- a/NineChronicles.Headless.Tests/Common/Fixtures.cs
+++ b/NineChronicles.Headless.Tests/Common/Fixtures.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Lib9c.Model.Order;
 using Lib9c.Tests;
@@ -66,11 +67,8 @@ namespace NineChronicles.Headless.Tests
             return shopState;
         }
 
-        public static readonly Address CombinationSlotAddress = AvatarStateFX.combinationSlotAddresses.First();
-        public static readonly CombinationSlotState CombinationSlotStateFx = new(
-            CombinationSlotAddress,
-            1
-        );
+        public static readonly List<CombinationSlotState> CombinationSlotStatesFx =
+            AvatarStateFX.combinationSlotAddresses.Select(x => new CombinationSlotState(x, 0)).ToList();
 
         public static ShardedShopStateV2 ShardedWeapon0ShopStateV2FX()
         {

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
@@ -74,19 +74,19 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 query,
                 source: new AvatarStateType.AvatarStateContext(
                     avatarState,
-                    addresses => addresses.Select(x =>
+                    addresses => addresses.Select(x => x switch
                     {
-                        if (x == Fixtures.AvatarAddress) return Fixtures.AvatarStateFX.Serialize();
-                        if (x == Fixtures.UserAddress) return Fixtures.AgentStateFx.Serialize();
-                        if (x == Fixtures.CombinationSlotAddress) return Fixtures.CombinationSlotStateFx.Serialize();
-                        return null;
+                        _ when x == Fixtures.AvatarAddress => Fixtures.AvatarStateFX.Serialize(),
+                        _ when x == Fixtures.UserAddress => Fixtures.AgentStateFx.Serialize(),
+                        _ when x == Fixtures.CombinationSlotAddress => Fixtures.CombinationSlotStateFx.Serialize(),
+                        _ => null
                     }).ToList(),
                     (_, _) => new FungibleAssetValue(),
                     0));
             var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
             Assert.Equal(expected, data);
         }
-        
+
         public static IEnumerable<object[]> Members => new List<object[]>
         {
             new object[]

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
@@ -74,12 +74,26 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 query,
                 source: new AvatarStateType.AvatarStateContext(
                     avatarState,
-                    addresses => addresses.Select(x => x switch
+                    addresses => addresses.Select(x =>
                     {
-                        _ when x == Fixtures.AvatarAddress => Fixtures.AvatarStateFX.Serialize(),
-                        _ when x == Fixtures.UserAddress => Fixtures.AgentStateFx.Serialize(),
-                        _ when x == Fixtures.CombinationSlotAddress => Fixtures.CombinationSlotStateFx.Serialize(),
-                        _ => null
+                        if (x == Fixtures.AvatarAddress)
+                        {
+                            return Fixtures.AvatarStateFX.Serialize();
+                        }
+
+                        if (x == Fixtures.UserAddress)
+                        {
+                            return Fixtures.AgentStateFx.Serialize();
+                        }
+
+                        var combinationSlotAddressIndex =
+                            Fixtures.AvatarStateFX.combinationSlotAddresses.FindIndex(address => x == address);
+                        if (combinationSlotAddressIndex > -1)
+                        {
+                            return Fixtures.CombinationSlotStatesFx[combinationSlotAddressIndex].Serialize();
+                        }
+
+                        return null;
                     }).ToList(),
                     (_, _) => new FungibleAssetValue(),
                     0));
@@ -109,17 +123,14 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 new Dictionary<string, object>
                 {
                     ["address"] = Fixtures.AvatarAddress.ToString(),
-                    ["combinationSlotState"] = new object[]
+                    ["combinationSlotState"] = Fixtures.CombinationSlotStatesFx.Select(x => new Dictionary<string, object?>
                     {
-                        new Dictionary<string, object>
-                        {
-                            ["address"] = Fixtures.CombinationSlotAddress.ToString(),
-                            ["unlockBlockIndex"] = 0,
-                            ["unlockStage"] = 1,
-                            ["startBlockIndex"] = 0,
-                            ["petId"] = null
-                        }
-                    }
+                        ["address"] = x.address.ToString(),
+                        ["unlockBlockIndex"] = x.UnlockBlockIndex,
+                        ["unlockStage"] = x.UnlockStage,
+                        ["startBlockIndex"] = x.StartBlockIndex,
+                        ["petId"] = x.PetId
+                    }).ToArray<object>(),
                 }
             }
         };

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
@@ -61,7 +61,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             const string query = @"
             {
                 address
-                combinationSlotStates {
+                combinationSlots {
                     address
                     unlockBlockIndex
                     unlockStage
@@ -123,7 +123,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 new Dictionary<string, object>
                 {
                     ["address"] = Fixtures.AvatarAddress.ToString(),
-                    ["combinationSlotStates"] = Fixtures.CombinationSlotStatesFx.Select(x => new Dictionary<string, object?>
+                    ["combinationSlots"] = Fixtures.CombinationSlotStatesFx.Select(x => new Dictionary<string, object?>
                     {
                         ["address"] = x.address.ToString(),
                         ["unlockBlockIndex"] = x.UnlockBlockIndex,

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
@@ -61,7 +61,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             const string query = @"
             {
                 address
-                combinationSlotState {
+                combinationSlotStates {
                     address
                     unlockBlockIndex
                     unlockStage
@@ -123,7 +123,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                 new Dictionary<string, object>
                 {
                     ["address"] = Fixtures.AvatarAddress.ToString(),
-                    ["combinationSlotState"] = Fixtures.CombinationSlotStatesFx.Select(x => new Dictionary<string, object?>
+                    ["combinationSlotStates"] = Fixtures.CombinationSlotStatesFx.Select(x => new Dictionary<string, object?>
                     {
                         ["address"] = x.address.ToString(),
                         ["unlockBlockIndex"] = x.UnlockBlockIndex,

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/AvatarStateTypeTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using GraphQL.Execution;
@@ -53,6 +54,39 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             Assert.Equal(expected, data);
         }
 
+        [Theory]
+        [MemberData(nameof(CombinationSlotSteteMembers))]
+        public async Task QueryWithCombinationSlotState(AvatarState avatarState, Dictionary<string, object> expected)
+        {
+            const string query = @"
+            {
+                address
+                combinationSlotState {
+                    address
+                    unlockBlockIndex
+                    unlockStage
+                    startBlockIndex
+                    petId
+                }
+            }
+            ";
+            var queryResult = await ExecuteQueryAsync<AvatarStateType>(
+                query,
+                source: new AvatarStateType.AvatarStateContext(
+                    avatarState,
+                    addresses => addresses.Select(x =>
+                    {
+                        if (x == Fixtures.AvatarAddress) return Fixtures.AvatarStateFX.Serialize();
+                        if (x == Fixtures.UserAddress) return Fixtures.AgentStateFx.Serialize();
+                        if (x == Fixtures.CombinationSlotAddress) return Fixtures.CombinationSlotStateFx.Serialize();
+                        return null;
+                    }).ToList(),
+                    (_, _) => new FungibleAssetValue(),
+                    0));
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
+            Assert.Equal(expected, data);
+        }
+        
         public static IEnumerable<object[]> Members => new List<object[]>
         {
             new object[]
@@ -65,6 +99,29 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                     ["index"] = 2,
                 },
             },
+        };
+
+        public static IEnumerable<object[]> CombinationSlotSteteMembers = new List<object[]>()
+        {
+            new object[]
+            {
+                Fixtures.AvatarStateFX,
+                new Dictionary<string, object>
+                {
+                    ["address"] = Fixtures.AvatarAddress.ToString(),
+                    ["combinationSlotState"] = new object[]
+                    {
+                        new Dictionary<string, object>
+                        {
+                            ["address"] = Fixtures.CombinationSlotAddress.ToString(),
+                            ["unlockBlockIndex"] = 0,
+                            ["unlockStage"] = 1,
+                            ["startBlockIndex"] = 0,
+                            ["petId"] = null
+                        }
+                    }
+                }
+            }
         };
     }
 }

--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CombinationSlotStateTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CombinationSlotStateTypeTest.cs
@@ -29,9 +29,9 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
             var expected = new Dictionary<string, object>()
             {
                 ["address"] = address.ToString(),
-                ["unlockBlockIndex"] = 0,
+                ["unlockBlockIndex"] = 0L,
                 ["unlockStage"] = 1,
-                ["startBlockIndex"] = 0,
+                ["startBlockIndex"] = 0L,
             };
             Assert.Equal(expected, data);
         }

--- a/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
@@ -111,7 +111,7 @@ namespace NineChronicles.Headless.GraphTypes.States
                 description: "Address list of combination slot.",
                 resolve: context => context.Source.AvatarState.combinationSlotAddresses);
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<CombinationSlotStateType>>>>(
-                "combinationSlotState",
+                "combinationSlotStates",
                 description: "Combination slots.",
                 resolve: context =>
                 {

--- a/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
@@ -110,6 +110,15 @@ namespace NineChronicles.Headless.GraphTypes.States
                 nameof(AvatarState.combinationSlotAddresses),
                 description: "Address list of combination slot.",
                 resolve: context => context.Source.AvatarState.combinationSlotAddresses);
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<CombinationSlotStateType>>>>(
+                "combinationSlotState",
+                description: "Combination slots.",
+                resolve: context => {
+                    var addresses = context.Source.AvatarState.combinationSlotAddresses;
+                    return context.Source.AccountStateGetter(addresses)
+                        .OfType<Dictionary>()
+                        .Select(x => new CombinationSlotState(x));
+                });
             Field<NonNullGraphType<CollectionMapType>>(
                 nameof(AvatarState.itemMap),
                 description: "List of acquired item ID.",

--- a/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
@@ -113,7 +113,8 @@ namespace NineChronicles.Headless.GraphTypes.States
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<CombinationSlotStateType>>>>(
                 "combinationSlotState",
                 description: "Combination slots.",
-                resolve: context => {
+                resolve: context =>
+                {
                     var addresses = context.Source.AvatarState.combinationSlotAddresses;
                     return context.Source.AccountStateGetter(addresses)
                         .OfType<Dictionary>()

--- a/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
@@ -111,7 +111,7 @@ namespace NineChronicles.Headless.GraphTypes.States
                 description: "Address list of combination slot.",
                 resolve: context => context.Source.AvatarState.combinationSlotAddresses);
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<CombinationSlotStateType>>>>(
-                "combinationSlotStates",
+                "combinationSlots",
                 description: "Combination slots.",
                 resolve: context =>
                 {

--- a/NineChronicles.Headless/GraphTypes/States/CombinationSlotStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/CombinationSlotStateType.cs
@@ -12,7 +12,7 @@ namespace NineChronicles.Headless.GraphTypes.States
                 nameof(CombinationSlotState.address),
                 description: "Address of combination slot.",
                 resolve: context => context.Source.address);
-            Field<NonNullGraphType<IntGraphType>>(
+            Field<NonNullGraphType<LongGraphType>>(
                 nameof(CombinationSlotState.UnlockBlockIndex),
                 description: "Block index at the combination slot can be usable.",
                 resolve: context => context.Source.UnlockBlockIndex);
@@ -20,7 +20,7 @@ namespace NineChronicles.Headless.GraphTypes.States
                 nameof(CombinationSlotState.UnlockStage),
                 description: "Stage id at the combination slot unlock.",
                 resolve: context => context.Source.UnlockStage);
-            Field<NonNullGraphType<IntGraphType>>(
+            Field<NonNullGraphType<LongGraphType>>(
                 nameof(CombinationSlotState.StartBlockIndex),
                 description: "Block index at the combination started.",
                 resolve: context => context.Source.StartBlockIndex);

--- a/NineChronicles.Headless/GraphTypes/States/CombinationSlotStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/CombinationSlotStateType.cs
@@ -24,6 +24,10 @@ namespace NineChronicles.Headless.GraphTypes.States
                 nameof(CombinationSlotState.StartBlockIndex),
                 description: "Block index at the combination started.",
                 resolve: context => context.Source.StartBlockIndex);
+            Field<IntGraphType>(
+                nameof(CombinationSlotState.PetId),
+                description: "Pet id used in equipment",
+                resolve: context => context.Source.PetId);
         }
     }
 }


### PR DESCRIPTION
Add CombinationSlot query in AvatarStateType query (resolves #2114)

## Usage
```graphql
avatarState {
    address
    combinationSlotState {
        address
        unlockBlockIndex
        unlockStage
        startBlockIndex
        petId
    }
}
```