### PR TITLE
Provide `index` parameter when to query state

### DIFF
--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -43,13 +43,20 @@ namespace NineChronicles.Headless.GraphTypes
                 {
                     Name = "hash",
                     Description = "Offset block hash for query.",
+                },
+                new QueryArgument<LongGraphType>
+                {
+                    Name = "index",
+                    Description = "Offset block index for query."
                 }),
                 resolve: context =>
                 {
-                    BlockHash? blockHash = context.GetArgument<byte[]>("hash") switch
+                    BlockHash? blockHash = (context.GetArgument<byte[]?>("hash"), context.GetArgument<long?>("index")) switch
                     {
-                        byte[] bytes => new BlockHash(bytes),
-                        null => standaloneContext.BlockChain?.Tip?.Hash,
+                        ({ } bytes, null) => new BlockHash(bytes),
+                        (null, { } index) => standaloneContext.BlockChain[index].Hash,
+                        (not null, not null) => throw new ArgumentException("Only one of 'hash' and 'index' must be given."),
+                        (null, null) => standaloneContext.BlockChain?.Tip?.Hash,
                     };
 
                     if (!(standaloneContext.BlockChain is { } chain))

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -51,12 +51,12 @@ namespace NineChronicles.Headless.GraphTypes
                 }),
                 resolve: context =>
                 {
-                    BlockHash? blockHash = (context.GetArgument<byte[]?>("hash"), context.GetArgument<long?>("index")) switch
+                    BlockHash blockHash = (context.GetArgument<byte[]?>("hash"), context.GetArgument<long?>("index")) switch
                     {
                         ({ } bytes, null) => new BlockHash(bytes),
                         (null, { } index) => standaloneContext.BlockChain[index].Hash,
                         (not null, not null) => throw new ArgumentException("Only one of 'hash' and 'index' must be given."),
-                        (null, null) => standaloneContext.BlockChain?.Tip?.Hash,
+                        (null, null) => standaloneContext.BlockChain.Tip.Hash,
                     };
 
                     if (!(standaloneContext.BlockChain is { } chain))
@@ -66,11 +66,7 @@ namespace NineChronicles.Headless.GraphTypes
 
                     return new StateContext(
                         chain.GetWorldState(blockHash),
-                        blockHash switch
-                        {
-                            BlockHash bh => chain[bh].Index,
-                            null => chain.Tip!.Index,
-                        },
+                        chain[blockHash].Index,
                         stateMemoryCache
                     );
                 }


### PR DESCRIPTION
## Description

When it's a PoW chain, it's very risky to access state by index. However, thanks to the work of the Libplanet team, the NineChronicles network has partially transitioned to PoS, so we're adding the ability to access it by index. We expect that this will solve the problem of replacing index with hash and then accessing it.

## GraphQL

```graphql
{
  state(address: "0x", index: 0)
  stateQuery(index: 0)
  {
    avatar(address: "0x") { name }
  }
}
```