### PR TITLE
fix: correct `ForkableActionEvaluator`'s configuration parsing logic

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -263,7 +263,7 @@ namespace NineChronicles.Headless.Executable
                             var range = new ForkableActionEvaluatorRange();
                             pair.Bind("Range", range);
                             var actionEvaluatorConfiguration =
-                                GetActionEvaluatorConfiguration(configuration.GetSection("ActionEvaluator")) ??
+                                GetActionEvaluatorConfiguration(pair.GetSection("ActionEvaluator")) ??
                                 throw new KeyNotFoundException();
                             return (range, actionEvaluatorConfiguration);
                         }).ToImmutableArray()


### PR DESCRIPTION
This pull request continues from #2140 🙄 