### PR TITLE
add account management feature

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -378,7 +378,7 @@ namespace NineChronicles.Headless.Executable
                             : (GraphQLNodeServiceProperties.MagicOnionHttpOptions?)null,
                     };
 
-                    var graphQLService = new GraphQLService(graphQLNodeServiceProperties);
+                    var graphQLService = new GraphQLService(graphQLNodeServiceProperties, standaloneContext, configuration);
                     hostBuilder = graphQLService.Configure(hostBuilder);
                 }
 
@@ -511,9 +511,12 @@ namespace NineChronicles.Headless.Executable
                         context,
                         new ConcurrentDictionary<string, Sentry.ITransaction>()
                     );
+
                     hostBuilder.UseNineChroniclesRPC(
                         rpcProperties,
-                        publisher
+                        publisher,
+                        standaloneContext,
+                        configuration
                     );
                 }
 

--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -122,5 +122,11 @@
             "ContentType": "application/json",
             "StatusCode": 403
         }
+    },
+    "MultiAccountManaging": {
+        "EnableManaging": false,
+        "ManagementTimeMinutes": 10,
+        "TxIntervalMinutes": 10,
+        "ThresholdCount": 50
     }
 }

--- a/NineChronicles.Headless.Tests/GraphQLStartupTest.cs
+++ b/NineChronicles.Headless.Tests/GraphQLStartupTest.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
 using Xunit;
 
 namespace NineChronicles.Headless.Tests
@@ -14,7 +15,8 @@ namespace NineChronicles.Headless.Tests
         public GraphQLStartupTest()
         {
             _configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
-            _startup = new GraphQLService.GraphQLStartup(_configuration);
+            var standaloneContext = CreateStandaloneContext();
+            _startup = new GraphQLService.GraphQLStartup(_configuration, standaloneContext);
         }
 
         [Theory]

--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -168,9 +168,10 @@ namespace NineChronicles.Headless
 
                 // Capture requests
                 Dictionary<string, HashSet<Address>> ipSignerList = new();
