### PR TITLE
Add `AddTxQuota` and `RemoveTxQuota` to ACS

### DIFF
--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/IMutableAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/IMutableAccessControlService.cs
@@ -8,6 +8,8 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
     {
         void DenyAccess(Address address);
         void AllowAccess(Address address);
+        void AddTxQuota(Address address, int quota);
+        void RemoveTxQuota(Address address);
         List<Address> ListBlockedAddresses(int offset, int limit);
     }
 }

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/IMutableAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/IMutableAccessControlService.cs
@@ -6,10 +6,8 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
 {
     public interface IMutableAccessControlService : IAccessControlService
     {
-        void DenyAccess(Address address);
-        void AllowAccess(Address address);
         void AddTxQuota(Address address, int quota);
         void RemoveTxQuota(Address address);
-        List<Address> ListBlockedAddresses(int offset, int limit);
+        List<Address> ListTxQuotaAddresses(int offset, int limit);
     }
 }

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Crypto;
@@ -16,20 +15,6 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
         {
         }
 
-        public void DenyAccess(Address address)
-        {
-            _db.StringSet(address.ToString(), "0");
-        }
-
-        public void AllowAccess(Address address)
-        {
-            var value = _db.StringGet(address.ToString());
-            if (value == "0")
-            {
-                _db.KeyDelete(address.ToString());
-            }
-        }
-
         public void AddTxQuota(Address address, int quota)
         {
             _db.StringSet(address.ToString(), quota.ToString());
@@ -40,7 +25,7 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
             _db.KeyDelete(address.ToString());
         }
 
-        public List<Address> ListBlockedAddresses(int offset, int limit)
+        public List<Address> ListTxQuotaAddresses(int offset, int limit)
         {
             var server = _db.Multiplexer.GetServer(_db.Multiplexer.GetEndPoints().First());
 
@@ -48,11 +33,10 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
                 server.Execute("SCAN", offset.ToString(), "COUNT", limit.ToString());
             if (result != null)
             {
-                long newCursor = long.Parse((string)result[0]!);
                 RedisKey[] keys = (RedisKey[])result[1]!;
-
                 return keys.Select(k => new Address(k.ToString())).ToList();
             }
+
             return new List<Address>();
         }
     }

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableRedisAccessControlService.cs
@@ -18,10 +18,24 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
 
         public void DenyAccess(Address address)
         {
-            _db.StringSet(address.ToString(), "denied");
+            _db.StringSet(address.ToString(), "0");
         }
 
         public void AllowAccess(Address address)
+        {
+            var value = _db.StringGet(address.ToString());
+            if (value == "0")
+            {
+                _db.KeyDelete(address.ToString());
+            }
+        }
+
+        public void AddTxQuota(Address address, int quota)
+        {
+            _db.StringSet(address.ToString(), quota.ToString());
+        }
+
+        public void RemoveTxQuota(Address address)
         {
             _db.KeyDelete(address.ToString());
         }

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
@@ -50,7 +50,7 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
             using var command = connection.CreateCommand();
             command.CommandText = AddTxQuotaSql;
             command.Parameters.AddWithValue("@Address", address.ToString());
