### PR TITLE
Bump OpenTelemetry-related dependencies

### DIFF
--- a/NineChronicles.Headless/GraphQLService.cs
+++ b/NineChronicles.Headless/GraphQLService.cs
@@ -183,11 +183,15 @@ namespace NineChronicles.Headless
                                     p.RequireClaim(
                                         "role",
                                         "Admin"));
+
+                            // FIXME: Use ConfigurationException after bumping to .NET 8 or later.
                             options.AddPolicy(
                                 JwtPolicyKey,
                                 p =>
-                                    p.RequireClaim("iss", jwtOptions["Issuer"]));
+                                    p.RequireClaim("iss",
+                                        jwtOptions["Issuer"] ?? throw new ArgumentException("jwtOptions[\"Issuer\"] is null.")));
                         });
+
                 services.AddGraphTypes();
             }
 

--- a/NineChronicles.Headless/Middleware/JwtAuthenticationMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/JwtAuthenticationMiddleware.cs
@@ -66,7 +66,11 @@ public class JwtAuthenticationMiddleware : IMiddleware
 
     private (string scheme, string token) ExtractSchemeAndToken(StringValues authorizationHeader)
     {
-        var headerValues = authorizationHeader[0].Split(" ");
+        if (authorizationHeader[0]?.Split(" ") is not string[] headerValues)
+        {
+            throw new ArgumentException("Authorization header isn't given.");
+        }
+
         if (headerValues.Length < 2)
         {
             throw new ArgumentException("Invalid Authorization header format.");

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -7,7 +7,7 @@
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>
     <!-- These should be removed once upgraded to patched packages -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU1904</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'DevEx' ">
@@ -50,13 +50,13 @@
     <PackageReference Include="Sentry.DiagnosticSource" Version="3.22.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="GraphQL" Version="4.7.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.DependencyInjection" Version="1.4.0-rc.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.11" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.1.0-rc.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.49.0.57237">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -6,8 +6,6 @@
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <!-- These should be removed once upgraded to patched packages -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'DevEx' ">


### PR DESCRIPTION
This pull request resolves https://github.com/planetarium/NineChronicles.Headless/issues/2453

This pull request does:
- Bump OpenTelemetry-related dependencies.
- Remove `WarningsNotAsErrors` option.
- FIx some compile errors related to nullable feature.