### PR TITLE
PDX-126: update transferAsset to accept custom ticker

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
@@ -282,7 +282,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
 
             var recipient = new PrivateKey().ToAddress();
             var sender = new PrivateKey().ToAddress();
-            var valueTypeWithMinter = valueType.Replace("[]", 
+            var valueTypeWithMinter = valueType.Replace("[]",
                 valueType.Contains("NCG") ? $"[\"{goldCurrencyState.Currency.Minters.First()}\"]" : "[]");
             var args = $"recipient: \"{recipient}\", sender: \"{sender}\", rawCurrency: {valueTypeWithMinter}, amount: \"17.5\"";
             if (memo)

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -171,10 +171,15 @@ namespace NineChronicles.Headless.GraphTypes
                         Description = "A string value to be transferred.",
                         Name = "amount",
                     },
-                    new QueryArgument<NonNullGraphType<CurrencyInputType>>
+                    new QueryArgument<CurrencyEnumType>
                     {
-                        Description = "A currency type to be transferred.",
+                        Description = "A enum value of currency to be transferred.",
                         Name = "currency",
+                    },
+                    new QueryArgument<CurrencyInputType>
+                    {
+                        Description = "A currency to be transferred.",
+                        Name = "rawCurrency",
                     },
                     new QueryArgument<StringGraphType>
                     {
@@ -186,7 +191,32 @@ namespace NineChronicles.Headless.GraphTypes
                 {
                     var sender = context.GetArgument<Address>("sender");
                     var recipient = context.GetArgument<Address>("recipient");
-                    var currency = context.GetArgument<Currency>("currency");
+                    var nullableRawCurrency = context.GetArgument<Currency?>("rawCurrency");
+                    var nullableCurrencyEnum = context.GetArgument<CurrencyEnum?>("currency");
+
+                    Currency currency;
+                    if (nullableRawCurrency is not null && nullableCurrencyEnum is not null)
+                    {
+                        throw new ExecutionError("Only one of currency and rawCurrency must be set.");
+                    }
+                    if (nullableCurrencyEnum is { } currencyEnum)
+                    {
+                        if (!standaloneContext.CurrencyFactory!.TryGetCurrency(currencyEnum, out var currencyFromEnum))
+                        {
+                            throw new ExecutionError($"Currency {currencyEnum} is not found.");
+                        }
+
+                        currency = currencyFromEnum;
+                    }
+                    else if (nullableRawCurrency is { } rawCurrency)
+                    {
+                        currency = rawCurrency;
+                    }
+                    else
+                    {
+                        throw new ExecutionError("Either currency or rawCurrency must be set.");
+                    }
+
                     var amount = FungibleAssetValue.Parse(currency, context.GetArgument<string>("amount"));
                     var memo = context.GetArgument<string?>("memo");
                     ActionBase action = new TransferAsset(sender, recipient, amount, memo);

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -165,15 +165,10 @@ namespace NineChronicles.Headless.GraphTypes
                         Description = "Address of recipient.",
                         Name = "recipient",
                     },
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    new QueryArgument<NonNullGraphType<FungibleAssetValueInputType>>
                     {
-                        Description = "A string value to be transferred.",
-                        Name = "amount",
-                    },
-                    new QueryArgument<NonNullGraphType<CurrencyEnumType>>
-                    {
-                        Description = "A currency type to be transferred.",
-                        Name = "currency",
+                        Name = "value",
+                        Description = "FungibleAssetValue to transfer."
                     },
                     new QueryArgument<StringGraphType>
                     {
@@ -185,15 +180,9 @@ namespace NineChronicles.Headless.GraphTypes
                 {
                     var sender = context.GetArgument<Address>("sender");
                     var recipient = context.GetArgument<Address>("recipient");
-                    var currencyEnum = context.GetArgument<CurrencyEnum>("currency");
-                    if (!standaloneContext.CurrencyFactory!.TryGetCurrency(currencyEnum, out var currency))
-                    {
-                        throw new ExecutionError($"Currency {currencyEnum} is not found.");
-                    }
-
-                    var amount = FungibleAssetValue.Parse(currency, context.GetArgument<string>("amount"));
+                    var value = context.GetArgument<FungibleAssetValue>("value");
                     var memo = context.GetArgument<string?>("memo");
-                    ActionBase action = new TransferAsset(sender, recipient, amount, memo);
+                    ActionBase action = new TransferAsset(sender, recipient, value, memo);
                     return Encode(context, action);
                 });
             Field<NonNullGraphType<ByteStringType>>(

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using Bencodex;
 using Bencodex.Types;
+using Google.Protobuf.WellKnownTypes;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet.Crypto;
@@ -165,10 +166,15 @@ namespace NineChronicles.Headless.GraphTypes
                         Description = "Address of recipient.",
                         Name = "recipient",
                     },
-                    new QueryArgument<NonNullGraphType<FungibleAssetValueInputType>>
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
                     {
-                        Name = "value",
-                        Description = "FungibleAssetValue to transfer."
+                        Description = "A string value to be transferred.",
+                        Name = "amount",
+                    },
+                    new QueryArgument<NonNullGraphType<CurrencyInputType>>
+                    {
+                        Description = "A currency type to be transferred.",
+                        Name = "currency",
                     },
                     new QueryArgument<StringGraphType>
                     {
@@ -180,9 +186,10 @@ namespace NineChronicles.Headless.GraphTypes
                 {
                     var sender = context.GetArgument<Address>("sender");
                     var recipient = context.GetArgument<Address>("recipient");
-                    var value = context.GetArgument<FungibleAssetValue>("value");
+                    var currency = context.GetArgument<Currency>("currency");
+                    var amount = FungibleAssetValue.Parse(currency, context.GetArgument<string>("amount"));
                     var memo = context.GetArgument<string?>("memo");
-                    ActionBase action = new TransferAsset(sender, recipient, value, memo);
+                    ActionBase action = new TransferAsset(sender, recipient, amount, memo);
                     return Encode(context, action);
                 });
             Field<NonNullGraphType<ByteStringType>>(


### PR DESCRIPTION
It resolves #2298.

As custom tickers(ex: Item_NT_111) was created, transferAsset action should be able to accept custom ticker instead of pre-defined enum currency.

changed schema looks like... :

```gql
actionQuery {
  transferAsset{
    sender: "0x00",
    recipient: "0x01",
    value: {
      ticker: "token_str",
      decimalPlaces: 18,
      minters: [],
      quantity: 100
    }
  }
}
```