### PR TITLE
Revert "Add AssemblyName to Executable to make shortcut naming (#2173)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ RUN apt-get update \
 
 VOLUME /data
 
-ENTRYPOINT ["./ncd"]
+ENTRYPOINT ["dotnet", "NineChronicles.Headless.Executable.dll"]

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -37,4 +37,4 @@ RUN apt-get update \
 
 VOLUME /data
 
-ENTRYPOINT ["./ncd"]
+ENTRYPOINT ["dotnet", "NineChronicles.Headless.Executable.dll"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -37,4 +37,4 @@ RUN apt-get update \
 
 VOLUME /data
 
-ENTRYPOINT ["./ncd"]
+ENTRYPOINT ["dotnet", "NineChronicles.Headless.Executable.dll"]

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -10,8 +10,6 @@
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <AssemblyName>ncd</AssemblyName>
-    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'DevEx' ">


### PR DESCRIPTION
This reverts commit a2f38717cae8dcec4bc2593c31f2d607c1219502.

We should analyze how to bypass the Native errors.