-                app.UseMiddleware<HttpCaptureMiddleware>(
+                app.UseMiddleware<HttpMultiAccountManagementMiddleware>(
                     StandaloneContext,
                     ipSignerList);
+                app.UseMiddleware<HttpCaptureMiddleware>();
 
                 app.UseMiddleware<LocalAuthenticationMiddleware>();
                 if (Configuration[NoCorsKey] is null)

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -95,10 +95,11 @@ namespace NineChronicles.Headless
                     services.AddGrpc(options =>
                     {
                         options.MaxReceiveMessageSize = null;
-                        options.Interceptors.Add<GrpcCaptureMiddleware>(
+                        options.Interceptors.Add<GrpMultiAccountManagementMiddleware>(
                             standaloneContext,
                             ipSignerList,
                             actionEvaluationPublisher);
+                        options.Interceptors.Add<GrpcCaptureMiddleware>(actionEvaluationPublisher);
                     });
                     services.AddMagicOnion();
                     services.AddSingleton(_ => actionEvaluationPublisher);

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -1,15 +1,19 @@
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NineChronicles.Headless.Properties;
 using System.Net;
 using Lib9c.Formatters;
 using Libplanet.Action;
+using Libplanet.Crypto;
 using Libplanet.Headless.Hosting;
 using MessagePack;
 using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
 using Nekoyume.Action;
 using NineChronicles.Headless.Middleware;
 using NineChronicles.Headless.Services;
@@ -68,7 +72,9 @@ namespace NineChronicles.Headless
         public static IHostBuilder UseNineChroniclesRPC(
             this IHostBuilder builder,
             RpcNodeServiceProperties properties,
-            ActionEvaluationPublisher actionEvaluationPublisher
+            ActionEvaluationPublisher actionEvaluationPublisher,
+            StandaloneContext standaloneContext,
+            IConfiguration configuration
         )
         {
             var context = new RpcContext
@@ -79,11 +85,20 @@ namespace NineChronicles.Headless
             return builder
                 .ConfigureServices(services =>
                 {
+                    Dictionary<string, HashSet<Address>> ipSignerList = new();
+                    if (Convert.ToBoolean(configuration.GetSection("MultiAccountManaging")["EnableManaging"]))
+                    {
+                        services.Configure<MultiAccountManagerProperties>(configuration.GetSection("MultiAccountManaging"));
+                    }
+
                     services.AddSingleton(_ => context);
                     services.AddGrpc(options =>
                     {
                         options.MaxReceiveMessageSize = null;
-                        options.Interceptors.Add<GrpcCaptureMiddleware>(actionEvaluationPublisher);
+                        options.Interceptors.Add<GrpcCaptureMiddleware>(
+                            standaloneContext,
+                            ipSignerList,
+                            actionEvaluationPublisher);
                     });
                     services.AddMagicOnion();
                     services.AddSingleton(_ => actionEvaluationPublisher);

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -95,7 +95,7 @@ namespace NineChronicles.Headless
                     services.AddGrpc(options =>
                     {
                         options.MaxReceiveMessageSize = null;
-                        options.Interceptors.Add<GrpMultiAccountManagementMiddleware>(
+                        options.Interceptors.Add<GrpcMultiAccountManagementMiddleware>(
                             standaloneContext,
                             ipSignerList,
                             actionEvaluationPublisher);

--- a/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
@@ -182,9 +182,9 @@ namespace NineChronicles.Headless.Middleware
                                     $"[GRPC-REQUEST-CAPTURE] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
                                 RestoreMultiAccount(agent);
                                 MultiAccountTxIntervalTracker[agent] =
-                                    DateTimeOffset.Now.AddMinutes(-(int)_options.Value.TxIntervalMinutes!);
+                                    DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes);
                                 _logger.Information(
-                                    $"[GRPC-REQUEST-CAPTURE] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes(-(int)_options.Value.TxIntervalMinutes!)}.");
+                                    $"[GRPC-REQUEST-CAPTURE] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes)}.");
                             }
                             else
                             {

--- a/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Types.Tx;
-using Microsoft.Extensions.Options;
-using NineChronicles.Headless.Properties;
 using Serilog;
 using static NineChronicles.Headless.NCActionUtils;
 
@@ -15,36 +12,13 @@ namespace NineChronicles.Headless.Middleware
 {
     public class GrpcCaptureMiddleware : Interceptor
     {
-        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountTxIntervalTracker = new();
-        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountManagementList = new();
         private readonly ILogger _logger;
-        private StandaloneContext _standaloneContext;
-        private readonly Dictionary<string, HashSet<Address>> _ipSignerList;
         private readonly ActionEvaluationPublisher _actionEvaluationPublisher;
-        private readonly IOptions<MultiAccountManagerProperties> _options;
 
-        public GrpcCaptureMiddleware(
-            StandaloneContext standaloneContext,
-            Dictionary<string,
-            HashSet<Address>> ipSignerList,
-            ActionEvaluationPublisher actionEvaluationPublisher,
-            IOptions<MultiAccountManagerProperties> options)
+        public GrpcCaptureMiddleware(ActionEvaluationPublisher actionEvaluationPublisher)
         {
             _logger = Log.Logger.ForContext<GrpcCaptureMiddleware>();
-            _standaloneContext = standaloneContext;
-            _ipSignerList = ipSignerList;
             _actionEvaluationPublisher = actionEvaluationPublisher;
-            _options = options;
-        }
-
-        private static void ManageMultiAccount(Address agent)
-        {
-            MultiAccountManagementList.Add(agent, DateTimeOffset.Now);
-        }
-
-        private static void RestoreMultiAccount(Address agent)
-        {
-            MultiAccountManagementList.Remove(agent);
         }
 
         public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
@@ -61,26 +35,6 @@ namespace NineChronicles.Headless.Middleware
                 _logger.Information(
                     "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent} Header: {Header}",
                     ipAddress, context.Method, agent, uaHeader);
-
-                if (_options.Value.EnableManaging)
-                {
-                    if (!_ipSignerList.ContainsKey(httpContext.Connection.RemoteIpAddress!.ToString()))
-                    {
-                        _logger.Information(
-                            "[GRPC-REQUEST-CAPTURE] Creating a new list for IP: {IP}",
-                            httpContext.Connection.RemoteIpAddress!.ToString());
-                        _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()] = new HashSet<Address>();
-                    }
-                    else
-                    {
-                        _logger.Information(
-                            "[GRPC-REQUEST-CAPTURE] List already created for IP: {IP} Count: {Count}",
-                            httpContext.Connection.RemoteIpAddress!.ToString(),
-                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count);
-                    }
-
-                    _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Add(agent);
-                }
             }
 
             if (context.Method is "/IBlockChainService/GetNextTxNonce" && request is byte[] getNextTxNonceAddressBytes)
@@ -88,32 +42,10 @@ namespace NineChronicles.Headless.Middleware
                 var agent = new Address(getNextTxNonceAddressBytes);
                 var httpContext = context.GetHttpContext();
                 var ipAddress = httpContext.Connection.RemoteIpAddress + ":" + httpContext.Connection.RemotePort;
-                var uaHeader = httpContext.Request.Headers["User-Agent"].FirstOrDefault()!;
-                AddClientByDevice(agent, uaHeader);
 
                 _logger.Information(
-                    "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent} Header: {Header}",
-                    ipAddress, context.Method, agent, uaHeader);
-
-                if (_options.Value.EnableManaging)
-                {
-                    if (!_ipSignerList.ContainsKey(httpContext.Connection.RemoteIpAddress!.ToString()))
-                    {
-                        _logger.Information(
-                            "[GRPC-REQUEST-CAPTURE] Creating a new list for IP: {IP}",
-                            httpContext.Connection.RemoteIpAddress!.ToString());
-                        _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()] = new HashSet<Address>();
-                    }
-                    else
-                    {
-                        _logger.Information(
-                            "[GRPC-REQUEST-CAPTURE] List already created for IP: {IP} Count: {Count}",
-                            httpContext.Connection.RemoteIpAddress!.ToString(),
-                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count);
-                    }
-
-                    _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Add(agent);
-                }
+                    "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent}",
+                    ipAddress, context.Method, agent);
             }
 
             if (context.Method is "/IBlockChainService/PutTransaction" && request is byte[] txBytes)
@@ -130,70 +62,6 @@ namespace NineChronicles.Headless.Middleware
                 {
                     await _actionEvaluationPublisher.AddClient(tx.Signer);
                     AddClientByDevice(tx.Signer, uaHeader);
-                }
-
-                if (_options.Value.EnableManaging)
-                {
-                    var agent = tx.Signer;
-                    if (_ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count >
-                        _options.Value.ThresholdCount)
-                    {
-                        _logger.Information(
-                            "[GRPC-REQUEST-CAPTURE] IP: {IP} List Count: {Count}, AgentAddresses: {Agent}",
-                            httpContext.Connection.RemoteIpAddress!.ToString(),
-                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count,
-                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()]);
-                        if (!MultiAccountManagementList.ContainsKey(agent))
-                        {
-                            if (!MultiAccountTxIntervalTracker.ContainsKey(agent))
-                            {
-                                _logger.Information(
-                                    $"[GRPC-REQUEST-CAPTURE] Adding agent {agent} to the agent tracker.");
-                                MultiAccountTxIntervalTracker.Add(agent, DateTimeOffset.Now);
-                            }
-                            else
-                            {
-                                if ((DateTimeOffset.Now - MultiAccountTxIntervalTracker[agent]).Minutes >=
-                                    _options.Value.TxIntervalMinutes)
-                                {
-                                    _logger.Information(
-                                        $"[GRPC-REQUEST-CAPTURE] Resetting Agent {agent}'s time because " +
-                                        $"it has been more than {_options.Value.TxIntervalMinutes} minutes since the last transaction.");
-                                    MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
-                                }
-                                else
-                                {
-                                    _logger.Information(
-                                        $"[GRPC-REQUEST-CAPTURE] Managing Agent {agent} for " +
-                                        $"{_options.Value.ManagementTimeMinutes} minutes due to " +
-                                        $"{_ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count} associated accounts.");
-                                    ManageMultiAccount(agent);
-                                    MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
-                                    throw new RpcException(new Status(StatusCode.Cancelled, "Request cancelled."));
-                                }
-                            }
-                        }
-                        else
-                        {
-                            if ((DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes >=
-                                _options.Value.ManagementTimeMinutes)
-                            {
-                                _logger.Information(
-                                    $"[GRPC-REQUEST-CAPTURE] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
-                                RestoreMultiAccount(agent);
-                                MultiAccountTxIntervalTracker[agent] =
-                                    DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes);
-                                _logger.Information(
-                                    $"[GRPC-REQUEST-CAPTURE] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes)}.");
-                            }
-                            else
-                            {
-                                _logger.Information(
-                                    $"[GRPC-REQUEST-CAPTURE] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes} minutes.");
-                                throw new RpcException(new Status(StatusCode.Cancelled, "Request cancelled."));
-                            }
-                        }
-                    }
                 }
 
                 _logger.Information(

--- a/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcCaptureMiddleware.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Types.Tx;
+using Microsoft.Extensions.Options;
+using NineChronicles.Headless.Properties;
 using Serilog;
 using static NineChronicles.Headless.NCActionUtils;
 
@@ -12,13 +15,36 @@ namespace NineChronicles.Headless.Middleware
 {
     public class GrpcCaptureMiddleware : Interceptor
     {
+        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountTxIntervalTracker = new();
+        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountManagementList = new();
         private readonly ILogger _logger;
-        private ActionEvaluationPublisher _actionEvaluationPublisher;
+        private StandaloneContext _standaloneContext;
+        private readonly Dictionary<string, HashSet<Address>> _ipSignerList;
+        private readonly ActionEvaluationPublisher _actionEvaluationPublisher;
+        private readonly IOptions<MultiAccountManagerProperties> _options;
 
-        public GrpcCaptureMiddleware(ActionEvaluationPublisher actionEvaluationPublisher)
+        public GrpcCaptureMiddleware(
+            StandaloneContext standaloneContext,
+            Dictionary<string,
+            HashSet<Address>> ipSignerList,
+            ActionEvaluationPublisher actionEvaluationPublisher,
+            IOptions<MultiAccountManagerProperties> options)
         {
             _logger = Log.Logger.ForContext<GrpcCaptureMiddleware>();
+            _standaloneContext = standaloneContext;
+            _ipSignerList = ipSignerList;
             _actionEvaluationPublisher = actionEvaluationPublisher;
+            _options = options;
+        }
+
+        private static void ManageMultiAccount(Address agent)
+        {
+            MultiAccountManagementList.Add(agent, DateTimeOffset.Now);
+        }
+
+        private static void RestoreMultiAccount(Address agent)
+        {
+            MultiAccountManagementList.Remove(agent);
         }
 
         public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
@@ -35,6 +61,26 @@ namespace NineChronicles.Headless.Middleware
                 _logger.Information(
                     "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent} Header: {Header}",
                     ipAddress, context.Method, agent, uaHeader);
+
+                if (_options.Value.EnableManaging)
+                {
+                    if (!_ipSignerList.ContainsKey(httpContext.Connection.RemoteIpAddress!.ToString()))
+                    {
+                        _logger.Information(
+                            "[GRPC-REQUEST-CAPTURE] Creating a new list for IP: {IP}",
+                            httpContext.Connection.RemoteIpAddress!.ToString());
+                        _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()] = new HashSet<Address>();
+                    }
+                    else
+                    {
+                        _logger.Information(
+                            "[GRPC-REQUEST-CAPTURE] List already created for IP: {IP} Count: {Count}",
+                            httpContext.Connection.RemoteIpAddress!.ToString(),
+                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count);
+                    }
+
+                    _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Add(agent);
+                }
             }
 
             if (context.Method is "/IBlockChainService/GetNextTxNonce" && request is byte[] getNextTxNonceAddressBytes)
@@ -42,10 +88,32 @@ namespace NineChronicles.Headless.Middleware
                 var agent = new Address(getNextTxNonceAddressBytes);
                 var httpContext = context.GetHttpContext();
                 var ipAddress = httpContext.Connection.RemoteIpAddress + ":" + httpContext.Connection.RemotePort;
+                var uaHeader = httpContext.Request.Headers["User-Agent"].FirstOrDefault()!;
+                AddClientByDevice(agent, uaHeader);
 
                 _logger.Information(
-                    "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent}",
-                    ipAddress, context.Method, agent);
+                    "[GRPC-REQUEST-CAPTURE] IP: {IP} Method: {Method} Agent: {Agent} Header: {Header}",
+                    ipAddress, context.Method, agent, uaHeader);
+
+                if (_options.Value.EnableManaging)
+                {
+                    if (!_ipSignerList.ContainsKey(httpContext.Connection.RemoteIpAddress!.ToString()))
+                    {
+                        _logger.Information(
+                            "[GRPC-REQUEST-CAPTURE] Creating a new list for IP: {IP}",
+                            httpContext.Connection.RemoteIpAddress!.ToString());
+                        _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()] = new HashSet<Address>();
+                    }
+                    else
+                    {
+                        _logger.Information(
+                            "[GRPC-REQUEST-CAPTURE] List already created for IP: {IP} Count: {Count}",
+                            httpContext.Connection.RemoteIpAddress!.ToString(),
+                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count);
+                    }
+
+                    _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Add(agent);
+                }
             }
 
             if (context.Method is "/IBlockChainService/PutTransaction" && request is byte[] txBytes)
@@ -62,6 +130,70 @@ namespace NineChronicles.Headless.Middleware
                 {
                     await _actionEvaluationPublisher.AddClient(tx.Signer);
                     AddClientByDevice(tx.Signer, uaHeader);
+                }
+
+                if (_options.Value.EnableManaging)
+                {
+                    var agent = tx.Signer;
+                    if (_ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count >
+                        _options.Value.ThresholdCount)
+                    {
+                        _logger.Information(
+                            "[GRPC-REQUEST-CAPTURE] IP: {IP} List Count: {Count}, AgentAddresses: {Agent}",
+                            httpContext.Connection.RemoteIpAddress!.ToString(),
+                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count,
+                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()]);
+                        if (!MultiAccountManagementList.ContainsKey(agent))
+                        {
+                            if (!MultiAccountTxIntervalTracker.ContainsKey(agent))
+                            {
+                                _logger.Information(
+                                    $"[GRPC-REQUEST-CAPTURE] Adding agent {agent} to the agent tracker.");
+                                MultiAccountTxIntervalTracker.Add(agent, DateTimeOffset.Now);
+                            }
+                            else
+                            {
+                                if ((DateTimeOffset.Now - MultiAccountTxIntervalTracker[agent]).Minutes >=
+                                    _options.Value.TxIntervalMinutes)
+                                {
+                                    _logger.Information(
+                                        $"[GRPC-REQUEST-CAPTURE] Resetting Agent {agent}'s time because " +
+                                        $"it has been more than {_options.Value.TxIntervalMinutes} minutes since the last transaction.");
+                                    MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
+                                }
+                                else
+                                {
+                                    _logger.Information(
+                                        $"[GRPC-REQUEST-CAPTURE] Managing Agent {agent} for " +
+                                        $"{_options.Value.ManagementTimeMinutes} minutes due to " +
+                                        $"{_ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count} associated accounts.");
+                                    ManageMultiAccount(agent);
+                                    MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
+                                    throw new RpcException(new Status(StatusCode.Cancelled, "Request cancelled."));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if ((DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes >=
+                                _options.Value.ManagementTimeMinutes)
+                            {
+                                _logger.Information(
+                                    $"[GRPC-REQUEST-CAPTURE] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
+                                RestoreMultiAccount(agent);
+                                MultiAccountTxIntervalTracker[agent] =
+                                    DateTimeOffset.Now.AddMinutes(-(int)_options.Value.TxIntervalMinutes!);
+                                _logger.Information(
+                                    $"[GRPC-REQUEST-CAPTURE] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes(-(int)_options.Value.TxIntervalMinutes!)}.");
+                            }
+                            else
+                            {
+                                _logger.Information(
+                                    $"[GRPC-REQUEST-CAPTURE] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes} minutes.");
+                                throw new RpcException(new Status(StatusCode.Cancelled, "Request cancelled."));
+                            }
+                        }
+                    }
                 }
 
                 _logger.Information(

--- a/NineChronicles.Headless/Middleware/GrpcMultiAccountManagementMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcMultiAccountManagementMiddleware.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using System.Threading.Tasks;
+using Libplanet.Crypto;
+using Libplanet.Types.Tx;
+using Microsoft.Extensions.Options;
+using NineChronicles.Headless.Properties;
+using Serilog;
+
+namespace NineChronicles.Headless.Middleware
+{
+    public class GrpMultiAccountManagementMiddleware : Interceptor
+    {
+        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountTxIntervalTracker = new();
+        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountManagementList = new();
+        private readonly ILogger _logger;
+        private StandaloneContext _standaloneContext;
+        private readonly Dictionary<string, HashSet<Address>> _ipSignerList;
+        private readonly ActionEvaluationPublisher _actionEvaluationPublisher;
+        private readonly IOptions<MultiAccountManagerProperties> _options;
+
+        public GrpMultiAccountManagementMiddleware(
+            StandaloneContext standaloneContext,
+            Dictionary<string, HashSet<Address>> ipSignerList,
+            ActionEvaluationPublisher actionEvaluationPublisher,
+            IOptions<MultiAccountManagerProperties> options)
+        {
+            _logger = Log.Logger.ForContext<GrpMultiAccountManagementMiddleware>();
+            _standaloneContext = standaloneContext;
+            _ipSignerList = ipSignerList;
+            _actionEvaluationPublisher = actionEvaluationPublisher;
+            _options = options;
+        }
+
+        private static void ManageMultiAccount(Address agent)
+        {
+            MultiAccountManagementList.Add(agent, DateTimeOffset.Now);
+        }
+
+        private static void RestoreMultiAccount(Address agent)
+        {
+            MultiAccountManagementList.Remove(agent);
+        }
+
+        public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+            TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
+        {
+            if (context.Method is "/IBlockChainService/AddClient" && request is byte[] addClientAddressBytes)
+            {
+                var agent = new Address(addClientAddressBytes);
+                var httpContext = context.GetHttpContext();
+
+                if (_options.Value.EnableManaging)
+                {
+                    if (!_ipSignerList.ContainsKey(httpContext.Connection.RemoteIpAddress!.ToString()))
+                    {
+                        _logger.Information(
+                            "[GRPC-MULTI-ACCOUNT-MANAGER] Creating a new list for IP: {IP}",
+                            httpContext.Connection.RemoteIpAddress!.ToString());
+                        _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()] = new HashSet<Address>();
+                    }
+                    else
+                    {
+                        _logger.Information(
+                            "[GRPC-MULTI-ACCOUNT-MANAGER] List already created for IP: {IP} Count: {Count}",
+                            httpContext.Connection.RemoteIpAddress!.ToString(),
+                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count);
+                    }
+
+                    _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Add(agent);
+                }
+            }
+
+            if (context.Method is "/IBlockChainService/GetNextTxNonce" && request is byte[] getNextTxNonceAddressBytes)
+            {
+                var agent = new Address(getNextTxNonceAddressBytes);
+                var httpContext = context.GetHttpContext();
+
+                if (_options.Value.EnableManaging)
+                {
+                    if (!_ipSignerList.ContainsKey(httpContext.Connection.RemoteIpAddress!.ToString()))
+                    {
+                        _logger.Information(
+                            "[GRPC-MULTI-ACCOUNT-MANAGER] Creating a new list for IP: {IP}",
+                            httpContext.Connection.RemoteIpAddress!.ToString());
+                        _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()] = new HashSet<Address>();
+                    }
+                    else
+                    {
+                        _logger.Information(
+                            "[GRPC-MULTI-ACCOUNT-MANAGER] List already created for IP: {IP} Count: {Count}",
+                            httpContext.Connection.RemoteIpAddress!.ToString(),
+                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count);
+                    }
+
+                    _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Add(agent);
+                }
+            }
+
+            if (context.Method is "/IBlockChainService/PutTransaction" && request is byte[] txBytes)
+            {
+                Transaction tx =
+                    Transaction.Deserialize(txBytes);
+                var httpContext = context.GetHttpContext();
+
+                if (_options.Value.EnableManaging)
+                {
+                    var agent = tx.Signer;
+                    if (_ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count >
+                        _options.Value.ThresholdCount)
+                    {
+                        _logger.Information(
+                            "[GRPC-MULTI-ACCOUNT-MANAGER] IP: {IP} List Count: {Count}, AgentAddresses: {Agent}",
+                            httpContext.Connection.RemoteIpAddress!.ToString(),
+                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count,
+                            _ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()]);
+                        if (!MultiAccountManagementList.ContainsKey(agent))
+                        {
+                            if (!MultiAccountTxIntervalTracker.ContainsKey(agent))
+                            {
+                                _logger.Information(
+                                    $"[GRPC-MULTI-ACCOUNT-MANAGER] Adding agent {agent} to the agent tracker.");
+                                MultiAccountTxIntervalTracker.Add(agent, DateTimeOffset.Now);
+                            }
+                            else
+                            {
+                                if ((DateTimeOffset.Now - MultiAccountTxIntervalTracker[agent]).Minutes >=
+                                    _options.Value.TxIntervalMinutes)
+                                {
+                                    _logger.Information(
+                                        $"[GRPC-MULTI-ACCOUNT-MANAGER] Resetting Agent {agent}'s time because " +
+                                        $"it has been more than {_options.Value.TxIntervalMinutes} minutes since the last transaction.");
+                                    MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
+                                }
+                                else
+                                {
+                                    _logger.Information(
+                                        $"[GRPC-MULTI-ACCOUNT-MANAGER] Managing Agent {agent} for " +
+                                        $"{_options.Value.ManagementTimeMinutes} minutes due to " +
+                                        $"{_ipSignerList[httpContext.Connection.RemoteIpAddress!.ToString()].Count} associated accounts.");
+                                    ManageMultiAccount(agent);
+                                    MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
+                                    throw new RpcException(new Status(StatusCode.Cancelled, "Request cancelled."));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if ((DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes >=
+                                _options.Value.ManagementTimeMinutes)
+                            {
+                                _logger.Information(
+                                    $"[GRPC-MULTI-ACCOUNT-MANAGER] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
+                                RestoreMultiAccount(agent);
+                                MultiAccountTxIntervalTracker[agent] =
+                                    DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes);
+                                _logger.Information(
+                                    $"[GRPC-MULTI-ACCOUNT-MANAGER] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes)}.");
+                            }
+                            else
+                            {
+                                _logger.Information(
+                                    $"[GRPC-MULTI-ACCOUNT-MANAGER] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes} minutes.");
+                                throw new RpcException(new Status(StatusCode.Cancelled, "Request cancelled."));
+                            }
+                        }
+                    }
+                }
+            }
+
+            return await base.UnaryServerHandler(request, context, continuation);
+        }
+    }
+}

--- a/NineChronicles.Headless/Middleware/GrpcMultiAccountManagementMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcMultiAccountManagementMiddleware.cs
@@ -11,7 +11,7 @@ using Serilog;
 
 namespace NineChronicles.Headless.Middleware
 {
-    public class GrpMultiAccountManagementMiddleware : Interceptor
+    public class GrpcMultiAccountManagementMiddleware : Interceptor
     {
         private static readonly Dictionary<Address, DateTimeOffset> MultiAccountTxIntervalTracker = new();
         private static readonly Dictionary<Address, DateTimeOffset> MultiAccountManagementList = new();
@@ -21,13 +21,13 @@ namespace NineChronicles.Headless.Middleware
         private readonly ActionEvaluationPublisher _actionEvaluationPublisher;
         private readonly IOptions<MultiAccountManagerProperties> _options;
 
-        public GrpMultiAccountManagementMiddleware(
+        public GrpcMultiAccountManagementMiddleware(
             StandaloneContext standaloneContext,
             Dictionary<string, HashSet<Address>> ipSignerList,
             ActionEvaluationPublisher actionEvaluationPublisher,
             IOptions<MultiAccountManagerProperties> options)
         {
-            _logger = Log.Logger.ForContext<GrpMultiAccountManagementMiddleware>();
+            _logger = Log.Logger.ForContext<GrpcMultiAccountManagementMiddleware>();
             _standaloneContext = standaloneContext;
             _ipSignerList = ipSignerList;
             _actionEvaluationPublisher = actionEvaluationPublisher;

--- a/NineChronicles.Headless/Middleware/GrpcMultiAccountManagementMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/GrpcMultiAccountManagementMiddleware.cs
@@ -148,8 +148,8 @@ namespace NineChronicles.Headless.Middleware
                         }
                         else
                         {
-                            if ((DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes >=
-                                _options.Value.ManagementTimeMinutes)
+                            var currentManagedTime = (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes;
+                            if (currentManagedTime >= _options.Value.ManagementTimeMinutes)
                             {
                                 _logger.Information(
                                     $"[GRPC-MULTI-ACCOUNT-MANAGER] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
@@ -162,7 +162,7 @@ namespace NineChronicles.Headless.Middleware
                             else
                             {
                                 _logger.Information(
-                                    $"[GRPC-MULTI-ACCOUNT-MANAGER] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes} minutes.");
+                                    $"[GRPC-MULTI-ACCOUNT-MANAGER] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - currentManagedTime} minutes.");
                                 throw new RpcException(new Status(StatusCode.Cancelled, "Request cancelled."));
                             }
                         }

--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -125,8 +125,8 @@ namespace NineChronicles.Headless.Middleware
                                         {
                                             _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
                                             RestoreMultiAccount(agent);
-                                            MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now.AddMinutes((int)-_options.Value.TxIntervalMinutes!);
-                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes((int)-_options.Value.TxIntervalMinutes!)}.");
+                                            MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes);
+                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes)}.");
                                         }
                                         else
                                         {

--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -1,6 +1,14 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Libplanet.Common;
+using Libplanet.Crypto;
+using Libplanet.Types.Tx;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using NineChronicles.Headless.Properties;
 using Serilog;
 using ILogger = Serilog.ILogger;
 
@@ -8,13 +16,35 @@ namespace NineChronicles.Headless.Middleware
 {
     public class HttpCaptureMiddleware
     {
+        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountTxIntervalTracker = new();
+        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountManagementList = new();
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
+        private StandaloneContext _standaloneContext;
+        private readonly Dictionary<string, HashSet<Address>> _ipSignerList;
+        private readonly IOptions<MultiAccountManagerProperties> _options;
 
-        public HttpCaptureMiddleware(RequestDelegate next)
+        public HttpCaptureMiddleware(
+            RequestDelegate next,
+            StandaloneContext standaloneContext,
+            Dictionary<string, HashSet<Address>> ipSignerList,
+            IOptions<MultiAccountManagerProperties> options)
         {
             _next = next;
             _logger = Log.Logger.ForContext<HttpCaptureMiddleware>();
+            _standaloneContext = standaloneContext;
+            _ipSignerList = ipSignerList;
+            _options = options;
+        }
+
+        private static void ManageMultiAccount(Address agent)
+        {
+            MultiAccountManagementList.Add(agent, DateTimeOffset.Now);
+        }
+
+        private static void RestoreMultiAccount(Address agent)
+        {
+            MultiAccountManagementList.Remove(agent);
         }
 
         public async Task InvokeAsync(HttpContext context)
@@ -28,9 +58,130 @@ namespace NineChronicles.Headless.Middleware
                 _logger.Information("[GRAPHQL-REQUEST-CAPTURE] IP: {IP} Method: {Method} Endpoint: {Path} {Body}",
                     remoteIp, context.Request.Method, context.Request.Path, body);
                 context.Request.Body.Seek(0, SeekOrigin.Begin);
+                if (_options.Value.EnableManaging)
+                {
+                    if (body.Contains("agent(address:\\\"") || body.Contains("agent(address: \\\""))
+                    {
+                        try
+                        {
+                            var agent = new Address(body.Split("\\\"")[1].Split("0x")[1]);
+                            UpdateIpSignerList(remoteIp!.ToString(), agent);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Error(
+                                "[GRAPHQL-REQUEST-CAPTURE-SIGNER] Error message: {message} Stacktrace: {stackTrace}",
+                                ex.Message,
+                                ex.StackTrace);
+                        }
+                    }
+
+                    if (body.Contains("stageTransaction"))
+                    {
+                        try
+                        {
+                            var pattern = "64313.*6565";
+                            var txPayload = Regex.Match(body, pattern).ToString();
+                            byte[] bytes = ByteUtil.ParseHex(txPayload);
+                            Transaction tx = Transaction.Deserialize(bytes);
+                            var agent = tx.Signer;
+                            if (_ipSignerList.ContainsKey(context.Connection.RemoteIpAddress!.ToString()))
+                            {
+                                if (_ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count > _options.Value.ThresholdCount)
+                                {
+                                    _logger.Information(
+                                        "[GRAPHQL-REQUEST-CAPTURE] IP: {IP} List Count: {Count}, AgentAddresses: {Agent}",
+                                        context.Connection.RemoteIpAddress!.ToString(),
+                                        _ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count,
+                                        _ipSignerList[context.Connection.RemoteIpAddress!.ToString()]);
+
+                                    if (!MultiAccountManagementList.ContainsKey(agent))
+                                    {
+                                        if (!MultiAccountTxIntervalTracker.ContainsKey(agent))
+                                        {
+                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Adding agent {agent} to the agent tracker.");
+                                            MultiAccountTxIntervalTracker.Add(agent, DateTimeOffset.Now);
+                                        }
+                                        else
+                                        {
+                                            if ((DateTimeOffset.Now - MultiAccountTxIntervalTracker[agent]).Minutes >= _options.Value.TxIntervalMinutes)
+                                            {
+                                                _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Resetting Agent {agent}'s time because it has been more than {_options.Value.TxIntervalMinutes} minutes since the last transaction.");
+                                                MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
+                                            }
+                                            else
+                                            {
+                                                _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Managing Agent {agent} for {_options.Value.ManagementTimeMinutes} minutes due to {_ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count} associated accounts.");
+                                                ManageMultiAccount(agent);
+                                                MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
+                                                await CancelRequestAsync(context);
+                                                return;
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if ((DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes > _options.Value.ManagementTimeMinutes)
+                                        {
+                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
+                                            RestoreMultiAccount(agent);
+                                            MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now.AddMinutes((int)-_options.Value.TxIntervalMinutes!);
+                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes((int)-_options.Value.TxIntervalMinutes!)}.");
+                                        }
+                                        else
+                                        {
+                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes} minutes.");
+                                            await CancelRequestAsync(context);
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                UpdateIpSignerList(remoteIp!.ToString(), agent);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Error(
+                                "[GRAPHQL-REQUEST-CAPTURE-SIGNER] Error message: {message} Stacktrace: {stackTrace}",
+                                ex.Message,
+                                ex.StackTrace);
+                        }
+                    }
+                }
             }
 
             await _next(context);
+        }
+
+        public void UpdateIpSignerList(string ip, Address agent)
+        {
+            if (!_ipSignerList.ContainsKey(ip))
+            {
+                _logger.Information(
+                    "[GRAPHQL-REQUEST-CAPTURE] Creating a new list for IP: {IP}",
+                    ip);
+                _ipSignerList[ip] = new HashSet<Address>();
+            }
+            else
+            {
+                _logger.Information(
+                    "[GRAPHQL-REQUEST-CAPTURE] List already created for IP: {IP} Count: {Count}",
+                    ip,
+                    _ipSignerList[ip].Count);
+            }
+
+            _ipSignerList[ip].Add(agent);
+        }
+
+        private async Task CancelRequestAsync(HttpContext context)
+        {
+            var message = "{ \"message\": \"Request cancelled.\" }";
+            context.Response.StatusCode = 403;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync(message);
         }
     }
 }

--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -1,14 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Libplanet.Common;
-using Libplanet.Crypto;
-using Libplanet.Types.Tx;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
-using NineChronicles.Headless.Properties;
 using Serilog;
 using ILogger = Serilog.ILogger;
 
@@ -16,35 +8,13 @@ namespace NineChronicles.Headless.Middleware
 {
     public class HttpCaptureMiddleware
     {
-        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountTxIntervalTracker = new();
-        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountManagementList = new();
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
-        private StandaloneContext _standaloneContext;
-        private readonly Dictionary<string, HashSet<Address>> _ipSignerList;
-        private readonly IOptions<MultiAccountManagerProperties> _options;
 
-        public HttpCaptureMiddleware(
-            RequestDelegate next,
-            StandaloneContext standaloneContext,
-            Dictionary<string, HashSet<Address>> ipSignerList,
-            IOptions<MultiAccountManagerProperties> options)
+        public HttpCaptureMiddleware(RequestDelegate next)
         {
             _next = next;
             _logger = Log.Logger.ForContext<HttpCaptureMiddleware>();
-            _standaloneContext = standaloneContext;
-            _ipSignerList = ipSignerList;
-            _options = options;
-        }
-
-        private static void ManageMultiAccount(Address agent)
-        {
-            MultiAccountManagementList.Add(agent, DateTimeOffset.Now);
-        }
-
-        private static void RestoreMultiAccount(Address agent)
-        {
-            MultiAccountManagementList.Remove(agent);
         }
 
         public async Task InvokeAsync(HttpContext context)
@@ -58,130 +28,9 @@ namespace NineChronicles.Headless.Middleware
                 _logger.Information("[GRAPHQL-REQUEST-CAPTURE] IP: {IP} Method: {Method} Endpoint: {Path} {Body}",
                     remoteIp, context.Request.Method, context.Request.Path, body);
                 context.Request.Body.Seek(0, SeekOrigin.Begin);
-                if (_options.Value.EnableManaging)
-                {
-                    if (body.Contains("agent(address:\\\"") || body.Contains("agent(address: \\\""))
-                    {
-                        try
-                        {
-                            var agent = new Address(body.Split("\\\"")[1].Split("0x")[1]);
-                            UpdateIpSignerList(remoteIp!.ToString(), agent);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.Error(
-                                "[GRAPHQL-REQUEST-CAPTURE-SIGNER] Error message: {message} Stacktrace: {stackTrace}",
-                                ex.Message,
-                                ex.StackTrace);
-                        }
-                    }
-
-                    if (body.Contains("stageTransaction"))
-                    {
-                        try
-                        {
-                            var pattern = "64313.*6565";
-                            var txPayload = Regex.Match(body, pattern).ToString();
-                            byte[] bytes = ByteUtil.ParseHex(txPayload);
-                            Transaction tx = Transaction.Deserialize(bytes);
-                            var agent = tx.Signer;
-                            if (_ipSignerList.ContainsKey(context.Connection.RemoteIpAddress!.ToString()))
-                            {
-                                if (_ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count > _options.Value.ThresholdCount)
-                                {
-                                    _logger.Information(
-                                        "[GRAPHQL-REQUEST-CAPTURE] IP: {IP} List Count: {Count}, AgentAddresses: {Agent}",
-                                        context.Connection.RemoteIpAddress!.ToString(),
-                                        _ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count,
-                                        _ipSignerList[context.Connection.RemoteIpAddress!.ToString()]);
-
-                                    if (!MultiAccountManagementList.ContainsKey(agent))
-                                    {
-                                        if (!MultiAccountTxIntervalTracker.ContainsKey(agent))
-                                        {
-                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Adding agent {agent} to the agent tracker.");
-                                            MultiAccountTxIntervalTracker.Add(agent, DateTimeOffset.Now);
-                                        }
-                                        else
-                                        {
-                                            if ((DateTimeOffset.Now - MultiAccountTxIntervalTracker[agent]).Minutes >= _options.Value.TxIntervalMinutes)
-                                            {
-                                                _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Resetting Agent {agent}'s time because it has been more than {_options.Value.TxIntervalMinutes} minutes since the last transaction.");
-                                                MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
-                                            }
-                                            else
-                                            {
-                                                _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Managing Agent {agent} for {_options.Value.ManagementTimeMinutes} minutes due to {_ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count} associated accounts.");
-                                                ManageMultiAccount(agent);
-                                                MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
-                                                await CancelRequestAsync(context);
-                                                return;
-                                            }
-                                        }
-                                    }
-                                    else
-                                    {
-                                        if ((DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes > _options.Value.ManagementTimeMinutes)
-                                        {
-                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
-                                            RestoreMultiAccount(agent);
-                                            MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes);
-                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes)}.");
-                                        }
-                                        else
-                                        {
-                                            _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes} minutes.");
-                                            await CancelRequestAsync(context);
-                                            return;
-                                        }
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                UpdateIpSignerList(remoteIp!.ToString(), agent);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.Error(
-                                "[GRAPHQL-REQUEST-CAPTURE-SIGNER] Error message: {message} Stacktrace: {stackTrace}",
-                                ex.Message,
-                                ex.StackTrace);
-                        }
-                    }
-                }
             }
 
             await _next(context);
-        }
-
-        public void UpdateIpSignerList(string ip, Address agent)
-        {
-            if (!_ipSignerList.ContainsKey(ip))
-            {
-                _logger.Information(
-                    "[GRAPHQL-REQUEST-CAPTURE] Creating a new list for IP: {IP}",
-                    ip);
-                _ipSignerList[ip] = new HashSet<Address>();
-            }
-            else
-            {
-                _logger.Information(
-                    "[GRAPHQL-REQUEST-CAPTURE] List already created for IP: {IP} Count: {Count}",
-                    ip,
-                    _ipSignerList[ip].Count);
-            }
-
-            _ipSignerList[ip].Add(agent);
-        }
-
-        private async Task CancelRequestAsync(HttpContext context)
-        {
-            var message = "{ \"message\": \"Request cancelled.\" }";
-            context.Response.StatusCode = 403;
-            context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(message);
         }
     }
 }

--- a/NineChronicles.Headless/Middleware/HttpMultiAccountManagementMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpMultiAccountManagementMiddleware.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Libplanet.Common;
+using Libplanet.Crypto;
+using Libplanet.Types.Tx;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using NineChronicles.Headless.Properties;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace NineChronicles.Headless.Middleware
+{
+    public class HttpMultiAccountManagementMiddleware
+    {
+        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountTxIntervalTracker = new();
+        private static readonly Dictionary<Address, DateTimeOffset> MultiAccountManagementList = new();
+        private readonly RequestDelegate _next;
+        private readonly ILogger _logger;
+        private StandaloneContext _standaloneContext;
+        private readonly Dictionary<string, HashSet<Address>> _ipSignerList;
+        private readonly IOptions<MultiAccountManagerProperties> _options;
+
+        public HttpMultiAccountManagementMiddleware(
+            RequestDelegate next,
+            StandaloneContext standaloneContext,
+            Dictionary<string, HashSet<Address>> ipSignerList,
+            IOptions<MultiAccountManagerProperties> options)
+        {
+            _next = next;
+            _logger = Log.Logger.ForContext<HttpMultiAccountManagementMiddleware>();
+            _standaloneContext = standaloneContext;
+            _ipSignerList = ipSignerList;
+            _options = options;
+        }
+
+        private static void ManageMultiAccount(Address agent)
+        {
+            MultiAccountManagementList.Add(agent, DateTimeOffset.Now);
+        }
+
+        private static void RestoreMultiAccount(Address agent)
+        {
+            MultiAccountManagementList.Remove(agent);
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            // Prevent to harm HTTP/2 communication.
+            if (context.Request.Protocol == "HTTP/1.1")
+            {
+                context.Request.EnableBuffering();
+                var remoteIp = context.Connection.RemoteIpAddress;
+                var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
+                context.Request.Body.Seek(0, SeekOrigin.Begin);
+                if (_options.Value.EnableManaging)
+                {
+                    if (body.Contains("agent(address:\\\"") || body.Contains("agent(address: \\\""))
+                    {
+                        try
+                        {
+                            var agent = new Address(body.Split("\\\"")[1].Split("0x")[1]);
+                            UpdateIpSignerList(remoteIp!.ToString(), agent);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Error(
+                                "[GRAPHQL-MULTI-ACCOUNT-MANAGER] Error message: {message} Stacktrace: {stackTrace}",
+                                ex.Message,
+                                ex.StackTrace);
+                        }
+                    }
+
+                    if (body.Contains("stageTransaction"))
+                    {
+                        try
+                        {
+                            var pattern = "64313.*6565";
+                            var txPayload = Regex.Match(body, pattern).ToString();
+                            byte[] bytes = ByteUtil.ParseHex(txPayload);
+                            Transaction tx = Transaction.Deserialize(bytes);
+                            var agent = tx.Signer;
+                            if (_ipSignerList.ContainsKey(context.Connection.RemoteIpAddress!.ToString()))
+                            {
+                                if (_ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count > _options.Value.ThresholdCount)
+                                {
+                                    _logger.Information(
+                                        "[GRAPHQL-MULTI-ACCOUNT-MANAGER] IP: {IP} List Count: {Count}, AgentAddresses: {Agent}",
+                                        context.Connection.RemoteIpAddress!.ToString(),
+                                        _ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count,
+                                        _ipSignerList[context.Connection.RemoteIpAddress!.ToString()]);
+
+                                    if (!MultiAccountManagementList.ContainsKey(agent))
+                                    {
+                                        if (!MultiAccountTxIntervalTracker.ContainsKey(agent))
+                                        {
+                                            _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Adding agent {agent} to the agent tracker.");
+                                            MultiAccountTxIntervalTracker.Add(agent, DateTimeOffset.Now);
+                                        }
+                                        else
+                                        {
+                                            if ((DateTimeOffset.Now - MultiAccountTxIntervalTracker[agent]).Minutes >= _options.Value.TxIntervalMinutes)
+                                            {
+                                                _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Resetting Agent {agent}'s time because it has been more than {_options.Value.TxIntervalMinutes} minutes since the last transaction.");
+                                                MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
+                                            }
+                                            else
+                                            {
+                                                _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Managing Agent {agent} for {_options.Value.ManagementTimeMinutes} minutes due to {_ipSignerList[context.Connection.RemoteIpAddress!.ToString()].Count} associated accounts.");
+                                                ManageMultiAccount(agent);
+                                                MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now;
+                                                await CancelRequestAsync(context);
+                                                return;
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if ((DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes > _options.Value.ManagementTimeMinutes)
+                                        {
+                                            _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
+                                            RestoreMultiAccount(agent);
+                                            MultiAccountTxIntervalTracker[agent] = DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes);
+                                            _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Current time: {DateTimeOffset.Now} Added time: {DateTimeOffset.Now.AddMinutes(-_options.Value.TxIntervalMinutes)}.");
+                                        }
+                                        else
+                                        {
+                                            _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes} minutes.");
+                                            await CancelRequestAsync(context);
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                UpdateIpSignerList(remoteIp!.ToString(), agent);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Error(
+                                "[GRAPHQL-MULTI-ACCOUNT-MANAGER] Error message: {message} Stacktrace: {stackTrace}",
+                                ex.Message,
+                                ex.StackTrace);
+                        }
+                    }
+                }
+            }
+
+            await _next(context);
+        }
+
+        public void UpdateIpSignerList(string ip, Address agent)
+        {
+            if (!_ipSignerList.ContainsKey(ip))
+            {
+                _logger.Information(
+                    "[GRAPHQL-MULTI-ACCOUNT-MANAGER] Creating a new list for IP: {IP}",
+                    ip);
+                _ipSignerList[ip] = new HashSet<Address>();
+            }
+            else
+            {
+                _logger.Information(
+                    "[GRAPHQL-MULTI-ACCOUNT-MANAGER] List already created for IP: {IP} Count: {Count}",
+                    ip,
+                    _ipSignerList[ip].Count);
+            }
+
+            _ipSignerList[ip].Add(agent);
+        }
+
+        private async Task CancelRequestAsync(HttpContext context)
+        {
+            var message = "{ \"message\": \"Request cancelled.\" }";
+            context.Response.StatusCode = 403;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync(message);
+        }
+    }
+}

--- a/NineChronicles.Headless/Middleware/HttpMultiAccountManagementMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpMultiAccountManagementMiddleware.cs
@@ -119,7 +119,8 @@ namespace NineChronicles.Headless.Middleware
                                     }
                                     else
                                     {
-                                        if ((DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes > _options.Value.ManagementTimeMinutes)
+                                        var currentManagedTime = (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes;
+                                        if (currentManagedTime > _options.Value.ManagementTimeMinutes)
                                         {
                                             _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Restoring Agent {agent} after {_options.Value.ManagementTimeMinutes} minutes.");
                                             RestoreMultiAccount(agent);
@@ -128,7 +129,7 @@ namespace NineChronicles.Headless.Middleware
                                         }
                                         else
                                         {
-                                            _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - (DateTimeOffset.Now - MultiAccountManagementList[agent]).Minutes} minutes.");
+                                            _logger.Information($"[GRAPHQL-MULTI-ACCOUNT-MANAGER] Agent {agent} is in managed status for the next {_options.Value.ManagementTimeMinutes - currentManagedTime} minutes.");
                                             await CancelRequestAsync(context);
                                             return;
                                         }

--- a/NineChronicles.Headless/Properties/MultiAccountManagerProperties.cs
+++ b/NineChronicles.Headless/Properties/MultiAccountManagerProperties.cs
@@ -4,10 +4,10 @@ namespace NineChronicles.Headless.Properties
     {
         public bool EnableManaging { get; set; }
 
-        public int? ManagementTimeMinutes { get; set; } = 10;
+        public int ManagementTimeMinutes { get; set; } = 10;
 
-        public int? TxIntervalMinutes { get; set; } = 10;
+        public int TxIntervalMinutes { get; set; } = 10;
 
-        public int? ThresholdCount { get; set; } = 50;
+        public int ThresholdCount { get; set; } = 50;
     }
 }

--- a/NineChronicles.Headless/Properties/MultiAccountManagerProperties.cs
+++ b/NineChronicles.Headless/Properties/MultiAccountManagerProperties.cs
@@ -1,0 +1,13 @@
+namespace NineChronicles.Headless.Properties
+{
+    public class MultiAccountManagerProperties
+    {
+        public bool EnableManaging { get; set; }
+
+        public int? ManagementTimeMinutes { get; set; } = 10;
+
+        public int? TxIntervalMinutes { get; set; } = 10;
+
+        public int? ThresholdCount { get; set; } = 50;
+    }
+}


### PR DESCRIPTION
This feature manages multiple accounts that originate from the same source. The feature is turned off by default and you can turn it on by adjusting the [appsettings.json](https://github.com/planetarium/NineChronicles.Headless/compare/development...area363:account-management?expand=1#diff-e47fc585cf3ec48a24eabba8519cf4fcffbfc15f80cc907dec2379af8ebdf134R125-R130) or by adding the configuration as environment variables.

### Basic configuration
- `EnableManaging`: turn `on/off` account management mode
- `ThresholdCount`: number of accounts from a single source to start managing (eg. `50` means that if there are `50` accounts that are from a single origin, the feature will start managing the associated accounts).
- `TxIntervalMinutes`: tx interval for accounts that are under management. (e.g. `10` means that the accounts under managment are allowed 1 tx every `10` minutes).
- "ManagementTimeMinutes": the amount of time the node will not except an account's tx if it goes over the `TxIntervalMinutes` value (e.g. `10` means that if an account under managment exceeds the `TxIntervalMinutes`, the node will not stage that account's tx for `10` minutes).