### PR TITLE
ci(gh-actions): disable tagging lib9c-stateservice

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -71,7 +71,6 @@ jobs:
       matrix:
         docker:
           - repo: planetariumhq/ninechronicles-headless
-          - repo: planetariumhq/lib9c-stateservice
     if: github.ref_type == 'tag' || github.event.inputs.imageTag != ''
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request diables tagging lib9c-stateservice. I forgot removing the part in #2164 