### PR TITLE
add `--consensus-propose-second-base` cli parameter

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -235,6 +235,7 @@ namespace Libplanet.Headless.Hosting
                     ConsensusPrivateKey = Properties.ConsensusPrivateKey,
                     ConsensusWorkers = 500,
                     TargetBlockInterval = TimeSpan.FromMilliseconds(Properties.ConsensusTargetBlockIntervalMilliseconds ?? 7000),
+                    ContextTimeoutOptions = Properties.ContextTimeoutOption,
                 };
             }
 

--- a/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeServiceProperties.cs
@@ -5,6 +5,7 @@ using Libplanet.Action;
 using Libplanet.Types.Blocks;
 using Libplanet.Crypto;
 using Libplanet.Net;
+using Libplanet.Net.Consensus;
 
 namespace Libplanet.Headless.Hosting
 {
@@ -66,6 +67,8 @@ namespace Libplanet.Headless.Hosting
         public TimeSpan MessageTimeout { get; set; } = TimeSpan.FromSeconds(60);
 
         public TimeSpan TipTimeout { get; set; } = TimeSpan.FromSeconds(60);
+
+        public ContextTimeoutOption ContextTimeoutOption { get; set; }
 
         public int DemandBuffer { get; set; } = 1150;
 

--- a/NineChronicles.Headless.Executable/Configuration.cs
+++ b/NineChronicles.Headless.Executable/Configuration.cs
@@ -84,6 +84,7 @@ namespace NineChronicles.Headless.Executable
         public string[]? ConsensusSeedStrings { get; set; }
         public ushort? ConsensusPort { get; set; }
         public double? ConsensusTargetBlockIntervalMilliseconds { get; set; }
+        public int? ConsensusProposeSecondBase { get; set; }
 
         public int? MaxTransactionPerBlock { get; set; }
 
@@ -143,6 +144,7 @@ namespace NineChronicles.Headless.Executable
             string? consensusPrivateKeyString,
             string[]? consensusSeedStrings,
             double? consensusTargetBlockIntervalMilliseconds,
+            int? consensusProposeSecondBase,
             int? maxTransactionPerBlock,
             string? sentryDsn,
             double? sentryTraceSampleRate,
@@ -195,6 +197,7 @@ namespace NineChronicles.Headless.Executable
             ConsensusSeedStrings = consensusSeedStrings ?? ConsensusSeedStrings;
             ConsensusPrivateKeyString = consensusPrivateKeyString ?? ConsensusPrivateKeyString;
             ConsensusTargetBlockIntervalMilliseconds = consensusTargetBlockIntervalMilliseconds ?? ConsensusTargetBlockIntervalMilliseconds;
+            ConsensusProposeSecondBase = consensusProposeSecondBase ?? ConsensusProposeSecondBase;
             MaxTransactionPerBlock = maxTransactionPerBlock ?? MaxTransactionPerBlock;
             SentryDsn = sentryDsn ?? SentryDsn;
             SentryTraceSampleRate = sentryTraceSampleRate ?? SentryTraceSampleRate;

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -205,6 +205,9 @@ namespace NineChronicles.Headless.Executable
             [Option("consensus-target-block-interval",
                 Description = "A target block interval used in consensus context. The unit is millisecond.")]
             double? consensusTargetBlockIntervalMilliseconds = null,
+            [Option("consensus-propose-second-base",
+                Description = "A propose second base for consensus context timeout. The unit is second.")]
+            int? consensusProposeSecondBase = null,
             [Option("maximum-transaction-per-block",
                 Description = "Maximum transactions allowed in a block. null by default.")]
             int? maxTransactionPerBlock = null,
@@ -304,7 +307,7 @@ namespace NineChronicles.Headless.Executable
                 logActionRenders, confirmations,
                 txLifeTime, messageTimeout, tipTimeout, demandBuffer, skipPreload,
                 minimumBroadcastTarget, bucketSize, chainTipStaleBehaviorType, txQuotaPerSigner, maximumPollPeers,
-                consensusPort, consensusPrivateKeyString, consensusSeedStrings, consensusTargetBlockIntervalMilliseconds,
+                consensusPort, consensusPrivateKeyString, consensusSeedStrings, consensusTargetBlockIntervalMilliseconds, consensusProposeSecondBase,
                 maxTransactionPerBlock, sentryDsn, sentryTraceSampleRate, arenaParticipantsSyncInterval
             );
 
@@ -406,6 +409,7 @@ namespace NineChronicles.Headless.Executable
                         consensusPrivateKeyString: headlessConfig.ConsensusPrivateKeyString,
                         consensusSeedStrings: headlessConfig.ConsensusSeedStrings,
                         consensusTargetBlockIntervalMilliseconds: headlessConfig.ConsensusTargetBlockIntervalMilliseconds,
+                        consensusProposeSecondBase: headlessConfig.ConsensusProposeSecondBase,
                         maximumPollPeers: headlessConfig.MaximumPollPeers,
                         actionEvaluatorConfiguration: actionEvaluatorConfiguration
                     );

--- a/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
+++ b/NineChronicles.Headless/Properties/NineChroniclesNodeServiceProperties.cs
@@ -7,6 +7,7 @@ using Libplanet.Crypto;
 using Libplanet.Net;
 using Libplanet.Headless.Hosting;
 using Libplanet.Headless;
+using Libplanet.Net.Consensus;
 using Nekoyume;
 
 namespace NineChronicles.Headless.Properties
@@ -93,6 +94,7 @@ namespace NineChronicles.Headless.Properties
                 string? consensusPrivateKeyString = null,
                 string[]? consensusSeedStrings = null,
                 double? consensusTargetBlockIntervalMilliseconds = null,
+                int? consensusProposeSecondBase = null,
                 IActionEvaluatorConfiguration? actionEvaluatorConfiguration = null)
         {
             var swarmPrivateKey = string.IsNullOrEmpty(swarmPrivateKeyString)
@@ -108,6 +110,10 @@ namespace NineChronicles.Headless.Properties
             var iceServers = iceServerStrings.Select(PropertyParser.ParseIceServer).ToImmutableArray();
             var peers = peerStrings.Select(PropertyParser.ParsePeer).ToImmutableArray();
             var consensusSeeds = consensusSeedStrings?.Select(PropertyParser.ParsePeer).ToImmutableList();
+
+            var consensusContextTimeoutOption = consensusProposeSecondBase.HasValue
+                ? new ContextTimeoutOption(consensusProposeSecondBase.Value)
+                : new ContextTimeoutOption();
 
             return new LibplanetNodeServiceProperties
             {
@@ -144,6 +150,7 @@ namespace NineChronicles.Headless.Properties
                 ConsensusSeeds = consensusSeeds,
                 ConsensusPrivateKey = consensusPrivateKey,
                 ConsensusTargetBlockIntervalMilliseconds = consensusTargetBlockIntervalMilliseconds,
+                ContextTimeoutOption = consensusContextTimeoutOption,
                 ActionEvaluatorConfiguration = actionEvaluatorConfiguration ?? new DefaultActionEvaluatorConfiguration(),
             };
         }


### PR DESCRIPTION
resolves #2441 

This PR introduces `--consensus-propose-second-base` cli parameter to customize `ContextTimeoutOption`.`ProposeSecondBase` in `LibplanetNodeService`