### PR TITLE
🩹 Changed `csproj` to temporarily ignore warnings

### DIFF
--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>
+    <!-- These should be removed once upgraded to patched packages -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'DevEx' ">


### PR DESCRIPTION
Newly found vulnerability prevents this project being compiled in [DP](https://github.com/planetarium/NineChronicles.DataProvider).