-            command.Parameters.AddWithValue("@Quota", quota.ToString());
+            command.Parameters.AddWithValue("@Quota", quota);
             command.ExecuteNonQuery();
         }
 

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
@@ -8,38 +8,12 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
 {
     public class MutableSqliteAccessControlService : SQLiteAccessControlService, IMutableAccessControlService
     {
-        private const string DenyAccessSql =
-            "INSERT OR IGNORE INTO blocklist (address, quota) VALUES (@Address, 0)";
-        private const string AllowAccessSql = "DELETE FROM blocklist WHERE address=@Address";
-
         private const string AddTxQuotaSql =
-            "INSERT OR IGNORE INTO blocklist (address, quota) VALUES (@Address, @Quota)";
-        private const string RemoveTxQuotaSql = "DELETE FROM blocklist WHERE address=@Address";
+            "INSERT OR IGNORE INTO txquotalist (address, quota) VALUES (@Address, @Quota)";
+        private const string RemoveTxQuotaSql = "DELETE FROM txquotalist WHERE address=@Address";
 
         public MutableSqliteAccessControlService(string connectionString) : base(connectionString)
         {
-        }
-
-        public void DenyAccess(Address address)
-        {
-            using var connection = new SqliteConnection(_connectionString);
-            connection.Open();
-
-            using var command = connection.CreateCommand();
-            command.CommandText = DenyAccessSql;
-            command.Parameters.AddWithValue("@Address", address.ToString());
-            command.ExecuteNonQuery();
-        }
-
-        public void AllowAccess(Address address)
-        {
-            using var connection = new SqliteConnection(_connectionString);
-            connection.Open();
-
-            using var command = connection.CreateCommand();
-            command.CommandText = AllowAccessSql;
-            command.Parameters.AddWithValue("@Address", address.ToString());
-            command.ExecuteNonQuery();
         }
 
         public void AddTxQuota(Address address, int quota)
@@ -65,25 +39,25 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
             command.ExecuteNonQuery();
         }
 
-        public List<Address> ListBlockedAddresses(int offset, int limit)
+        public List<Address> ListTxQuotaAddresses(int offset, int limit)
         {
-            var blockedAddresses = new List<Address>();
+            var txQuotaAddresses = new List<Address>();
 
             using var connection = new SqliteConnection(_connectionString);
             connection.Open();
 
             using var command = connection.CreateCommand();
-            command.CommandText = $"SELECT address FROM blocklist LIMIT @Limit OFFSET @Offset";
+            command.CommandText = $"SELECT address FROM txquotalist LIMIT @Limit OFFSET @Offset";
             command.Parameters.AddWithValue("@Limit", limit);
             command.Parameters.AddWithValue("@Offset", offset);
 
             using var reader = command.ExecuteReader();
             while (reader.Read())
             {
-                blockedAddresses.Add(new Address(reader.GetString(0)));
+                txQuotaAddresses.Add(new Address(reader.GetString(0)));
             }
 
-            return blockedAddresses;
+            return txQuotaAddresses;
         }
     }
 }

--- a/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
+++ b/NineChronicles.Headless.AccessControlCenter/AccessControlService/MutableSqliteAccessControlService.cs
@@ -9,8 +9,12 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
     public class MutableSqliteAccessControlService : SQLiteAccessControlService, IMutableAccessControlService
     {
         private const string DenyAccessSql =
-            "INSERT OR IGNORE INTO blocklist (address) VALUES (@Address)";
+            "INSERT OR IGNORE INTO blocklist (address, quota) VALUES (@Address, 0)";
         private const string AllowAccessSql = "DELETE FROM blocklist WHERE address=@Address";
+
+        private const string AddTxQuotaSql =
+            "INSERT OR IGNORE INTO blocklist (address, quota) VALUES (@Address, @Quota)";
+        private const string RemoveTxQuotaSql = "DELETE FROM blocklist WHERE address=@Address";
 
         public MutableSqliteAccessControlService(string connectionString) : base(connectionString)
         {
@@ -34,6 +38,29 @@ namespace NineChronicles.Headless.AccessControlCenter.AccessControlService
 
             using var command = connection.CreateCommand();
             command.CommandText = AllowAccessSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+            command.ExecuteNonQuery();
+        }
+
+        public void AddTxQuota(Address address, int quota)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = AddTxQuotaSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+            command.Parameters.AddWithValue("@Quota", quota.ToString());
+            command.ExecuteNonQuery();
+        }
+
+        public void RemoveTxQuota(Address address)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = RemoveTxQuotaSql;
             command.Parameters.AddWithValue("@Address", address.ToString());
             command.ExecuteNonQuery();
         }

--- a/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
@@ -18,30 +18,15 @@ namespace NineChronicles.Headless.AccessControlCenter.Controllers
         }
 
         [HttpGet("entries/{address}")]
