### PR TITLE
Add `itemSubType` argument to `InventoryType.equipments` field

### DIFF
--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/InventoryType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/InventoryType.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using GraphQL;
 using GraphQL.Types;
 using Nekoyume.Model.Item;
+using NineChronicles.Headless.GraphTypes.States.Models.Item.Enum;
 
 namespace NineChronicles.Headless.GraphTypes.States.Models.Item
 {
@@ -26,15 +27,38 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
                     {
                         Name = "equipped",
                         Description = "filter equipped inventory item"
+                    },
+                    new QueryArgument<ItemSubTypeEnumType>
+                    {
+                        Name = "itemSubType",
+                        Description = "An item subtype for fetching only equipment where " +
+                                      "its subtype is the same. If it wasn't given, you'll " +
+                                      "get all equipment without relationship to the subtype."
                     }),
                 resolve: context =>
                 {
                     var equipments = context.Source.Equipments;
                     var equippedFilter = context.GetArgument<bool?>("equipped");
+                    var itemSubTypeFilter = context.GetArgument<ItemSubType?>("itemSubType");
                     if (equippedFilter.HasValue)
                     {
                         equipments = equipments.Where(x => x.equipped == equippedFilter.Value).ToList();
                     }
+
+                    if (itemSubTypeFilter is not null)
+                    {
+                        equipments = equipments.Where(equipment => equipment.ItemSubType == itemSubTypeFilter);
+                    }
+<<<<<<< Updated upstream
+=======
+
+                    if (itemIdsFilter is not null)
+                    {
+                        var set = itemIdsFilter.ToHashSet();
+                        equipments = equipments.Where(equipment => set.Contains(equipment.ItemId));
+                    }
+>>>>>>> Stashed changes
+
                     return equipments;
                 }
             );

--- a/NineChronicles.Headless/GraphTypes/States/Models/Item/InventoryType.cs
+++ b/NineChronicles.Headless/GraphTypes/States/Models/Item/InventoryType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using GraphQL;
@@ -34,12 +35,19 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
                         Description = "An item subtype for fetching only equipment where " +
                                       "its subtype is the same. If it wasn't given, you'll " +
                                       "get all equipment without relationship to the subtype."
+                    },
+                    new QueryArgument<ListGraphType<NonNullGraphType<GuidGraphType>>>
+                    {
+                        Name = "itemIds",
+                        Description = "ItemIds for fetching only equipment where id is in " +
+                                      "the given argument."
                     }),
                 resolve: context =>
                 {
                     var equipments = context.Source.Equipments;
                     var equippedFilter = context.GetArgument<bool?>("equipped");
                     var itemSubTypeFilter = context.GetArgument<ItemSubType?>("itemSubType");
+                    var itemIdsFilter = context.GetArgument<Guid[]?>("itemIds");
                     if (equippedFilter.HasValue)
                     {
                         equipments = equipments.Where(x => x.equipped == equippedFilter.Value).ToList();
@@ -49,15 +57,12 @@ namespace NineChronicles.Headless.GraphTypes.States.Models.Item
                     {
                         equipments = equipments.Where(equipment => equipment.ItemSubType == itemSubTypeFilter);
                     }
-<<<<<<< Updated upstream
-=======
 
                     if (itemIdsFilter is not null)
                     {
                         var set = itemIdsFilter.ToHashSet();
                         equipments = equipments.Where(equipment => set.Contains(equipment.ItemId));
                     }
->>>>>>> Stashed changes
 
                     return equipments;
                 }


### PR DESCRIPTION
This pull request resolves https://github.com/planetarium/NineChronicles.Headless/issues/2189

![image](https://github.com/planetarium/NineChronicles.Headless/assets/26626194/7257a3fa-be94-40a7-b54c-7a70a6f66c8f)
