### PR TITLE
fix: close xml tag

### DIFF
--- a/Libplanet.Headless/ReducedStore.cs
+++ b/Libplanet.Headless/ReducedStore.cs
@@ -10,7 +10,7 @@ using Libplanet.Tx;
 namespace Libplanet.Headless
 {
     /// <summary>
-    /// A <see cref="IStore"> decorator that reduce space consumption by omitting input calls which
+    /// A <see cref="IStore"/> decorator that reduce space consumption by omitting input calls which
     /// are unused by Nine Chronicles.
     /// <para>Calls on this will be forwarded to its <see cref="InternalStore"/>, except for:</para>
     /// <list type="bullet">


### PR DESCRIPTION
When working on *NineChronicles.Headless* project, I've often seen the `dotnet format` command put dots in awkward places. 😠 

![image](https://github.com/planetarium/NineChronicles.Headless/assets/26626194/19d19567-172d-4cf1-a568-4cb950831742)

While reverting it, I saw the below error. It was because of the `<see cref="IStore">` part. It should be closed like `<see ... />`.

<img width="338" alt="image" src="https://github.com/planetarium/NineChronicles.Headless/assets/26626194/ea4c4f72-d715-4ebe-9886-15313b48e4a2">

After fixing the part, the `dotnet format` command doesn't put dots in awkward places 🤔 . It seems like the `dotnet format`'s bug... but this pull request is enough for this case.