-        public ActionResult<bool> IsAccessDenied(string address)
+        public ActionResult<bool> IsListed(string address)
         {
-            return _accessControlService.IsAccessDenied(new Address(address));
+            return _accessControlService.IsListed(new Address(address));
         }
 
-        [HttpPost("entries/{address}/deny")]
-        public ActionResult DenyAccess(string address)
+        [HttpPost("entries/add-tx-quota/{address}/{quota:int}")]
+        public ActionResult AddTxQuota(string address, int quota)
         {
-            _accessControlService.DenyAccess(new Address(address));
-            return Ok();
-        }
-
-        [HttpPost("entries/{address}/allow")]
-        public ActionResult AllowAccess(string address)
-        {
-            _accessControlService.AllowAccess(new Address(address));
-            return Ok();
-        }
-
-        [HttpPost("entries/add-tx-quota/{address}/{quota}")]
-        public ActionResult AddTxQuota(string address, string quota)
-        {
-            var txQuota = Convert.ToInt32(quota);
-            _accessControlService.AddTxQuota(new Address(address), txQuota);
+            _accessControlService.AddTxQuota(new Address(address), quota);
             return Ok();
         }
 
@@ -70,7 +55,7 @@ namespace NineChronicles.Headless.AccessControlCenter.Controllers
             }
 
             return _accessControlService
-                .ListBlockedAddresses(offset, limit)
+                .ListTxQuotaAddresses(offset, limit)
                 .Select(a => a.ToString())
                 .ToList();
         }

--- a/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NineChronicles.Headless.AccessControlCenter.AccessControlService;
@@ -33,6 +34,21 @@ namespace NineChronicles.Headless.AccessControlCenter.Controllers
         public ActionResult AllowAccess(string address)
         {
             _accessControlService.AllowAccess(new Address(address));
+            return Ok();
+        }
+
+        [HttpPost("entries/add-tx-quota/{address}/{quota}")]
+        public ActionResult AddTxQuota(string address, string quota)
+        {
+            var txQuota = Convert.ToInt32(quota);
+            _accessControlService.AddTxQuota(new Address(address), txQuota);
+            return Ok();
+        }
+
+        [HttpPost("entries/remove-tx-quota/{address}")]
+        public ActionResult RemoveTxQuota(string address)
+        {
+            _accessControlService.RemoveTxQuota(new Address(address));
             return Ok();
         }
 

--- a/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
@@ -18,9 +18,9 @@ namespace NineChronicles.Headless.AccessControlCenter.Controllers
         }
 
         [HttpGet("entries/{address}")]
-        public ActionResult<bool> IsListed(string address)
+        public ActionResult<int?> GetTxQuota(string address)
         {
-            return _accessControlService.IsListed(new Address(address));
+            return _accessControlService.GetTxQuota(new Address(address));
         }
 
         [HttpPost("entries/add-tx-quota/{address}/{quota:int}")]

--- a/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
@@ -26,10 +26,10 @@ namespace NineChronicles.Headless.AccessControlCenter.Controllers
         [HttpPost("entries/add-tx-quota/{address}/{quota:int}")]
         public ActionResult AddTxQuota(string address, int quota)
         {
-            var maxLimit = 10;
-            if (quota > maxLimit)
+            var maxQuota = 10;
+            if (quota > maxQuota)
             {
-                return BadRequest($"The limit cannot exceed {maxLimit}.");
+                return BadRequest($"The quota cannot exceed {maxQuota}.");
             }
 
             _accessControlService.AddTxQuota(new Address(address), quota);

--- a/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
+++ b/NineChronicles.Headless.AccessControlCenter/Controllers/AccessControlServiceController.cs
@@ -26,6 +26,12 @@ namespace NineChronicles.Headless.AccessControlCenter.Controllers
         [HttpPost("entries/add-tx-quota/{address}/{quota:int}")]
         public ActionResult AddTxQuota(string address, int quota)
         {
+            var maxLimit = 10;
+            if (quota > maxLimit)
+            {
+                return BadRequest($"The limit cannot exceed {maxLimit}.");
+            }
+
             _accessControlService.AddTxQuota(new Address(address), quota);
             return Ok();
         }

--- a/NineChronicles.Headless/Services/RedisAccessControlService.cs
+++ b/NineChronicles.Headless/Services/RedisAccessControlService.cs
@@ -16,13 +16,13 @@ namespace NineChronicles.Headless.Services
             _db = redis.GetDatabase();
         }
 
