### PR TITLE
track client count by device

### DIFF
--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -75,7 +75,7 @@ namespace NineChronicles.Headless
                 description: "Number of RPC clients connected.");
             meter.CreateObservableGauge(
                 "ninechronicles_rpc_clients_count_by_device",
-                () => new []
+                () => new[]
                 {
                     new Measurement<int>(this.GetClientsCountByDevice("mobile"), new[] { new KeyValuePair<string, object?>("device", "mobile") }),
                     new Measurement<int>(this.GetClientsCountByDevice("pc"), new[] { new KeyValuePair<string, object?>("device", "pc") }),

--- a/NineChronicles.Headless/ActionEvaluationPublisher.cs
+++ b/NineChronicles.Headless/ActionEvaluationPublisher.cs
@@ -74,17 +74,14 @@ namespace NineChronicles.Headless
                 () => this.GetClients().Count,
                 description: "Number of RPC clients connected.");
             meter.CreateObservableGauge(
-                "ninechronicles_rpc_clients_mobile_count",
-                () => this.GetClientsCountByDevice("mobile"),
-                description: "Number of mobile RPC clients connected.");
-            meter.CreateObservableGauge(
-                "ninechronicles_rpc_clients_pc_count",
-                () => this.GetClientsCountByDevice("pc"),
-                description: "Number of pc RPC clients connected.");
-            meter.CreateObservableGauge(
-                "ninechronicles_rpc_clients_other_count",
-                () => this.GetClientsCountByDevice("other"),
-                description: "Number of other RPC clients connected.");
+                "ninechronicles_rpc_clients_count_by_device",
+                () => new []
+                {
+                    new Measurement<int>(this.GetClientsCountByDevice("mobile"), new[] { new KeyValuePair<string, object?>("device", "mobile") }),
+                    new Measurement<int>(this.GetClientsCountByDevice("pc"), new[] { new KeyValuePair<string, object?>("device", "pc") }),
+                    new Measurement<int>(this.GetClientsCountByDevice("other"), new[] { new KeyValuePair<string, object?>("device", "other") }),
+                },
+                description: "Number of RPC clients connected by device.");
 
             ActionEvaluationHub.OnClientDisconnected += RemoveClient;
         }

--- a/NineChronicles.Headless/GraphTypes/RpcInformationQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/RpcInformationQuery.cs
@@ -34,7 +34,7 @@ namespace NineChronicles.Headless.GraphTypes
                     string device = context.GetArgument<string>("device");
                     return publisher.GetClientsCountByDevice(device);
                 });
-            Field<NonNullGraphType<ListGraphType<AddressType>>>(
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<AddressType>>>>(
                 name: "clientsByDevice",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<StringGraphType>>

--- a/NineChronicles.Headless/GraphTypes/RpcInformationQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/RpcInformationQuery.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQL;
 using GraphQL.Types;
 using Libplanet.Explorer.GraphTypes;
 using Log = Serilog.Log;
@@ -19,6 +20,34 @@ namespace NineChronicles.Headless.GraphTypes
                 name: "clients",
                 description: "List of address connected to this node.",
                 resolve: context => publisher.GetClients());
+            Field<NonNullGraphType<IntGraphType>>(
+                name: "totalCountByDevice",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Name = "device"
+                    }
+                ),
+                description: "total count by connected to this node.",
+                resolve: context =>
+                {
+                    string device = context.GetArgument<string>("device");
+                    return publisher.GetClientsCountByDevice(device);
+                });
+            Field<NonNullGraphType<ListGraphType<AddressType>>>(
+                name: "clientsByDevice",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Name = "device"
+                    }
+                ),
+                description: "clients connected to this node by device.",
+                resolve: context =>
+                {
+                    string device = context.GetArgument<string>("device");
+                    return publisher.GetClientsByDevice(device);
+                });
         }
     }
 }

