### PR TITLE
Customize max transaction per block

### DIFF
--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -85,6 +85,8 @@ namespace NineChronicles.Headless.Executable
         public ushort? ConsensusPort { get; set; }
         public double? ConsensusTargetBlockIntervalMilliseconds { get; set; }
 
+        public int? MaxTransactionPerBlock { get; set; }
+
         public string SentryDsn { get; set; } = "";
 
         public double SentryTraceSampleRate { get; set; } = 0.01;
@@ -141,6 +143,7 @@ namespace NineChronicles.Headless.Executable
             string? consensusPrivateKeyString,
             string[]? consensusSeedStrings,
             double? consensusTargetBlockIntervalMilliseconds,
+            int? maxTransactionPerBlock,
             string? sentryDsn,
             double? sentryTraceSampleRate,
             int? arenaParticipantsSyncInterval
@@ -192,6 +195,7 @@ namespace NineChronicles.Headless.Executable
             ConsensusSeedStrings = consensusSeedStrings ?? ConsensusSeedStrings;
             ConsensusPrivateKeyString = consensusPrivateKeyString ?? ConsensusPrivateKeyString;
             ConsensusTargetBlockIntervalMilliseconds = consensusTargetBlockIntervalMilliseconds ?? ConsensusTargetBlockIntervalMilliseconds;
+            MaxTransactionPerBlock = maxTransactionPerBlock ?? MaxTransactionPerBlock;
             SentryDsn = sentryDsn ?? SentryDsn;
             SentryTraceSampleRate = sentryTraceSampleRate ?? SentryTraceSampleRate;
             ArenaParticipantsSyncInterval = arenaParticipantsSyncInterval ?? ArenaParticipantsSyncInterval;

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -205,6 +205,9 @@ namespace NineChronicles.Headless.Executable
             [Option("consensus-target-block-interval",
                 Description = "A target block interval used in consensus context. The unit is millisecond.")]
             double? consensusTargetBlockIntervalMilliseconds = null,
+            [Option("maximum-transaction-per-block",
+                Description = "Maximum transactions allowed in a block. null by default.")]
+            int? maxTransactionPerBlock = null,
             [Option("config", new[] { 'C' },
                 Description = "Absolute path of \"appsettings.json\" file to provide headless configurations.")]
             string? configPath = "appsettings.json",
@@ -302,7 +305,7 @@ namespace NineChronicles.Headless.Executable
                 txLifeTime, messageTimeout, tipTimeout, demandBuffer, skipPreload,
                 minimumBroadcastTarget, bucketSize, chainTipStaleBehaviorType, txQuotaPerSigner, maximumPollPeers,
                 consensusPort, consensusPrivateKeyString, consensusSeedStrings, consensusTargetBlockIntervalMilliseconds,
-                sentryDsn, sentryTraceSampleRate, arenaParticipantsSyncInterval
+                maxTransactionPerBlock, sentryDsn, sentryTraceSampleRate, arenaParticipantsSyncInterval
             );
 
 #if SENTRY || ! DEBUG
@@ -348,6 +351,14 @@ namespace NineChronicles.Headless.Executable
             {
                 throw new CommandExitedException(
                     "--miner-private-key must be present to turn on mining at libplanet node.",
+                    -1
+                );
+            }
+
+            if (headlessConfig.ConsensusPrivateKeyString is null && headlessConfig.MaxTransactionPerBlock is not null)
+            {
+                throw new CommandExitedException(
+                    "--maximum-transaction-per-block can only be used when --consensus-private-key is provided.",
                     -1
                 );
             }
@@ -459,6 +470,7 @@ namespace NineChronicles.Headless.Executable
                         MinerCount = headlessConfig.MinerCount,
                         MinerBlockInterval = minerBlockInterval,
                         TxQuotaPerSigner = headlessConfig.TxQuotaPerSigner,
+                        MaxTransactionPerBlock = headlessConfig.MaxTransactionPerBlock
                     };
                 var arenaMemoryCache = new StateMemoryCache();
                 hostBuilder.ConfigureServices(services =>

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -897,7 +897,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 ConsensusPeers = ImmutableList<BoundPeer>.Empty
             };
 
-            var blockPolicy = NineChroniclesNodeService.GetBlockPolicy(Planet.Odin, StaticActionLoaderSingleton.Instance);
+            var blockPolicy = NineChroniclesNodeService.GetBlockPolicy(Planet.Odin, StaticActionLoaderSingleton.Instance, null);
             var service = new NineChroniclesNodeService(userPrivateKey, properties, blockPolicy, Planet.Odin, StaticActionLoaderSingleton.Instance);
             StandaloneContextFx.NineChroniclesNodeService = service;
             StandaloneContextFx.BlockChain = service.Swarm?.BlockChain;

--- a/NineChronicles.Headless/NineChroniclesNodeService.cs
+++ b/NineChronicles.Headless/NineChroniclesNodeService.cs
@@ -203,7 +203,8 @@ namespace NineChronicles.Headless
 
             IBlockPolicy blockPolicy = GetBlockPolicy(
                 properties.Planet,
-                properties.ActionLoader
+                properties.ActionLoader,
+                properties.MaxTransactionPerBlock
             );
             var service = new NineChroniclesNodeService(
                 properties.MinerPrivateKey,
@@ -256,8 +257,8 @@ namespace NineChronicles.Headless
             return service;
         }
 
-        internal static IBlockPolicy GetBlockPolicy(Planet planet, IActionLoader actionLoader)
-             => new BlockPolicySource(actionLoader).GetPolicy(planet);
+        internal static IBlockPolicy GetBlockPolicy(Planet planet, IActionLoader actionLoader, int? maxTransactionPerBlock)
+            => new BlockPolicySource(actionLoader, maxTransactionPerBlock).GetPolicy(planet);
 
         public Task<bool> CheckPeer(string addr) => NodeService?.CheckPeer(addr) ?? throw new InvalidOperationException();
 

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -53,6 +53,8 @@ namespace NineChronicles.Headless.Properties
 
         public int TxQuotaPerSigner { get; set; }
 
+        public int? MaxTransactionPerBlock { get; set; }
+
         public IActionLoader ActionLoader { get; init; }
 
         public StateServiceManagerServiceOptions? StateServiceManagerService { get; }


### PR DESCRIPTION
The new `MaxTransactionPerBlock` parameter will customize the libplanet chain's `maxtransactionperblock` policy when operating validators.

Must be merged after https://github.com/planetarium/lib9c/pull/2475 and lib9c version must be rebumped.