### PR TITLE
configure arena list sync worker for avoid memory pressure

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -211,6 +211,8 @@ namespace NineChronicles.Headless.Executable
             double? sentryTraceSampleRate = null,
             [Option(Description = "arena participants list sync interval time")]
             int? arenaParticipantsSyncInterval = null,
+            [Option(Description = "arena participants list sync enable")]
+            bool arenaParticipantsSync = true,
             [Ignore] CancellationToken? cancellationToken = null
         )
         {
@@ -464,7 +466,10 @@ namespace NineChronicles.Headless.Executable
                                 .AddPrometheusExporter());
 
                     // worker
-                    services.AddHostedService(_ => new ArenaParticipantsWorker(arenaMemoryCache, standaloneContext, headlessConfig.ArenaParticipantsSyncInterval));
+                    if (arenaParticipantsSync)
+                    {
+                        services.AddHostedService(_ => new ArenaParticipantsWorker(arenaMemoryCache, standaloneContext, headlessConfig.ArenaParticipantsSyncInterval));
+                    }
                     services.AddSingleton(arenaMemoryCache);
                 });
 


### PR DESCRIPTION
```yang@yangcheon-ung-ui-MacBookPro data-provider % kubectl top pod test-headless-1-0 -n heimdall
NAME                CPU(cores)   MEMORY(bytes)
test-headless-1-0   1071m        10024Mi
yang@yangcheon-ung-ui-MacBookPro data-provider % kubectl top pod remote-headless-1-0 -n heimdall
NAME                  CPU(cores)   MEMORY(bytes)
remote-headless-1-0   1335m        11949Mi
yang@yangcheon-ung-ui-MacBookPro data-provider % kubectl top pod remote-headless-1-0 -n heimdall
NAME                  CPU(cores)   MEMORY(bytes)
remote-headless-1-0   1362m        13565Mi
yang@yangcheon-ung-ui-MacBookPro data-provider % kubectl top pod test-headless-1-0 -n heimdall
NAME                CPU(cores)   MEMORY(bytes)
test-headless-1-0   156m         393Mi
```


When a worker prepare list of arena players, excessive memory usage occurs due to state caching. 
modify the option turn on/off the worker for avoid memory pressure