### PR TITLE
ci(gh-actions): check typos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,9 @@ jobs:
                 for file in "${FILES[@]}"; do
                   ajv validate -s appsettings-schema.json -d "$file"
                 done
+    typos:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Check typos
+              uses: crate-ci/typos@v1.15.5

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneMutationTest.cs
@@ -994,7 +994,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
         private Block MakeGenesisBlock(
             Address adminAddress,
-            Currency curreny,
+            Currency currency,
             IImmutableSet<Address> activatedAccounts,
             RankingState0? rankingState = null)
         {
@@ -1018,7 +1018,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                             ),
                             adminAddressState: new AdminState(adminAddress, 1500000),
                             activatedAccountsState: new ActivatedAccountsState(activatedAccounts),
-                            goldCurrencyState: new GoldCurrencyState(curreny),
+                            goldCurrencyState: new GoldCurrencyState(currency),
                             goldDistributions: new GoldDistribution[0],
                             tableSheets: _sheets,
                             pendingActivationStates: new PendingActivationState[] { }

--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -241,7 +241,7 @@ namespace NineChronicles.Headless
                             catch (Exception e)
                             {
                                 // FIXME add logger as property
-                                Log.Error(e, "Skip broadcasting blcok render due to the unexpected exception");
+                                Log.Error(e, "Skip broadcasting block render due to the unexpected exception");
                             }
                         }
                     );

--- a/NineChronicles.Headless/GraphTypes/ActivationStatusMutation.cs
+++ b/NineChronicles.Headless/GraphTypes/ActivationStatusMutation.cs
@@ -56,7 +56,7 @@ namespace NineChronicles.Headless.GraphTypes
                     }
                     catch (ArgumentException ae)
                     {
-                        context.Errors.Add(new ExecutionError("The given key isn't in the correct foramt.", ae));
+                        context.Errors.Add(new ExecutionError("The given key isn't in the correct format.", ae));
                         return false;
                     }
                     catch (Exception e)

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,18 @@
+[default]
+extend-ignore-re = [
+    "\\\"([a-zA-Z0-9][a-zA-Z0-9])+\\\"",  # for hexadecimal string values.
+    "2nd"
+]
+
+[default.extend-identifiers]
+fo = "fo"  # FungibleOrder
+
+[default.extend-words]
+ba = "ba"  # byte array
+oce = "oce"  # OperationCanceledException
+Equipments = "Equipments"  # FIXME: Equipment is noncount word but our team doesn't have the policy about it.
+
+[files]
+extend-exclude = [
+    "Lib9c/*"
+]


### PR DESCRIPTION
This pull request resolves https://github.com/planetarium/NineChronicles.Headless/issues/1329.
This pull request suggests to check typos with GitHub Actions, [`typos` CLI tool](https://github.com/crate-ci/typos).

You can see the configuration file's spec at https://github.com/crate-ci/typos/blob/master/docs/reference.md#config-fields.
You can correct typos easily by running `typos . -w`.

p.s. I had tried to apply this tool in https://github.com/planetarium/NineChronicles.Headless/pull/1369, but there was no configurable option to ignore base64 or hexadecimal strings at that time 🙄 