-        public bool IsAccessDenied(Address address)
+        public bool IsListed(Address address)
         {
             var result = _db.KeyExists(address.ToString());
             if (result)
             {
                 Log.ForContext("Source", nameof(IAccessControlService))
-                    .Debug("\"{Address}\" is access denied", address);
+                    .Debug("\"{Address}\" is listed", address);
             }
 
             return result;

--- a/NineChronicles.Headless/Services/RedisAccessControlService.cs
+++ b/NineChronicles.Headless/Services/RedisAccessControlService.cs
@@ -34,10 +34,11 @@ namespace NineChronicles.Headless.Services
             if (!result.IsNull)
             {
                 Log.ForContext("Source", nameof(IAccessControlService))
-                    .Debug("\"{Address}\" access level: {level}", address, result);
+                    .Debug("\"{Address}\" Tx Quota: {Quota}", address, result);
+                return Convert.ToInt32(result);
             }
 
-            return Convert.ToInt32(result);
+            return null;
         }
     }
 }

--- a/NineChronicles.Headless/Services/RedisAccessControlService.cs
+++ b/NineChronicles.Headless/Services/RedisAccessControlService.cs
@@ -16,18 +16,6 @@ namespace NineChronicles.Headless.Services
             _db = redis.GetDatabase();
         }
 
-        public bool IsListed(Address address)
-        {
-            var result = _db.KeyExists(address.ToString());
-            if (result)
-            {
-                Log.ForContext("Source", nameof(IAccessControlService))
-                    .Debug("\"{Address}\" is listed", address);
-            }
-
-            return result;
-        }
-
         public int? GetTxQuota(Address address)
         {
             RedisValue result = _db.StringGet(address.ToString());

--- a/NineChronicles.Headless/Services/RedisAccessControlService.cs
+++ b/NineChronicles.Headless/Services/RedisAccessControlService.cs
@@ -1,3 +1,4 @@
+using System;
 using StackExchange.Redis;
 using Libplanet.Crypto;
 using Nekoyume.Blockchain;
@@ -25,6 +26,18 @@ namespace NineChronicles.Headless.Services
             }
 
             return result;
+        }
+
+        public int? GetTxQuota(Address address)
+        {
+            RedisValue result = _db.StringGet(address.ToString());
+            if (!result.IsNull)
+            {
+                Log.ForContext("Source", nameof(IAccessControlService))
+                    .Debug("\"{Address}\" access level: {level}", address, result);
+            }
+
+            return Convert.ToInt32(result);
         }
     }
 }

--- a/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
+++ b/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
@@ -9,11 +9,11 @@ namespace NineChronicles.Headless.Services
     public class SQLiteAccessControlService : IAccessControlService
     {
         private const string CreateTableSql =
-            "CREATE TABLE IF NOT EXISTS blocklist (address VARCHAR(42), quota INT)";
-        private const string CheckAccessSql =
-            "SELECT EXISTS(SELECT 1 FROM blocklist WHERE address=@Address)";
+            "CREATE TABLE IF NOT EXISTS txquotalist (address VARCHAR(42), quota INT)";
+        private const string CheckAddressSql =
+            "SELECT EXISTS(SELECT 1 FROM txquotalist WHERE address=@Address)";
         private const string GetTxQuotaSql =
-            "SELECT quota FROM blocklist WHERE address=@Address";
+            "SELECT quota FROM txquotalist WHERE address=@Address";
 
         protected readonly string _connectionString;
 
@@ -28,13 +28,13 @@ namespace NineChronicles.Headless.Services
             command.ExecuteNonQuery();
         }
 
