### PR TITLE
Introduce runes query in avatarState GraphQL

### DIFF
--- a/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/AvatarStateType.cs
@@ -1,11 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bencodex.Types;
 using GraphQL.Types;
-using Libplanet.Action;
 using Libplanet.Explorer.GraphTypes;
 using Libplanet.Action.State;
+using Nekoyume.Action;
 using Nekoyume.Model.State;
+using Nekoyume.TableData;
 using NineChronicles.Headless.GraphTypes.States.Models;
 using NineChronicles.Headless.GraphTypes.States.Models.World;
 using NineChronicles.Headless.GraphTypes.States.Models.Item;
@@ -106,6 +108,27 @@ namespace NineChronicles.Headless.GraphTypes.States
                 nameof(AvatarState.inventory),
                 description: "Avatar inventory.",
                 resolve: context => context.Source.AvatarState.inventory);
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<RuneStateType>>>>(
+                name: "runes",
+                description: "Rune list of avatar",
+                resolve: context =>
+                {
+                    var runeSheet = context.Source.AccountState.GetSheet<RuneSheet>();
+                    var runeList = new List<RuneState>();
+                    foreach (var rune in runeSheet)
+                    {
+                        var runeState = context.Source.GetState(
+                            RuneState.DeriveAddress(context.Source.AvatarState.address, rune.Id)
+                        );
+                        if (runeState is not null)
+                        {
+                            runeList.Add(new RuneState(runeState as List));
+                        }
+                    }
+
+                    return runeList;
+                }
+            );
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<AddressType>>>>(
                 nameof(AvatarState.combinationSlotAddresses),
                 description: "Address list of combination slot.",

--- a/NineChronicles.Headless/GraphTypes/States/RuneStateType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/RuneStateType.cs
@@ -1,0 +1,21 @@
+using GraphQL.Types;
+using Nekoyume.Model.State;
+
+namespace NineChronicles.Headless.GraphTypes.States;
+
+public class RuneStateType : ObjectGraphType<RuneState>
+{
+    public RuneStateType()
+    {
+        Field<NonNullGraphType<IntGraphType>>(
+            nameof(RuneState.RuneId),
+            description: "ID of rune.",
+            resolve: context => context.Source.RuneId
+        );
+        Field<NonNullGraphType<IntGraphType>>(
+            nameof(RuneState.Level),
+            description: "Level of this rune.",
+            resolve: context => context.Source.Level
+        );
+    }
+}


### PR DESCRIPTION
To get runes in avatar, I created new `RuneStateType` and include it into `avatarState` query.
`runes` is not inside inventory because it's not in [Inventory](https://github.com/planetarium/lib9c/blob/development/Lib9c/Model/Item/Inventory.cs), but in [avatar](https://github.com/planetarium/lib9c/blob/07fad34fa36e03af8cf317938812eb2667592b85/Lib9c/Model/State/RuneState.cs#L9-L10).

Query looks like:
```graphql
query {
  stateQuery {
    avatar (avatarAddress:"0xDD21DCc1A9d393550A49999363e383c8409Ee1A2") {
      runes {
        runeId
        level
      }
    }
  }
}
```

and the result looks like:
```json
{
  "data": {
    "stateQuery": {
      "avatar": {
        "runes": [
          {
            "runeId": 10001,
            "level": 9
          },
          {
            "runeId": 10002,
            "level": 79
          },
          {
            "runeId": 10003,
            "level": 42
          },
          ...
        ]
      }
    }
  },
  "extensions": {}
}
```

![Screenshot from 2023-08-09 01-05-07](https://github.com/planetarium/NineChronicles.Headless/assets/3654082/74b94b62-c1e7-4e08-91b6-58915dfe9cb2)
