### PR TITLE
hotfix(v200170): Disable .NET runtime instruments

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -481,8 +481,6 @@ namespace NineChronicles.Headless.Executable
                         .WithMetrics(
                             builder => builder
                                 .AddMeter("NineChronicles")
-                                .AddRuntimeInstrumentation()
-                                .AddAspNetCoreInstrumentation()
                                 .AddPrometheusExporter());
 
                     // worker


### PR DESCRIPTION
This will be `131` release not v200171.