### PR TITLE
Add detail to graphQL exceptions

### DIFF
--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -160,6 +160,11 @@ namespace NineChronicles.Headless
                             {
                                 Log.Error(context.Exception.ToString());
                                 Log.Error(context.ErrorMessage);
+
+                                context.Exception.Data["exception"] = context.Exception.GetType().ToString();
+                                context.Exception.Data["message"] = context.Exception.Message;
+                                context.Exception.Data["innerException"] = context.Exception.InnerException?.GetType().ToString();
+                                context.Exception.Data["stackTrace"] = context.Exception.StackTrace;
                             };
                         })
                     .AddSystemTextJson()


### PR DESCRIPTION
## Notes

Exposes inner exception message and stack trace for better debugging. However, there are some security concerns such as exposing sensitive information (such as passing private key around inside an exception message).

From what I gather, it'd be best if such exception decorating is only allowed under so called "development environment" (via `IWebHostEnvironment.IsDevelopment()`). I'm not sure whether such notion applies to our current deployment strategy (centrally run yet open distributed, if that makes any sense). 🙄

It would be nice to have the option to turn it on and off. 😗

## Before

```json
{
  "errors": [
    {
      "message": "Error trying to resolve field 'getTx'.",
      "locations": [
        {
          "line": 3,
          "column": 5
        }
      ],
      "path": [
        "transaction",
        "getTx"
      ],
      "extensions": {
        "code": "ARGUMENT_OUT_OF_RANGE",
        "codes": [
          "ARGUMENT_OUT_OF_RANGE"
        ]
      }
    }
  ],
  "data": {
    "transaction": {
      "getTx": null
    }
  },
  "extensions": {}
}
```

## After

```json
{
  "errors": [
    {
      "message": "Error trying to resolve field 'getTx'.",
      "locations": [
        {
          "line": 3,
          "column": 5
        }
      ],
      "path": [
        "transaction",
        "getTx"
      ],
      "extensions": {
        "code": "ARGUMENT_OUT_OF_RANGE",
        "codes": [
          "ARGUMENT_OUT_OF_RANGE"
        ],
        "data": {
          "exception": "System.ArgumentOutOfRangeException",
          "message": "A length of a hexadecimal string must be an even number. (Parameter 'hex')",
          "innerException": null,
          "stackTrace": "   at Libplanet.Common.ByteUtil.ParseHex(String hex) in /app/Lib9c/.Libplanet/Libplanet.Common/ByteUtil.cs:line 49\n   at NineChronicles.Headless.GraphTypes.TxIdType.ParseValue(Object value) in /app/NineChronicles.Headless/GraphTypes/TxIdType.cs:line 33\n   at NineChronicles.Headless.GraphTypes.TxIdType.ParseLiteral(IValue value) in /app/NineChronicles.Headless/GraphTypes/TxIdType.cs:line 44\n   at GraphQL.Execution.ExecutionHelper.CoerceValue(IGraphType type, IValue input, Variables variables, Object fieldDefault) in /_/src/GraphQL/Execution/ExecutionHelper.cs:line 69\n   at GraphQL.Execution.ExecutionHelper.CoerceValue(IGraphType type, IValue input, Variables variables, Object fieldDefault) in /_/src/GraphQL/Execution/ExecutionHelper.cs:line 46\n   at GraphQL.Execution.ExecutionHelper.GetArgumentValues(QueryArguments definitionArguments, Arguments astArguments, Variables variables) in /_/src/GraphQL/Execution/ExecutionHelper.cs:line 28\n   at GraphQL.ReadonlyResolveFieldContext.get_Arguments() in /_/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs:line 78\n   at GraphQL.ResolveFieldContextExtensions.TryGetArgument(IResolveFieldContext context, Type argumentType, String name, Object& result) in /_/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs:line 59\n   at GraphQL.ResolveFieldContextExtensions.GetArgument[TType](IResolveFieldContext context, String name, TType defaultValue) in /_/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs:line 20\n   at NineChronicles.Headless.GraphTypes.TransactionHeadlessQuery.<>c__DisplayClass0_0.<.ctor>b__1(IResolveFieldContext`1 context) in /app/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs:line 61\n   at GraphQL.Resolvers.FuncFieldResolver`2.GraphQL.Resolvers.IFieldResolver.Resolve(IResolveFieldContext context) in /_/src/GraphQL/Resolvers/FuncFieldResolver.cs:line 158\n   at GraphQL.Execution.ExecutionStrategy.ExecuteNodeAsync(ExecutionContext context, ExecutionNode node) in /_/src/GraphQL/Execution/ExecutionStrategy.cs:line 428"
        }
      }
    }
  ],
  "data": {
    "transaction": {
      "getTx": null
    }
  },
  "extensions": {}
}
```