### PR TITLE
🔨 PDX-136: Fix ncTransactions bug when startingBlockIndex is the same as the tip index

### DIFF
--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -319,7 +319,7 @@ namespace NineChronicles.Headless.GraphTypes
                 return new List<Block>();
             }
 
-            var count = (int)Math.Min(limit, chain.Tip.Index - from);
+            var count = (int)Math.Min(limit, chain.Tip.Index - from + 1);
             var blocks = Enumerable.Range(0, count)
                 .ToList()
                 .AsParallel()


### PR DESCRIPTION
It resolves #2305 