### PR TITLE
[WIP] Add query/subscription to query transaction with action type filter

### DIFF
--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -1,10 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Bencodex;
+using Bencodex.Json;
 using GraphQL;
 using GraphQL.Types;
 using Bencodex.Types;
+using GraphQL.NewtonsoftJson;
 using Lib9c;
 using Libplanet.Blockchain;
 using Libplanet.Types.Tx;
@@ -56,6 +63,65 @@ namespace NineChronicles.Headless.GraphTypes
 
                     var txId = context.GetArgument<TxId>("txId");
                     return blockChain.GetTransaction(txId);
+                }
+            );
+
+            IEnumerable<Block> ListBlocks(BlockChain chain, long from, long limit)
+            {
+                if (chain.Count <= from)
+                {
+                    yield break;
+                }
+
+                var block = chain[from];
+                for (var i = 0; i < limit; i++)
+                {
+                    if (block is null)
+                    {
+                        yield break;
+                    }
+
+                    yield return block;
+
+                    block = block != chain.Tip ? chain[block.Index + 1] : null;
+                }
+            }
+            Field<ListGraphType<TransactionType>>(
+                name: "ncTransactions",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<LongGraphType>>
+                        { Name = "startingBlockIndex", Description = "start block index for query tx."},
+                    new QueryArgument<NonNullGraphType<LongGraphType>>
+                        { Name = "limit", Description = "number of block to query."},
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                        { Name = "actionType", Description = "filter tx by having actions' type" }
+                ),
+                resolve: context =>
+                {
+                    if (standaloneContext.BlockChain is not BlockChain blockChain)
+                    {
+                         throw new ExecutionError(
+                             $"{nameof(StandaloneContext)}.{nameof(StandaloneContext.BlockChain)} was not set yet!");
+                    }
+
+                    var startingBlockIndex = context.GetArgument<long>("startingBlockIndex");
+                    var limit = context.GetArgument<long>("limit");
+                    var actionType = context.GetArgument<string>("actionType");
+
+                    var blocks = ListBlocks(blockChain, startingBlockIndex, limit);
+                    var transactions = blocks
+                        .SelectMany((block) => block.Transactions)
+                        .Where((tx) => tx.Actions.Any(rawAction =>
+                        {
+                            if (rawAction is not Dictionary action || action["type_id"] is not Text typeId)
+                            {
+                                return false;
+                            }
+
+                            return typeId == actionType;
+                        }));
+
+                    return transactions;
                 }
             );
 


### PR DESCRIPTION
- Add ncTransactions query that can query transactions with action type filter
- Add tx subscription emitting transaction, txResults having specific action type


## Example (NOT FIXED NAMING for fields, arguments)

```graphql
subscription {
  tx {
    transaction {
		id
	}
	transactionResult {
		blockHash
		blockIndex
		txSuccess
	}
  }
}
```


```graphql
query {
	transaction {
		ncTransactions(startingBlockIndex, limit, actionType) {
			id
			action
		}
	}
}
```