### PR TITLE
[Feature] Introduce Access control service and Access control center

### DIFF
--- a/Dockerfile.ACC
+++ b/Dockerfile.ACC
@@ -1,0 +1,37 @@
+# Use the SDK image to build the app
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS build-env
+WORKDIR /app
+ARG COMMIT
+
+# Copy csproj and restore as distinct layers
+COPY ./Lib9c/Lib9c/Lib9c.csproj ./Lib9c/
+COPY ./NineChronicles.Headless/NineChronicles.Headless.csproj ./NineChronicles.Headless/
+COPY ./NineChronicles.Headless.AccessControlCenter/NineChronicles.Headless.AccessControlCenter.csproj ./NineChronicles.Headless.AccessControlCenter/
+RUN dotnet restore Lib9c
+RUN dotnet restore NineChronicles.Headless
+RUN dotnet restore NineChronicles.Headless.AccessControlCenter
+
+# Copy everything else and build
+COPY . ./
+RUN dotnet publish NineChronicles.Headless.AccessControlCenter/NineChronicles.Headless.AccessControlCenter.csproj \
+    -c Release \
+    -r linux-x64 \
+    -o out \
+    --self-contained \
+    --version-suffix $COMMIT
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
+WORKDIR /app
+RUN apt-get update && apt-get install -y libc6-dev
+COPY --from=build-env /app/out .
+
+# Install native deps & utilities for production
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+        libc6-dev jq curl \
+     && rm -rf /var/lib/apt/lists/*
+
+VOLUME /data
+
+ENTRYPOINT ["dotnet", "NineChronicles.Headless.AccessControlCenter.dll"]

--- a/Dockerfile.ACC.amd64
+++ b/Dockerfile.ACC.amd64
@@ -1,0 +1,37 @@
+# Use the SDK image to build the app
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS build-env
+WORKDIR /app
+ARG COMMIT
+
+# Copy csproj and restore as distinct layers
+COPY ./Lib9c/Lib9c/Lib9c.csproj ./Lib9c/
+COPY ./NineChronicles.Headless/NineChronicles.Headless.csproj ./NineChronicles.Headless/
+COPY ./NineChronicles.Headless.AccessControlCenter/NineChronicles.Headless.AccessControlCenter.csproj ./NineChronicles.Headless.AccessControlCenter/
+RUN dotnet restore Lib9c
+RUN dotnet restore NineChronicles.Headless
+RUN dotnet restore NineChronicles.Headless.AccessControlCenter
+
+# Copy everything else and build
+COPY . ./
+RUN dotnet publish NineChronicles.Headless.AccessControlCenter/NineChronicles.Headless.AccessControlCenter.csproj \
+    -c Release \
+    -r linux-x64 \
+    -o out \
+    --self-contained \
+    --version-suffix $COMMIT
+
+# Build runtime image
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y libc6-dev
+COPY --from=build-env /app/out .
+
+# Install native deps & utilities for production
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+        libc6-dev jq curl \
+     && rm -rf /var/lib/apt/lists/*
+
+VOLUME /data
+
+ENTRYPOINT ["dotnet", "NineChronicles.Headless.AccessControlCenter.dll"]

--- a/Dockerfile.ACC.arm64v8
+++ b/Dockerfile.ACC.arm64v8
@@ -1,0 +1,37 @@
+# Use the SDK image to build the app
+FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS build-env
+WORKDIR /app
+ARG COMMIT
+
+# Copy csproj and restore as distinct layers
+COPY ./Lib9c/Lib9c/Lib9c.csproj ./Lib9c/
+COPY ./NineChronicles.Headless/NineChronicles.Headless.csproj ./NineChronicles.Headless/
+COPY ./NineChronicles.Headless.AccessControlCenter/NineChronicles.Headless.AccessControlCenter.csproj ./NineChronicles.Headless.AccessControlCenter/
+RUN dotnet restore Lib9c
+RUN dotnet restore NineChronicles.Headless
+RUN dotnet restore NineChronicles.Headless.AccessControlCenter
+
+# Copy everything else and build
+COPY . ./
+RUN dotnet publish NineChronicles.Headless.AccessControlCenter/NineChronicles.Headless.AccessControlCenter.csproj \
+    -c Release \
+    -r linux-arm64 \
+    -o out \
+    --self-contained \
+    --version-suffix $COMMIT
+
+# Build runtime image
+FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim-arm64v8
+WORKDIR /app
+RUN apt-get update && apt-get install -y libc6-dev
+COPY --from=build-env /app/out .
+
+# Install native deps & utilities for production
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+        libc6-dev jq curl \
+     && rm -rf /var/lib/apt/lists/*
+
+VOLUME /data
+
+ENTRYPOINT ["dotnet", "NineChronicles.Headless.AccessControlCenter.dll"]

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/IMutableAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/IMutableAccessControlService.cs
@@ -1,0 +1,13 @@
+using Libplanet.Crypto;
+using System.Collections.Generic;
+using Nekoyume.Blockchain;
+
+namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
+{
+    public interface IMutableAccessControlService : IAccessControlService
+    {
+        void DenyAccess(Address address);
+        void AllowAccess(Address address);
+        List<Address> ListBlockedAddresses(int offset, int limit);
+    }
+}

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableAccessControlServiceFactory.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableAccessControlServiceFactory.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
+{
+    public static class MutableAccessControlServiceFactory
+    {
+        public enum StorageType
+        {
+            /// <summary>
+            /// Use Redis
+            /// </summary>
+            Redis,
+
+            /// <summary>
+            /// Use SQLite
+            /// </summary>
+            SQLite
+        }
+
+        public static IMutableAccessControlService Create(
+            StorageType storageType,
+            string connectionString
+        )
+        {
+            return storageType switch
+            {
+                StorageType.Redis => new MutableRedisAccessControlService(connectionString),
+                StorageType.SQLite => new MutableSqliteAccessControlService(connectionString),
+                _ => throw new ArgumentOutOfRangeException(nameof(storageType), storageType, null)
+            };
+        }
+    }
+}

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet.Crypto;
+using NineChronicles.Headless.Services;
+
+namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
+{
+    public class MutableRedisAccessControlService : RedisAccessControlService, IMutableAccessControlService
+    {
+
+        public MutableRedisAccessControlService(string storageUri) : base(storageUri)
+        {
+        }
+
+        public void DenyAccess(Address address)
+        {
+            _db.StringSet(address.ToString(), "denied");
+        }
+
+        public void AllowAccess(Address address)
+        {
+            _db.KeyDelete(address.ToString());
+        }
+
+        public List<Address> ListBlockedAddresses(int offset, int limit)
+        {
+            var server = _db.Multiplexer.GetServer(_db.Multiplexer.GetEndPoints().First());
+            var keys = server
+                .Keys()
+                .Select(k => new Address(k.ToString()))
+                .ToList();
+
+            return keys.Skip(offset).Take(limit).ToList();
+        }
+    }
+}

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
@@ -7,7 +7,6 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
 {
     public class MutableRedisAccessControlService : RedisAccessControlService, IMutableAccessControlService
     {
-
         public MutableRedisAccessControlService(string storageUri) : base(storageUri)
         {
         }
@@ -25,12 +24,12 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
         public List<Address> ListBlockedAddresses(int offset, int limit)
         {
             var server = _db.Multiplexer.GetServer(_db.Multiplexer.GetEndPoints().First());
-            var keys = server
+            return server
                 .Keys()
                 .Select(k => new Address(k.ToString()))
+                .Skip(offset)
+                .Take(limit)
                 .ToList();
-
-            return keys.Skip(offset).Take(limit).ToList();
         }
     }
 }

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using Microsoft.Data.Sqlite;
+using Libplanet.Crypto;
+using NineChronicles.Headless.Services;
+
+namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
+{
+    public class MutableSqliteAccessControlService : SQLiteAccessControlService, IMutableAccessControlService
+    {
+        private const string DenyAccessSql =
+            "INSERT OR IGNORE INTO blocklist (address) VALUES (@Address)";
+        private const string AllowAccessSql = "DELETE FROM blocklist WHERE address=@Address";
+
+        public MutableSqliteAccessControlService(string connectionString) : base(connectionString)
+        {
+        }
+
+        public void DenyAccess(Address address)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = DenyAccessSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+            command.ExecuteNonQuery();
+        }
+
+        public void AllowAccess(Address address)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = AllowAccessSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+            command.ExecuteNonQuery();
+        }
+
+        public List<Address> ListBlockedAddresses(int offset, int limit)
+        {
+            var blockedAddresses = new List<Address>();
+
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = $"SELECT address FROM blocklist LIMIT @Limit OFFSET @Offset";
+            command.Parameters.AddWithValue("@Limit", limit);
+            command.Parameters.AddWithValue("@Offset", offset);
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                blockedAddresses.Add(new Address(reader.GetString(0)));
+            }
+
+            return blockedAddresses;
+        }
+    }
+}

--- a/NineChronicles.Headless.AccessControlCenter/AcsService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AcsService.cs
@@ -11,27 +11,18 @@ namespace NineChronicles.Headless.AccessControlCenter
 {
     public class AcsService
     {
-        private readonly string _acsType;
-        private readonly string _acsConnectionString;
-
-        public AcsService(string acsType, string acsConnectionString)
+        public AcsService(Configuration configuration)
         {
-            _acsType = acsType;
-            _acsConnectionString = acsConnectionString;
+            Configuration = configuration;
         }
+
+        public Configuration Configuration { get; }
 
         public IHostBuilder Configure(IHostBuilder hostBuilder, int port)
         {
             return hostBuilder.ConfigureWebHostDefaults(builder =>
             {
-                builder.UseStartup(
-                    x =>
-                        new RestApiStartup(
-                            x.Configuration,
-                            _acsType,
-                            _acsConnectionString
-                        )
-                );
+                builder.UseStartup(x => new RestApiStartup(Configuration));
                 builder.ConfigureKestrel(options =>
                 {
                     options.ListenAnyIP(
@@ -47,29 +38,23 @@ namespace NineChronicles.Headless.AccessControlCenter
 
         internal class RestApiStartup
         {
-            private readonly string _acsType;
-            private readonly string _acsConnectionString;
-
-            public RestApiStartup(
-                IConfiguration configuration,
-                string acsType,
-                string acsConnectionString
-            )
+            public RestApiStartup(Configuration configuration)
             {
                 Configuration = configuration;
-                _acsType = acsType;
-                _acsConnectionString = acsConnectionString;
             }
 
-            public IConfiguration Configuration { get; }
+            public Configuration Configuration { get; }
 
             public void ConfigureServices(IServiceCollection services)
             {
                 services.AddControllers();
 
                 var accessControlService = MutableAccessControlServiceFactory.Create(
-                    Enum.Parse<MutableAccessControlServiceFactory.StorageType>(_acsType, true),
-                    _acsConnectionString
+                    Enum.Parse<MutableAccessControlServiceFactory.StorageType>(
+                        Configuration.AccessControlServiceType,
+                        true
+                    ),
+                    Configuration.AccessControlServiceConnectionString
                 );
 
                 services.AddSingleton(accessControlService);

--- a/NineChronicles.Headless.AccessControlCenter/AcsService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AcsService.cs
@@ -1,0 +1,95 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NineChronicles.Headless.AccessControlCenter.AccessControlService;
+
+namespace NineChronicles.Headless.AccessControlCenter
+{
+    public class AcsService
+    {
+        private readonly string _acsType;
+        private readonly string _acsConnectionString;
+
+        public AcsService(string acsType, string acsConnectionString)
+        {
+            _acsType = acsType;
+            _acsConnectionString = acsConnectionString;
+        }
+
+        public IHostBuilder Configure(IHostBuilder hostBuilder, int port)
+        {
+            return hostBuilder.ConfigureWebHostDefaults(builder =>
+            {
+                builder.UseStartup(
+                    x =>
+                        new RestApiStartup(
+                            x.Configuration,
+                            _acsType,
+                            _acsConnectionString
+                        )
+                );
+                builder.ConfigureKestrel(options =>
+                {
+                    options.ListenAnyIP(
+                        port,
+                        listenOptions =>
+                        {
+                            listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                        }
+                    );
+                });
+            });
+        }
+
+        internal class RestApiStartup
+        {
+            private readonly string _acsType;
+            private readonly string _acsConnectionString;
+
+            public RestApiStartup(
+                IConfiguration configuration,
+                string acsType,
+                string acsConnectionString
+            )
+            {
+                Configuration = configuration;
+                _acsType = acsType;
+                _acsConnectionString = acsConnectionString;
+            }
+
+            public IConfiguration Configuration { get; }
+
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddControllers();
+
+                var accessControlService = MutableAccessControlServiceFactory.Create(
+                    Enum.Parse<MutableAccessControlServiceFactory.StorageType>(_acsType, true),
+                    _acsConnectionString
+                );
+
+                services.AddSingleton(accessControlService);
+            }
+
+            public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+            {
+                if (env.IsDevelopment())
+                {
+                    app.UseDeveloperExceptionPage();
+                }
+
+                app.UseRouting();
+                app.UseAuthorization();
+
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapControllers();
+                });
+            }
+        }
+    }
+}

--- a/NineChronicles.Headless.AccessControlCenter/Configuration.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Configuration.cs
@@ -1,0 +1,11 @@
+namespace NineChronicles.Headless.AccessControlCenter
+{
+    public class Configuration
+    {
+        public int Port { get; set; }
+
+        public string AccessControlServiceType { get; set; } = null!;
+
+        public string AccessControlServiceConnectionString { get; set; } = null!;
+    }
+}

--- a/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using NineChronicles.Headless.AccessControlCenter.AccessControlService;
+using System.Linq;
+using Libplanet.Crypto;
+
+namespace NineChronicles.Headless.AccessControlCenter.Controllers
+{
+    [ApiController]
+    public class AccessControlServiceController : ControllerBase
+    {
+        private readonly IMutableAccessControlService _accessControlService;
+
+        public AccessControlServiceController(IMutableAccessControlService accessControlService)
+        {
+            _accessControlService = accessControlService;
+        }
+
+        [HttpGet("entries/{address}")]
+        public ActionResult<bool> IsAccessDenied(string address)
+        {
+            return _accessControlService.IsAccessDenied(new Address(address));
+        }
+
+        [HttpPost("entries/{address}/deny")]
+        public ActionResult DenyAccess(string address)
+        {
+            _accessControlService.DenyAccess(new Address(address));
+            return Ok();
+        }
+
+        [HttpPost("entries/{address}/allow")]
+        public ActionResult AllowAccess(string address)
+        {
+            _accessControlService.AllowAccess(new Address(address));
+            return Ok();
+        }
+
+        [HttpGet("entries")]
+        public ActionResult<List<string>> ListBlockedAddresses(int offset, int limit)
+        {
+            return _accessControlService
+                .ListBlockedAddresses(offset, limit)
+                .Select(a => a.ToString())
+                .ToList();
+        }
+    }
+}

--- a/NineChronicles.Headless.AccessControlCenter/NineChronicles.Headless.AccessControlCenter.csproj
+++ b/NineChronicles.Headless.AccessControlCenter/NineChronicles.Headless.AccessControlCenter.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>..\NineChronicles.Headless.Common.ruleset</CodeAnalysisRuleSet>
+    <Nullable>enable</Nullable>
+    <Configurations>Debug;Release;DevEx</Configurations>
+    <Platforms>AnyCPU</Platforms>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.49.0.57237">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lib9c\Lib9c.Policy\Lib9c.Policy.csproj" />
+    <ProjectReference Include="..\NineChronicles.Headless\NineChronicles.Headless.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NineChronicles.Headless.AccessControlCenter/Program.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Program.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace NineChronicles.Headless.AccessControlCenter
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            // Get configuration
+            string configPath =
+                Environment.GetEnvironmentVariable("ACS_CONFIG_FILE") ?? "appsettings.json";
+
+            var configurationBuilder = new ConfigurationBuilder()
+                .AddJsonFile(configPath)
+                .AddEnvironmentVariables("ACS_");
+            IConfiguration config = configurationBuilder.Build();
+
+            var acsConfig = new Configuration();
+            config.Bind(acsConfig);
+
+            var service = new AcsService(
+                acsConfig.AccessControlServiceType,
+                acsConfig.AccessControlServiceConnectionString
+            );
+            var hostBuilder = service.Configure(Host.CreateDefaultBuilder(), acsConfig.Port);
+            var host = hostBuilder.Build();
+            host.Run();
+        }
+    }
+}

--- a/NineChronicles.Headless.AccessControlCenter/Program.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Program.cs
@@ -10,20 +10,17 @@ namespace NineChronicles.Headless.AccessControlCenter
         {
             // Get configuration
             string configPath =
-                Environment.GetEnvironmentVariable("ACS_CONFIG_FILE") ?? "appsettings.json";
+                Environment.GetEnvironmentVariable("ACC_CONFIG_FILE") ?? "appsettings.json";
 
             var configurationBuilder = new ConfigurationBuilder()
                 .AddJsonFile(configPath)
-                .AddEnvironmentVariables("ACS_");
+                .AddEnvironmentVariables("ACC_");
             IConfiguration config = configurationBuilder.Build();
 
             var acsConfig = new Configuration();
             config.Bind(acsConfig);
 
-            var service = new AcsService(
-                acsConfig.AccessControlServiceType,
-                acsConfig.AccessControlServiceConnectionString
-            );
+            var service = new AcsService(acsConfig);
             var hostBuilder = service.Configure(Host.CreateDefaultBuilder(), acsConfig.Port);
             var host = hostBuilder.Build();
             host.Run();

--- a/NineChronicles.Headless.AccessControlCenter/appsettings.json
+++ b/NineChronicles.Headless.AccessControlCenter/appsettings.json
@@ -1,0 +1,5 @@
+{
+    "Port": "31259",
+    "AccessControlServiceType": "redis",
+    "AccessControlServiceConnectionString": "localhost:6379"
+}

--- a/NineChronicles.Headless.Executable.sln
+++ b/NineChronicles.Headless.Executable.sln
@@ -78,6 +78,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.Remote
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.RemoteBlockChainStates", "Lib9c\.Libplanet.Extensions.RemoteBlockChainStates\Libplanet.Extensions.RemoteBlockChainStates.csproj", "{8F9E5505-C157-4DF3-A419-FF0108731397}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NineChronicles.Headless.AccessControlCenter", "NineChronicles.Headless.AccessControlCenter\NineChronicles.Headless.AccessControlCenter.csproj", "{162C0F4B-A1D9-4132-BC34-31F1247BC26B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -703,6 +705,24 @@ Global
 		{8F9E5505-C157-4DF3-A419-FF0108731397}.Release|x64.Build.0 = Release|Any CPU
 		{8F9E5505-C157-4DF3-A419-FF0108731397}.Release|x86.ActiveCfg = Release|Any CPU
 		{8F9E5505-C157-4DF3-A419-FF0108731397}.Release|x86.Build.0 = Release|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Debug|x64.Build.0 = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Debug|x86.Build.0 = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.DevEx|Any CPU.ActiveCfg = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.DevEx|Any CPU.Build.0 = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.DevEx|x64.ActiveCfg = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.DevEx|x64.Build.0 = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.DevEx|x86.ActiveCfg = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.DevEx|x86.Build.0 = Debug|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Release|x64.ActiveCfg = Release|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Release|x64.Build.0 = Release|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Release|x86.ActiveCfg = Release|Any CPU
+		{162C0F4B-A1D9-4132-BC34-31F1247BC26B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -89,6 +89,8 @@ namespace NineChronicles.Headless.Executable
 
         public StateServiceManagerServiceOptions? StateServiceManagerService { get; set; }
 
+        public AccessControlServiceOptions? AccessControlService { get; set; }
+
         public void Overwrite(
             string? appProtocolVersionString,
             string[]? trustedAppProtocolVersionSignerStrings,

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -205,7 +205,11 @@ namespace NineChronicles.Headless.Executable
                 Description = "Absolute path of \"appsettings.json\" file to provide headless configurations.")]
             string? configPath = "appsettings.json",
             [Option(Description = "Sentry DSN")]
-            string? sentryDsn = "",
+            string? sentryDsn = "",           
+            [Option(Description = "AccessControlService Type")]
+            string? acsType = null,
+            [Option(Description = "AccessControlService ConnectionString")]
+            string? acsConnectionString = null,
             [Option(Description = "Trace sample rate for sentry")]
             double? sentryTraceSampleRate = null,
             [Ignore] CancellationToken? cancellationToken = null
@@ -436,7 +440,7 @@ namespace NineChronicles.Headless.Executable
                     : new PrivateKey(ByteUtil.ParseHex(headlessConfig.MinerPrivateKeyString));
                 TimeSpan minerBlockInterval = TimeSpan.FromMilliseconds(headlessConfig.MinerBlockIntervalMilliseconds);
                 var nineChroniclesProperties =
-                    new NineChroniclesNodeServiceProperties(actionLoader, headlessConfig.StateServiceManagerService)
+                    new NineChroniclesNodeServiceProperties(actionLoader, headlessConfig.StateServiceManagerService, headlessConfig.AccessControlService)
                     {
                         MinerPrivateKey = minerPrivateKey,
                         Libplanet = properties,

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -205,11 +205,7 @@ namespace NineChronicles.Headless.Executable
                 Description = "Absolute path of \"appsettings.json\" file to provide headless configurations.")]
             string? configPath = "appsettings.json",
             [Option(Description = "Sentry DSN")]
-            string? sentryDsn = "",           
-            [Option(Description = "AccessControlService Type")]
-            string? acsType = null,
-            [Option(Description = "AccessControlService ConnectionString")]
-            string? acsConnectionString = null,
+            string? sentryDsn = "",
             [Option(Description = "Trace sample rate for sentry")]
             double? sentryTraceSampleRate = null,
             [Ignore] CancellationToken? cancellationToken = null

--- a/NineChronicles.Headless.Tests/GraphQLStartupTest.cs
+++ b/NineChronicles.Headless.Tests/GraphQLStartupTest.cs
@@ -4,8 +4,8 @@ using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using static NineChronicles.Headless.Tests.GraphQLTestUtils;
 using Xunit;
+using static NineChronicles.Headless.Tests.GraphQLTestUtils;
 
 namespace NineChronicles.Headless.Tests
 {

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneSubscriptionTest.cs
@@ -54,7 +54,6 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 BlockChain.Append(block, GenerateBlockCommit(block.Index, block.Hash, GenesisValidators));
 
                 // var data = (Dictionary<string, object>)((ExecutionNode) result.Data!).ToValue()!;
-
                 Assert.Equal(index, BlockChain.Tip.Index);
                 await Task.Delay(TimeSpan.FromSeconds(1));
 

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -39,7 +39,9 @@
     <PackageReference Include="MagicOnion.Abstractions" Version="5.0.3" />
     <PackageReference Include="MagicOnion.Server" Version="5.0.3" />
     <PackageReference Include="MagicOnion.Server.HttpGateway" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="NRedisStack" Version="0.9.0" />
     <PackageReference Include="Sentry" Version="3.23.0" />
     <PackageReference Include="Sentry.AspNetCore.Grpc" Version="3.22.0" />
     <PackageReference Include="Sentry.DiagnosticSource" Version="3.22.0" />

--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -20,6 +20,7 @@ using Nekoyume.Blockchain;
 using Nekoyume.Blockchain.Policy;
 using NineChronicles.Headless.Properties;
 using NineChronicles.Headless.Utils;
+using NineChronicles.Headless.Services;
 using NineChronicles.RPC.Shared.Exceptions;
 using Nito.AsyncEx;
 using Serilog;
@@ -78,14 +79,27 @@ namespace NineChronicles.Headless
             bool ignorePreloadFailure = false,
             bool strictRendering = false,
             TimeSpan txLifeTime = default,
-            int txQuotaPerSigner = 10
+            int txQuotaPerSigner = 10,
+            AccessControlServiceOptions? acsOptions = null
         )
         {
             MinerPrivateKey = minerPrivateKey;
             Properties = properties;
 
             LogEventLevel logLevel = LogEventLevel.Debug;
-            IStagePolicy stagePolicy = new NCStagePolicy(txLifeTime, txQuotaPerSigner);
+
+            IAccessControlService? accessControlService = null;
+
+            if (acsOptions != null)
+            {
+                accessControlService = AccessControlServiceFactory.Create(
+                    acsOptions.GetStorageType(),
+                    acsOptions.AccessControlServiceConnectionString
+                );
+            }
+
+            IStagePolicy stagePolicy = new NCStagePolicy(
+                txLifeTime, txQuotaPerSigner, accessControlService);
 
             BlockRenderer = new BlockRenderer();
             ActionRenderer = new ActionRenderer();
@@ -201,7 +215,8 @@ namespace NineChronicles.Headless
                 ignorePreloadFailure: properties.IgnorePreloadFailure,
                 strictRendering: properties.StrictRender,
                 txLifeTime: properties.TxLifeTime,
-                txQuotaPerSigner: properties.TxQuotaPerSigner
+                txQuotaPerSigner: properties.TxQuotaPerSigner,
+                acsOptions: properties.AccessControlServiceOptions
             );
             service.ConfigureContext(context);
             var meter = new Meter("NineChronicles");

--- a/NineChronicles.Headless/Properties/AccessControlServiceOptions.cs
+++ b/NineChronicles.Headless/Properties/AccessControlServiceOptions.cs
@@ -8,7 +8,7 @@ namespace NineChronicles.Headless.Properties
     {
         [Required]
         public string AccessControlServiceType { get; set; } = null!;
-    
+
         [Required]
         public string AccessControlServiceConnectionString { get; set; } = null!;
 

--- a/NineChronicles.Headless/Properties/AccessControlServiceOptions.cs
+++ b/NineChronicles.Headless/Properties/AccessControlServiceOptions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using NineChronicles.Headless.Services;
+
+namespace NineChronicles.Headless.Properties
+{
+    public class AccessControlServiceOptions
+    {
+        [Required]
+        public string AccessControlServiceType { get; set; } = null!;
+    
+        [Required]
+        public string AccessControlServiceConnectionString { get; set; } = null!;
+
+        public AccessControlServiceFactory.StorageType GetStorageType()
+        {
+            return Enum.Parse<AccessControlServiceFactory.StorageType>(AccessControlServiceType, true);
+        }
+    }
+}

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -12,10 +12,12 @@ namespace NineChronicles.Headless.Properties
 {
     public class NineChroniclesNodeServiceProperties
     {
-        public NineChroniclesNodeServiceProperties(IActionLoader actionLoader, StateServiceManagerServiceOptions? stateServiceManagerServiceOptions)
+        public NineChroniclesNodeServiceProperties(
+            IActionLoader actionLoader, StateServiceManagerServiceOptions? stateServiceManagerServiceOptions, AccessControlServiceOptions? accessControlServiceOptions)
         {
             ActionLoader = actionLoader;
             StateServiceManagerService = stateServiceManagerServiceOptions;
+            AccessControlServiceOptions = accessControlServiceOptions;
         }
 
         /// <summary>
@@ -53,6 +55,8 @@ namespace NineChronicles.Headless.Properties
         public IActionLoader ActionLoader { get; init; }
 
         public StateServiceManagerServiceOptions? StateServiceManagerService { get; }
+
+        public AccessControlServiceOptions? AccessControlServiceOptions { get; }
 
         public static LibplanetNodeServiceProperties
             GenerateLibplanetNodeServiceProperties(

--- a/NineChronicles.Headless/Services/AccessControlServiceFactory.cs
+++ b/NineChronicles.Headless/Services/AccessControlServiceFactory.cs
@@ -1,0 +1,34 @@
+using System;
+using Nekoyume.Blockchain;
+
+namespace NineChronicles.Headless.Services
+{
+    public static class AccessControlServiceFactory
+    {
+        public enum StorageType
+        {
+            /// <summary>
+            /// Use Redis
+            /// </summary>
+            Redis,
+
+            /// <summary>
+            /// Use SQLite
+            /// </summary>
+            SQLite
+        }
+
+        public static IAccessControlService Create(
+            StorageType storageType,
+            string connectionString
+        )
+        {
+            return storageType switch
+            {
+                StorageType.Redis => new RedisAccessControlService(connectionString),
+                StorageType.SQLite => new SQLiteAccessControlService(connectionString),
+                _ => throw new ArgumentOutOfRangeException(nameof(storageType), storageType, null)
+            };
+        }
+    }
+}

--- a/NineChronicles.Headless/Services/RedisAccessControlService.cs
+++ b/NineChronicles.Headless/Services/RedisAccessControlService.cs
@@ -1,0 +1,22 @@
+using StackExchange.Redis;
+using Libplanet.Crypto;
+using Nekoyume.Blockchain;
+
+namespace NineChronicles.Headless.Services
+{
+    public class RedisAccessControlService : IAccessControlService
+    {
+        private IDatabase _db;
+
+        public RedisAccessControlService(string storageUri)
+        {
+            var redis = ConnectionMultiplexer.Connect(storageUri);
+            _db = redis.GetDatabase();
+        }
+
+        public bool IsAccessDenied(Address address)
+        {
+            return _db.KeyExists(address.ToString());
+        }
+    }
+}

--- a/NineChronicles.Headless/Services/RedisAccessControlService.cs
+++ b/NineChronicles.Headless/Services/RedisAccessControlService.cs
@@ -6,7 +6,7 @@ namespace NineChronicles.Headless.Services
 {
     public class RedisAccessControlService : IAccessControlService
     {
-        private IDatabase _db;
+        protected IDatabase _db;
 
         public RedisAccessControlService(string storageUri)
         {

--- a/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
+++ b/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
@@ -1,0 +1,41 @@
+using Microsoft.Data.Sqlite;
+using Libplanet.Crypto;
+using Nekoyume.Blockchain;
+
+namespace NineChronicles.Headless.Services
+{
+    public class SQLiteAccessControlService : IAccessControlService
+    {
+        private const string CreateTableSql =
+            "CREATE TABLE IF NOT EXISTS blocklist (address VARCHAR(42))";
+        private const string CheckAccessSql =
+            "SELECT EXISTS(SELECT 1 FROM blocklist WHERE address=@Address)";
+
+        private readonly string _connectionString;
+
+        public SQLiteAccessControlService(string connectionString)
+        {
+            _connectionString = connectionString;
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = CreateTableSql;
+            command.ExecuteNonQuery();
+        }
+
+        public bool IsAccessDenied(Address address)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = CheckAccessSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+
+            var result = command.ExecuteScalar();
+
+            return result is not null && (long)result == 1;
+        }
+    }
+}

--- a/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
+++ b/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
@@ -11,7 +11,7 @@ namespace NineChronicles.Headless.Services
         private const string CheckAccessSql =
             "SELECT EXISTS(SELECT 1 FROM blocklist WHERE address=@Address)";
 
-        private readonly string _connectionString;
+        protected readonly string _connectionString;
 
         public SQLiteAccessControlService(string connectionString)
         {


### PR DESCRIPTION
This PR should be merged after [lib9c PR](https://github.com/planetarium/lib9c/pull/2168) and then bumped.

This PR introduces the following changes related to the `AccessControlService`

- Added core logic for AccessControlService to manage access permissions.
- The AccessControlCenter can now control access permissions for using the REST API.
- Users can choose their desired storage type (SQLite, Redis). When an address is added as a key to the specified storage, it will be denied during staging in NCPolicy.
<img width="816" alt="image" src="https://github.com/planetarium/NineChronicles.Headless/assets/30599098/930c124e-c578-49ec-a244-693282926510">