-        public bool IsAccessDenied(Address address)
+        public bool IsListed(Address address)
         {
             using var connection = new SqliteConnection(_connectionString);
             connection.Open();
 
             using var command = connection.CreateCommand();
-            command.CommandText = CheckAccessSql;
+            command.CommandText = CheckAddressSql;
             command.Parameters.AddWithValue("@Address", address.ToString());
 
             var queryResult = command.ExecuteScalar();
@@ -44,7 +44,7 @@ namespace NineChronicles.Headless.Services
             if (result)
             {
                 Log.ForContext("Source", nameof(IAccessControlService))
-                    .Debug("\"{Address}\" is access denied", address);
+                    .Debug("\"{Address}\" is listed", address);
             }
 
             return result;

--- a/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
+++ b/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Data.Sqlite;
 using Libplanet.Crypto;
 using Nekoyume.Blockchain;
@@ -8,9 +9,11 @@ namespace NineChronicles.Headless.Services
     public class SQLiteAccessControlService : IAccessControlService
     {
         private const string CreateTableSql =
-            "CREATE TABLE IF NOT EXISTS blocklist (address VARCHAR(42))";
+            "CREATE TABLE IF NOT EXISTS blocklist (address VARCHAR(42), quota INT)";
         private const string CheckAccessSql =
             "SELECT EXISTS(SELECT 1 FROM blocklist WHERE address=@Address)";
+        private const string GetTxQuotaSql =
+            "SELECT quota FROM blocklist WHERE address=@Address";
 
         protected readonly string _connectionString;
 
@@ -45,6 +48,20 @@ namespace NineChronicles.Headless.Services
             }
 
             return result;
+        }
+
+        public int? GetTxQuota(Address address)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = GetTxQuotaSql;
+            command.Parameters.AddWithValue("@Address", address.ToString());
+
+            var queryResult = command.ExecuteScalar();
+
+            return Convert.ToInt32(queryResult);
         }
     }
 }

--- a/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
+++ b/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
@@ -10,8 +10,6 @@ namespace NineChronicles.Headless.Services
     {
         private const string CreateTableSql =
             "CREATE TABLE IF NOT EXISTS txquotalist (address VARCHAR(42), quota INT)";
-        private const string CheckAddressSql =
-            "SELECT EXISTS(SELECT 1 FROM txquotalist WHERE address=@Address)";
         private const string GetTxQuotaSql =
             "SELECT quota FROM txquotalist WHERE address=@Address";
 
@@ -26,28 +24,6 @@ namespace NineChronicles.Headless.Services
             using var command = connection.CreateCommand();
             command.CommandText = CreateTableSql;
             command.ExecuteNonQuery();
-        }
-
-        public bool IsListed(Address address)
-        {
-            using var connection = new SqliteConnection(_connectionString);
-            connection.Open();
-
-            using var command = connection.CreateCommand();
-            command.CommandText = CheckAddressSql;
-            command.Parameters.AddWithValue("@Address", address.ToString());
-
-            var queryResult = command.ExecuteScalar();
-
-            var result = queryResult is not null && (long)queryResult == 1;
-
-            if (result)
-            {
-                Log.ForContext("Source", nameof(IAccessControlService))
-                    .Debug("\"{Address}\" is listed", address);
-            }
-
-            return result;
         }
 
         public int? GetTxQuota(Address address)

--- a/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
+++ b/NineChronicles.Headless/Services/SQLiteAccessControlService.cs
@@ -61,7 +61,12 @@ namespace NineChronicles.Headless.Services
 
             var queryResult = command.ExecuteScalar();
 
-            return Convert.ToInt32(queryResult);
+            if (queryResult != null)
+            {
+                return Convert.ToInt32(queryResult);
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
### Changes
- Add `AddTxQuota` and `RemoveTxQuota` to ACS to set or delete individual signer's `txQuotaPerSigner`.

Replaces https://github.com/planetarium/NineChronicles.Headless/pull/2276.