### PR TITLE
fix duplicate publisher in RPC mode

### DIFF
--- a/NineChronicles.Headless/HostBuilderExtensions.cs
+++ b/NineChronicles.Headless/HostBuilderExtensions.cs
@@ -26,15 +26,11 @@ namespace NineChronicles.Headless
         public static IHostBuilder UseNineChroniclesNode(
             this IHostBuilder builder,
             NineChroniclesNodeServiceProperties properties,
-            StandaloneContext context
+            StandaloneContext context,
+            ActionEvaluationPublisher actionEvaluationPublisher,
+            NineChroniclesNodeService service
         )
         {
-            NineChroniclesNodeService service =
-                NineChroniclesNodeService.Create(properties, context);
-            var rpcContext = new RpcContext
-            {
-                RpcRemoteSever = false
-            };
             return builder.ConfigureServices(services =>
             {
                 services.AddHostedService(provider => service);
@@ -53,19 +49,8 @@ namespace NineChronicles.Headless
                 {
                     services.AddSingleton<LibplanetNodeServiceProperties>(provider => libplanetNodeServiceProperties);
                 }
-                services.AddSingleton(provider =>
-                {
-                    return new ActionEvaluationPublisher(
-                        context.NineChroniclesNodeService!.BlockRenderer,
-                        context.NineChroniclesNodeService!.ActionRenderer,
-                        context.NineChroniclesNodeService!.ExceptionRenderer,
-                        context.NineChroniclesNodeService!.NodeStatusRenderer,
-                        IPAddress.Loopback.ToString(),
-                        0,
-                        rpcContext,
-                        provider.GetRequiredService<ConcurrentDictionary<string, ITransaction>>()
-                    );
-                });
+
+                services.AddSingleton(_ => actionEvaluationPublisher);
             });
         }
 


### PR DESCRIPTION
This PR addresses the issue where `ActionEvaluationPublisher` was instantiated twice in RPC mode. Now, the publisher is initialized in `Program.cs` and subsequently passed to both `UseNineChroniclesNode` and `UseNineChroniclesNodeRPC` methods found in `HostBuilderExtensions.cs`.