### PR TITLE
Add CurrencyTicker in RewardInfo to distinquish currency

### DIFF
--- a/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
+++ b/NineChronicles.Headless.Executable.Tests/Commands/ActionCommandTest.cs
@@ -192,7 +192,9 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
         [InlineData(ClaimStakeReward3.ObsoleteBlockIndex, typeof(ClaimStakeReward3))]
         [InlineData(ClaimStakeReward3.ObsoleteBlockIndex + 1, typeof(ClaimStakeReward4))]
         [InlineData(ClaimStakeReward4.ObsoleteBlockIndex, typeof(ClaimStakeReward4))]
-        [InlineData(ClaimStakeReward4.ObsoleteBlockIndex + 1, typeof(ClaimStakeReward))]
+        [InlineData(ClaimStakeReward4.ObsoleteBlockIndex + 1, typeof(ClaimStakeReward5))]
+        [InlineData(ClaimStakeReward5.ObsoleteBlockIndex, typeof(ClaimStakeReward5))]
+        [InlineData(ClaimStakeReward5.ObsoleteBlockIndex + 1, typeof(ClaimStakeReward))]
         [InlineData(long.MaxValue, typeof(ClaimStakeReward))]
         public void ClaimStakeRewardWithBlockIndex(long blockIndex, Type expectedActionType)
         {
@@ -218,8 +220,8 @@ namespace NineChronicles.Headless.Executable.Tests.Commands
 
         [Theory]
         [InlineData(0, 0, -1)]
-        [InlineData(1, 5, 0)]
-        [InlineData(6, 6, -1)]
+        [InlineData(1, 6, 0)]
+        [InlineData(7, 7, -1)]
         public void ClaimStakeRewardWithActionVersion(
             int actionVersionMin,
             int actionVersionMax,

--- a/NineChronicles.Headless.Executable/Commands/TxCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/TxCommand.cs
@@ -74,6 +74,7 @@ namespace NineChronicles.Headless.Executable.Commands
                     nameof(ClaimStakeReward2) => new ClaimStakeReward2(),
                     nameof(ClaimStakeReward3) => new ClaimStakeReward3(),
                     nameof(ClaimStakeReward4) => new ClaimStakeReward4(),
+                    nameof(ClaimStakeReward5) => new ClaimStakeReward5(),
                     nameof(ClaimStakeReward) => new ClaimStakeReward(),
                     nameof(TransferAsset) => new TransferAsset(),
                     nameof(MigrateMonsterCollection) => new MigrateMonsterCollection(),

--- a/NineChronicles.Headless.Executable/appsettings.mainnet.json
+++ b/NineChronicles.Headless.Executable/appsettings.mainnet.json
@@ -89,10 +89,6 @@
         "GraphQLHost": "localhost",
         "GraphQLPort": 31280,
         "NoCors": true,
-        "ChainTipStaleBehaviorType": "reboot",
-        "ActionEvaluator": {
-            "type": "RemoteActionEvaluator",
-            "stateServiceEndpoint": "http://localhost:11111/evaluation"
-        }
+        "ChainTipStaleBehaviorType": "reboot"
     }
 }

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardInfoType.cs
@@ -29,7 +29,7 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Table
                 nameof(StakeRegularRewardSheet.RewardInfo.CurrencyDecimalPlaces),
                 resolve: context => context.Source.CurrencyDecimalPlaces
             );
-            Field<DecimalGraphType>(
+            Field<NonNullGraphType<DecimalGraphType>>(
                 nameof(StakeRegularRewardSheet.RewardInfo.DecimalRate),
                 resolve: context => context.Source.DecimalRate
             );

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardInfoType.cs
@@ -11,19 +11,28 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Table
                 nameof(StakeRegularRewardSheet.RewardInfo.ItemId),
                 resolve: context => context.Source.ItemId
             );
+#pragma warning disable CS0618
             Field<NonNullGraphType<IntGraphType>>(
                 nameof(StakeRegularRewardSheet.RewardInfo.Rate),
                 resolve: context => context.Source.Rate
             );
+#pragma warning restore CS0618
             Field<NonNullGraphType<StakeRewardEnumType>>(
                 nameof(StakeRegularRewardSheet.RewardInfo.Type),
                 resolve: context => context.Source.Type
             );
-            Field<StakeRewardEnumType>(
+            Field<StringGraphType>(
                 nameof(StakeRegularRewardSheet.RewardInfo.CurrencyTicker),
                 resolve: context => context.Source.CurrencyTicker
             );
-
+            Field<IntGraphType>(
+                nameof(StakeRegularRewardSheet.RewardInfo.CurrencyDecimalPlaces),
+                resolve: context => context.Source.CurrencyDecimalPlaces
+            );
+            Field<DecimalGraphType>(
+                nameof(StakeRegularRewardSheet.RewardInfo.DecimalRate),
+                resolve: context => context.Source.DecimalRate
+            );
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardInfoType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Table/StakeRegularRewardInfoType.cs
@@ -17,7 +17,13 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Table
             );
             Field<NonNullGraphType<StakeRewardEnumType>>(
                 nameof(StakeRegularRewardSheet.RewardInfo.Type),
-                resolve: context => context.Source.Type);
+                resolve: context => context.Source.Type
+            );
+            Field<StakeRewardEnumType>(
+                nameof(StakeRegularRewardSheet.RewardInfo.CurrencyTicker),
+                resolve: context => context.Source.CurrencyTicker
+            );
+
         }
     }
 }


### PR DESCRIPTION
Please refer to this issue. https://github.com/planetarium/9c-launcher/issues/2279

To put it simply, in order to print "Currency" Type of reward in Monster Collection,
Launcher needs extra field for FAV identifier. so I added a field.

This pull request based on https://github.com/planetarium/lib9c/pull/2071.