### PR TITLE
Bump lib9c

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierSheetTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/States/Models/CrystalMonsterCollectionMultiplierSheetTypeTest.cs
@@ -59,6 +59,16 @@ namespace NineChronicles.Headless.Tests.GraphTypes.States.Models
                     ["level"] = 5,
                     ["multiplier"] = 300,
                 },
+                new Dictionary<string, object>
+                {
+                    ["level"] = 6,
+                    ["multiplier"] = 300,
+                },
+                new Dictionary<string, object>
+                {
+                    ["level"] = 7,
+                    ["multiplier"] = 300,
+                },
             };
             var expected = new Dictionary<string, object> { { "orderedList", list } };
             Assert.Equal(expected, data);


### PR DESCRIPTION
Fix failing `CrystalMonsterCollectionMultiplierSheetTypeTest` after bumping lib9c to https://github.com/planetarium/lib9c/commit/dd343eb6f69f857e8547126b88990cdd9d133fc3.