--- a/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using System.Threading.Tasks;
@@ -11,20 +13,36 @@ namespace NineChronicles.Headless.Middleware
     public class GrpcCaptureMiddleware : Interceptor
     {
         private readonly ILogger _logger;
+        private ActionEvaluationPublisher _actionEvaluationPublisher;
 
-        public GrpcCaptureMiddleware()
+        public GrpcCaptureMiddleware(ActionEvaluationPublisher actionEvaluationPublisher)
         {
             _logger = Log.Logger.ForContext<GrpcCaptureMiddleware>();
+            _actionEvaluationPublisher = actionEvaluationPublisher;
         }
 
         public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
             TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
         {
-            if (context.Method is "/IBlockChainService/AddClient" or "/IBlockChainService/GetNextTxNonce" && request is byte[] addressBytes)
+            if (context.Method is "/IBlockChainService/AddClient" && request is byte[] addClientAddressBytes)
             {
-                var agent = new Address(addressBytes);
+                var agent = new Address(addClientAddressBytes);
                 var httpContext = context.GetHttpContext();
                 var ipAddress = httpContext.Connection.RemoteIpAddress + ":" + httpContext.Connection.RemotePort;
+                var uaHeader = httpContext.Request.Headers["User-Agent"].FirstOrDefault()!;
+                AddClientByDevice(agent, uaHeader);
+
+                _logger.Information(
+                    "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent} Header: {Header}",
+                    ipAddress, context.Method, agent, uaHeader);
+            }
+
+            if (context.Method is "/IBlockChainService/GetNextTxNonce" && request is byte[] getNextTxNonceAddressBytes)
+            {
+                var agent = new Address(getNextTxNonceAddressBytes);
+                var httpContext = context.GetHttpContext();
+                var ipAddress = httpContext.Connection.RemoteIpAddress + ":" + httpContext.Connection.RemotePort;
+
                 _logger.Information(
                     "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent}",
                     ipAddress, context.Method, agent);
@@ -39,12 +57,39 @@ namespace NineChronicles.Headless.Middleware
                     : "NoAction";
                 var httpContext = context.GetHttpContext();
                 var ipAddress = httpContext.Connection.RemoteIpAddress + ":" + httpContext.Connection.RemotePort;
+                var uaHeader = httpContext.Request.Headers["User-Agent"].FirstOrDefault()!;
+                if (!_actionEvaluationPublisher.GetClients().Contains(tx.Signer))
+                {
+                    await _actionEvaluationPublisher.AddClient(tx.Signer);
+                    AddClientByDevice(tx.Signer, uaHeader);
+                }
+
                 _logger.Information(
                     "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent} Action: {Action}",
                     ipAddress, context.Method, tx.Signer, actionName);
             }
 
             return await base.UnaryServerHandler(request, context, continuation);
+        }
+
+        private void AddClientByDevice(Address agentAddress, string userAgentHeader)
+        {
+            if (userAgentHeader.Contains("windows", StringComparison.InvariantCultureIgnoreCase)
+                || userAgentHeader.Contains("macintosh", StringComparison.InvariantCultureIgnoreCase)
+                || userAgentHeader.Contains("linux", StringComparison.InvariantCultureIgnoreCase))
+            {
+                _actionEvaluationPublisher.AddClientByDevice(agentAddress, "pc");
+            }
+            else if (userAgentHeader.Contains("android", StringComparison.InvariantCultureIgnoreCase)
+                     || userAgentHeader.Contains("iphone", StringComparison.InvariantCultureIgnoreCase)
+                     || userAgentHeader.Contains("ipad", StringComparison.InvariantCultureIgnoreCase))
+            {
+                _actionEvaluationPublisher.AddClientByDevice(agentAddress, "mobile");
+            }
+            else
+            {
+                _actionEvaluationPublisher.AddClientByDevice(agentAddress, "other");
+            }
         }
     }
 }


### PR DESCRIPTION
This PR utilizes `GrpcCaptureMiddleware` to track RPC clients by device (PC/mobile/other). 

In order to use the `GrpcCaptureMiddleware`, `ActionEvaluationPublisher` needs to be passed down to the middleware so I've made some adjustments in `Program.cs` when `UseNineChroniclesRPC()` method is called.

### Device metrics in grafana
![image](https://github.com/planetarium/NineChronicles.Headless/assets/42176649/e5fb6320-4825-418d-93a2-0851aa585133)
