### PR TITLE
feat: store updated states' addresses at least

### DIFF
--- a/Libplanet.Headless/ReducedStore.cs
+++ b/Libplanet.Headless/ReducedStore.cs
@@ -112,7 +112,7 @@ namespace Libplanet.Headless
             TxSuccess reducedTxSuccess = new TxSuccess(
                 txSuccess.BlockHash,
                 txSuccess.TxId,
-                updatedStates: ImmutableDictionary<Address, IValue>.Empty,
+                updatedStates: txSuccess.UpdatedStates.ToImmutableDictionary(pair => pair.Key, _ => (IValue)Null.Value),
                 fungibleAssetsDelta: txSuccess.FungibleAssetsDelta,
                 updatedFungibleAssets: txSuccess.UpdatedFungibleAssets,
                 actionsLogsList: txSuccess.ActionsLogsList


### PR DESCRIPTION
This pull request suggests storing `TxSuccess.UpdatedStates`' addresses at least. When users want to know *REAL UPDATED ADDRESSES*, there is no way to know it because `Transaction.UpdatedAddresses` is deprecated and not trustable, and `TxSuccess.UpdatedStates` doesn't store anything. Then why we used `ReducedStore`? The `TxSuccess.UpdatedStates` was too big to store in gamers' storage. (like a copy of the `/states` directory). Sadly, no gamers have local storage. In addition, it is not big to store only updated addresses.

If this feature is applied, developers can get real updated addresses easily since the applied block index.