### PR TITLE
Set tipChanged subject's buffer size to 1

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -56,6 +56,8 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 // var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
 
                 Assert.Equal(index, BlockChain.Tip.Index);
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
                 var result = await ExecuteSubscriptionQueryAsync("subscription { tipChanged { index hash } }");
                 Assert.IsType<SubscriptionExecutionResult>(result);
                 var subscribeResult = (SubscriptionExecutionResult)result;

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -53,14 +53,14 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                     lastCommit: GenerateBlockCommit(BlockChain.Tip.Index, BlockChain.Tip.Hash, GenesisValidators));
                 BlockChain.Append(block, GenerateBlockCommit(block.Index, block.Hash, GenesisValidators));
 
-                var result = await ExecuteSubscriptionQueryAsync("subscription { tipChanged { index hash } }");
-
                 // var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
+
+                Assert.Equal(index, BlockChain.Tip.Index);
+                var result = await ExecuteSubscriptionQueryAsync("subscription { tipChanged { index hash } }");
                 Assert.IsType<SubscriptionExecutionResult>(result);
                 var subscribeResult = (SubscriptionExecutionResult)result;
-                Assert.Equal(index, BlockChain.Tip.Index);
                 var stream = subscribeResult.Streams!.Values.FirstOrDefault();
-                var rawEvents = await stream.Take((int)index);
+                var rawEvents = await stream.Take(1);
                 Assert.NotNull(rawEvents);
 
                 var events = (Dictionary<string, object>)((ExecutionNode)rawEvents.Data!).ToValue()!;

--- a/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneSubscription.cs
@@ -122,7 +122,7 @@ namespace NineChronicles.Headless.GraphTypes
 
         private BlockHeader? _tipHeader;
 
-        private ISubject<TipChanged> _subject = new ReplaySubject<TipChanged>();
+        private ISubject<TipChanged> _subject = new ReplaySubject<TipChanged>(1);
 
         private ISubject<Transaction> _transactionSubject = new Subject<Transaction>();
 


### PR DESCRIPTION
This pull request updates the buffer size of `subscription.tipChanged` API's subject to 1. Without the limitation, the `ReplaySubject` uses `int.MaxValue` as its buffer size. It is very useless to provide `tipChanged` subscription feature. It just causes too many subscription responses and uses too much memory.

When I tested with launcher, it works well.