### PR TITLE
fix(graphql): return null instead of errors

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -84,6 +84,11 @@ namespace NineChronicles.Headless.GraphTypes
 
                     var state = blockChain.GetStates(new[] { address }, blockHash)[0];
 
+                    if (state is null)
+                    {
+                        return null;
+                    }
+
                     return new Codec().Encode(state);
                 }
             );


### PR DESCRIPTION
This pull request makes `query.state` field return `null` when the state corresponding to `address` doesn't exist. The original behavior is throwing `NullReferenceException` via `Bencodex.Codec.Encode` doesn't allow its parameter to be `null`.