### PR TITLE
release: version 4

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
@@ -191,7 +191,9 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         [InlineData(ClaimStakeReward2.ObsoletedIndex, typeof(ClaimStakeReward2))]
         [InlineData(ClaimStakeReward2.ObsoletedIndex + 1, typeof(ClaimStakeReward3))]
         [InlineData(ClaimStakeReward3.ObsoleteBlockIndex, typeof(ClaimStakeReward3))]
-        [InlineData(ClaimStakeReward3.ObsoleteBlockIndex + 1, typeof(ClaimStakeReward))]
+        [InlineData(ClaimStakeReward3.ObsoleteBlockIndex + 1, typeof(ClaimStakeReward4))]
+        [InlineData(ClaimStakeReward4.ObsoleteBlockIndex, typeof(ClaimStakeReward4))]
+        [InlineData(ClaimStakeReward4.ObsoleteBlockIndex + 1, typeof(ClaimStakeReward))]
         [InlineData(long.MaxValue, typeof(ClaimStakeReward))]
         public void ClaimStakeRewardWithBlockIndex(long blockIndex, Type expectedActionType)
         {
@@ -217,8 +219,8 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 
         [Theory]
         [InlineData(0, 0, -1)]
-        [InlineData(1, 4, 0)]
-        [InlineData(5, 5, -1)]
+        [InlineData(1, 5, 0)]
+        [InlineData(6, 6, -1)]
         public void ClaimStakeRewardWithActionVersion(
             int actionVersionMin,
             int actionVersionMax,

--- a/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/TxCommandTest.cs
@@ -103,6 +103,7 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         [InlineData(null, 2, true)]
         [InlineData(null, 3, false)]
         [InlineData(null, 4, true)]
+        [InlineData(null, 5, false)]
         public void Sign_ClaimStakeReward(long? blockIndex, int? actionVersion, bool gas)
         {
             var filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());

--- a/NineChronicles.Headless.Executable/Commands/TxCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/TxCommand.cs
@@ -72,6 +72,7 @@ namespace NineChronicles.Headless.Executable.Commands
                     nameof(ClaimStakeReward1) => new ClaimStakeReward1(),
                     nameof(ClaimStakeReward2) => new ClaimStakeReward2(),
                     nameof(ClaimStakeReward3) => new ClaimStakeReward3(),
+                    nameof(ClaimStakeReward4) => new ClaimStakeReward4(),
                     nameof(ClaimStakeReward) => new ClaimStakeReward(),
                     nameof(TransferAsset) => new TransferAsset(),
                     nameof(MigrateMonsterCollection) => new MigrateMonsterCollection(),

--- a/NineChronicles.Headless/GraphTypes/States/StakeStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/StakeStateType.cs
@@ -56,27 +56,8 @@ namespace NineChronicles.Headless.GraphTypes.States
             Field<NonNullGraphType<LongGraphType>>(
                 "claimableBlockIndex",
                 description: "The block index the user can claim rewards.",
-                resolve: context =>
-                {
-                    var stakeState = context.Source.StakeState;
-                    if (context.Source.BlockIndex >= ActionObsoleteConfig.V100290ObsoleteIndex)
-                    {
-                        if (stakeState.ReceivedBlockIndex > 0)
-                        {
-                            long lastStep = Math.DivRem(
-                                stakeState.ReceivedBlockIndex - stakeState.StartedBlockIndex,
-                                StakeState.RewardInterval,
-                                out _
-                            );
-
-                            return stakeState.StartedBlockIndex + (lastStep + 1) * StakeState.RewardInterval;
-                        }
-
-                        return stakeState.StartedBlockIndex + StakeState.RewardInterval;
-                    }
-
-                    return Math.Max(stakeState.StartedBlockIndex, stakeState.ReceivedBlockIndex) + StakeState.RewardInterval;
-                });
+                resolve: context => context.Source.StakeState.GetClaimableBlockIndex(
+                    context.Source.BlockIndex));
             Field<NonNullGraphType<StakeAchievementsType>>(
                 nameof(StakeState.Achievements),
                 description: "The staking achievements.",


### PR DESCRIPTION
- Bump `lib9c`
- Use `lib9c` logic when calculate some in resolver method of graphql.
- Add more case to tx sign command.