### PR TITLE
Add whitelist option to ACC service

### DIFF
--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/IMutableAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/IMutableAccessControlService.cs
@@ -8,6 +8,8 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
     {
         void DenyAccess(Address address);
         void AllowAccess(Address address);
+        void DenyWhiteList(Address address);
+        void AllowWhiteList(Address address);
         List<Address> ListBlockedAddresses(int offset, int limit);
     }
 }

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
@@ -18,12 +18,30 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
 
         public void DenyAccess(Address address)
         {
-            _db.StringSet(address.ToString(), "denied");
+            _db.StringSet(address.ToString(), "0");
         }
 
         public void AllowAccess(Address address)
         {
-            _db.KeyDelete(address.ToString());
+            var value = _db.StringGet(address.ToString());
+            if (value == "0")
+            {
+                _db.KeyDelete(address.ToString());
+            }
+        }
+
+        public void DenyWhiteList(Address address)
+        {
+            var value = _db.StringGet(address.ToString());
+            if (value == "1")
+            {
+                _db.KeyDelete(address.ToString());
+            }
+        }
+
+        public void AllowWhiteList(Address address)
+        {
+            _db.StringSet(address.ToString(), "1");
         }
 
         public List<Address> ListBlockedAddresses(int offset, int limit)

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
@@ -9,8 +9,12 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
     public class MutableSqliteAccessControlService : SQLiteAccessControlService, IMutableAccessControlService
     {
         private const string DenyAccessSql =
-            "INSERT OR IGNORE INTO blocklist (address) VALUES (@Address)";
+            "INSERT OR IGNORE INTO blocklist (address) VALUES (@Address, 0)";
         private const string AllowAccessSql = "DELETE FROM blocklist WHERE address=@Address";
+
+        private const string AllowWhiteListSql =
+            "INSERT OR IGNORE INTO blocklist (address) VALUES (@Address, 1)";
+        private const string DenyWhiteListSql = "DELETE FROM blocklist WHERE address=@Address";
 
         public MutableSqliteAccessControlService(string connectionString) : base(connectionString)
         {
@@ -34,6 +38,28 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
 
             using var command = connection.CreateCommand();
             command.CommandText = AllowAccessSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+            command.ExecuteNonQuery();
+        }
+
+        public void DenyWhiteList(Address address)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = DenyWhiteListSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+            command.ExecuteNonQuery();
+        }
+
+        public void AllowWhiteList(Address address)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = AllowWhiteListSql;
             command.Parameters.AddWithValue("@Address", address.ToString());
             command.ExecuteNonQuery();
         }

--- a/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
@@ -36,6 +36,20 @@ namespace NineChronicles.Headless.AccessControlCenter.Controllers
             return Ok();
         }
 
+        [HttpPost("entries/{address}/deny-whitelist")]
+        public ActionResult DenyWhiteList(string address)
+        {
+            _accessControlService.DenyWhiteList(new Address(address));
+            return Ok();
+        }
+
+        [HttpPost("entries/{address}/allow-whitelist")]
+        public ActionResult AllowWhiteList(string address)
+        {
+            _accessControlService.AllowWhiteList(new Address(address));
+            return Ok();
+        }
+
         [HttpGet("entries")]
         public ActionResult<List<string>> ListBlockedAddresses(int offset, int limit)
         {

--- a/NineChronicles.Headless/Services/RedisAccessControlService.cs
+++ b/NineChronicles.Headless/Services/RedisAccessControlService.cs
@@ -1,3 +1,4 @@
+using System;
 using StackExchange.Redis;
 using Libplanet.Crypto;
 using Nekoyume.Blockchain;
@@ -25,6 +26,22 @@ namespace NineChronicles.Headless.Services
             }
 
             return result;
+        }
+
+        public int GetAccessLevel(Address address)
+        {
+            RedisValue result = _db.StringGet(address.ToString());
+            if (result.IsNull)
+            {
+                result = "-1";
+            }
+            else
+            {
+                Log.ForContext("Source", nameof(IAccessControlService))
+                    .Debug("\"{Address}\" access level: {level}", address, result);
+            }
+
+            return Convert.ToInt32(result);
         }
     }
 }

--- a/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
+++ b/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Data.Sqlite;
 using Libplanet.Crypto;
 using Nekoyume.Blockchain;
@@ -8,9 +9,11 @@ namespace NineChronicles.Headless.Services
     public class SQLiteAccessControlService : IAccessControlService
     {
         private const string CreateTableSql =
-            "CREATE TABLE IF NOT EXISTS blocklist (address VARCHAR(42))";
+            "CREATE TABLE IF NOT EXISTS blocklist (address VARCHAR(42), level INT)";
         private const string CheckAccessSql =
             "SELECT EXISTS(SELECT 1 FROM blocklist WHERE address=@Address)";
+        private const string CheckAccessLevelSql =
+            "SELECT level FROM blocklist WHERE address=@Address";
 
         protected readonly string _connectionString;
 
@@ -45,6 +48,20 @@ namespace NineChronicles.Headless.Services
             }
 
             return result;
+        }
+
+        public int GetAccessLevel(Address address)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = CheckAccessLevelSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+
+            var queryResult = command.ExecuteScalar() ?? "-1";
+
+            return Convert.ToInt32(queryResult);
         }
     }
 }


### PR DESCRIPTION
Previously, the ACC checked if an address simply exists in the db to determine whether it should be denied.

The new update refers to the value of the address key to determine its 'access level":

- A value of `0` means that the address should be denied.
- A value of `1` means that the address is whitelisted and all txs should be staged without limit.

In the future, the numeric value of the key will be used to allow more txs to be mined in a block (This change needs further investigation into dynamically adjusting the `BlockPolicy`).

p.s. This PR requires a new `lib9c` bump after https://github.com/planetarium/lib9c/pull/2191 is merged.