### PR TITLE
don't use multiaccount middleware if not enabled

### DIFF
--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -167,10 +167,14 @@ namespace NineChronicles.Headless
                 }
 
                 // Capture requests
-                Dictionary<string, HashSet<Address>> ipSignerList = new();
-                app.UseMiddleware<HttpMultiAccountManagementMiddleware>(
-                    StandaloneContext,
-                    ipSignerList);
+                if (Convert.ToBoolean(Configuration.GetSection("MultiAccountManaging")["EnableManaging"]))
+                {
+                    Dictionary<string, HashSet<Address>> ipSignerList = new();
+                    app.UseMiddleware<HttpMultiAccountManagementMiddleware>(
+                        StandaloneContext,
+                        ipSignerList);
+                }
+
                 app.UseMiddleware<HttpCaptureMiddleware>();
 
                 app.UseMiddleware<LocalAuthenticationMiddleware>();

--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -85,7 +85,6 @@ namespace NineChronicles.Headless
             return builder
                 .ConfigureServices(services =>
                 {
-                    Dictionary<string, HashSet<Address>> ipSignerList = new();
                     if (Convert.ToBoolean(configuration.GetSection("MultiAccountManaging")["EnableManaging"]))
                     {
                         services.Configure<MultiAccountManagerProperties>(configuration.GetSection("MultiAccountManaging"));
@@ -95,10 +94,15 @@ namespace NineChronicles.Headless
                     services.AddGrpc(options =>
                     {
                         options.MaxReceiveMessageSize = null;
-                        options.Interceptors.Add<GrpcMultiAccountManagementMiddleware>(
-                            standaloneContext,
-                            ipSignerList,
-                            actionEvaluationPublisher);
+                        if (Convert.ToBoolean(configuration.GetSection("MultiAccountManaging")["EnableManaging"]))
+                        {
+                            Dictionary<string, HashSet<Address>> ipSignerList = new();
+                            options.Interceptors.Add<GrpcMultiAccountManagementMiddleware>(
+                                standaloneContext,
+                                ipSignerList,
+                                actionEvaluationPublisher);
+                        }
+
                         options.Interceptors.Add<GrpcCaptureMiddleware>(actionEvaluationPublisher);
                     });
                     services.AddMagicOnion();


### PR DESCRIPTION
Minor adjustment to use multiaccount management middlewares only when enabled.