### PR TITLE
Add dotnet related metrics

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -494,6 +494,8 @@ namespace NineChronicles.Headless.Executable
                             builder => builder
                                 .AddMeter("NineChronicles")
                                 .AddMeter("MagicOnion.Server")
+                                .AddAspNetCoreInstrumentation()
+                                .AddRuntimeInstrumentation()
                                 .AddPrometheusExporter())
                         .WithTracing(
                             builder => builder


### PR DESCRIPTION
SSIA
example
```
# TYPE http_server_request_duration_seconds histogram
# UNIT http_server_request_duration_seconds seconds
# HELP http_server_request_duration_seconds Duration of HTTP server requests.
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.005"} 77 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.01"} 78 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.025"} 78 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.05"} 78 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.075"} 78 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.1"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.25"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.5"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="0.75"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="1"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="2.5"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="5"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="7.5"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="10"} 79 1721198393274
http_server_request_duration_seconds_bucket{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http",le="+Inf"} 79 1721198393274
http_server_request_duration_seconds_sum{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http"} 0.1309920000000001 1721198393274
http_server_request_duration_seconds_count{otel_scope_name="OpenTelemetry.Instrumentation.AspNetCore",otel_scope_version="1.0.0.0",http_request_method="GET",http_response_status_code="200",network_protocol_version="1.1",url_scheme="http"} 79 1721198393274
# TYPE process_runtime_dotnet_gc_collections_count_total counter
# HELP process_runtime_dotnet_gc_collections_count_total Number of garbage collections that have occurred since process start.
process_runtime_dotnet_gc_collections_count_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0",generation="gen2"} 1 1721198393274
process_runtime_dotnet_gc_collections_count_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0",generation="gen1"} 0 1721198393274
process_runtime_dotnet_gc_collections_count_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0",generation="gen0"} 1 1721198393274
# TYPE process_runtime_dotnet_gc_objects_size_bytes gauge
# UNIT process_runtime_dotnet_gc_objects_size_bytes bytes
# HELP process_runtime_dotnet_gc_objects_size_bytes Count of bytes currently in use by objects in the GC heap that haven't been collected yet. Fragmentation and other GC committed memory pools are excluded.
process_runtime_dotnet_gc_objects_size_bytes{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 108369960 1721198393274
# TYPE process_runtime_dotnet_gc_allocations_size_bytes_total counter
# UNIT process_runtime_dotnet_gc_allocations_size_bytes_total bytes
# HELP process_runtime_dotnet_gc_allocations_size_bytes_total Count of bytes allocated on the managed GC heap since the process start. .NET objects are allocated from this heap. Object allocations from unmanaged languages such as C/C++ do not use this heap.
process_runtime_dotnet_gc_allocations_size_bytes_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 197138088 1721198393274
# TYPE process_runtime_dotnet_gc_committed_memory_size_bytes gauge
# UNIT process_runtime_dotnet_gc_committed_memory_size_bytes bytes
# HELP process_runtime_dotnet_gc_committed_memory_size_bytes The amount of committed virtual memory for the managed GC heap, as observed during the latest garbage collection. Committed virtual memory may be larger than the heap size because it includes both memory for storing existing objects (the heap size) and some extra memory that is ready to handle newly allocated objects in the future. The value will be unavailable until at least one garbage collection has occurred.
process_runtime_dotnet_gc_committed_memory_size_bytes{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 87130112 1721198393274
# TYPE process_runtime_dotnet_gc_heap_size_bytes gauge
# UNIT process_runtime_dotnet_gc_heap_size_bytes bytes
# HELP process_runtime_dotnet_gc_heap_size_bytes The heap size (including fragmentation), as observed during the latest garbage collection. The value will be unavailable until at least one garbage collection has occurred.
process_runtime_dotnet_gc_heap_size_bytes{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0",generation="gen0"} 11491608 1721198393274
process_runtime_dotnet_gc_heap_size_bytes{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0",generation="gen1"} 22910112 1721198393274
process_runtime_dotnet_gc_heap_size_bytes{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0",generation="gen2"} 240 1721198393274
process_runtime_dotnet_gc_heap_size_bytes{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0",generation="loh"} 15411536 1721198393274
process_runtime_dotnet_gc_heap_size_bytes{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0",generation="poh"} 211920 1721198393274
# TYPE process_runtime_dotnet_jit_il_compiled_size_bytes_total counter
# UNIT process_runtime_dotnet_jit_il_compiled_size_bytes_total bytes
# HELP process_runtime_dotnet_jit_il_compiled_size_bytes_total Count of bytes of intermediate language that have been compiled since the process start.
process_runtime_dotnet_jit_il_compiled_size_bytes_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 1014240 1721198393274
# TYPE process_runtime_dotnet_jit_methods_compiled_count_total counter
# HELP process_runtime_dotnet_jit_methods_compiled_count_total The number of times the JIT compiler compiled a method since the process start. The JIT compiler may be invoked multiple times for the same method to compile with different generic parameters, or because tiered compilation requested different optimization settings.
process_runtime_dotnet_jit_methods_compiled_count_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 13624 1721198393274
# TYPE process_runtime_dotnet_jit_compilation_time_nanoseconds_total counter
# UNIT process_runtime_dotnet_jit_compilation_time_nanoseconds_total nanoseconds
# HELP process_runtime_dotnet_jit_compilation_time_nanoseconds_total The amount of time the JIT compiler has spent compiling methods since the process start.
process_runtime_dotnet_jit_compilation_time_nanoseconds_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 2037607200 1721198393274
# TYPE process_runtime_dotnet_monitor_lock_contention_count_total counter
# HELP process_runtime_dotnet_monitor_lock_contention_count_total The number of times there was contention when trying to acquire a monitor lock since the process start. Monitor locks are commonly acquired by using the lock keyword in C#, or by calling Monitor.Enter() and Monitor.TryEnter().
process_runtime_dotnet_monitor_lock_contention_count_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 59 1721198393274
# TYPE process_runtime_dotnet_thread_pool_threads_count gauge
# HELP process_runtime_dotnet_thread_pool_threads_count The number of thread pool threads that currently exist.
process_runtime_dotnet_thread_pool_threads_count{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 16 1721198393274
# TYPE process_runtime_dotnet_thread_pool_completed_items_count_total counter
# HELP process_runtime_dotnet_thread_pool_completed_items_count_total The number of work items that have been processed by the thread pool since the process start.
process_runtime_dotnet_thread_pool_completed_items_count_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 6235 1721198393274
# TYPE process_runtime_dotnet_thread_pool_queue_length gauge
# HELP process_runtime_dotnet_thread_pool_queue_length The number of work items that are currently queued to be processed by the thread pool.
process_runtime_dotnet_thread_pool_queue_length{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 0 1721198393274
# TYPE process_runtime_dotnet_timer_count gauge
# HELP process_runtime_dotnet_timer_count The number of timer instances that are currently active. Timers can be created by many sources such as System.Threading.Timer, Task.Delay, or the timeout in a CancellationSource. An active timer is registered to tick at some point in the future and has not yet been canceled.
process_runtime_dotnet_timer_count{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 16 1721198393274
# TYPE process_runtime_dotnet_assemblies_count gauge
# HELP process_runtime_dotnet_assemblies_count The number of .NET assemblies that are currently loaded.
process_runtime_dotnet_assemblies_count{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 234 1721198393274
# TYPE process_runtime_dotnet_exceptions_count_total counter
# HELP process_runtime_dotnet_exceptions_count_total Count of exceptions that have been thrown in managed code, since the observation started. The value will be unavailable until an exception has been thrown after OpenTelemetry.Instrumentation.Runtime initialization.
process_runtime_dotnet_exceptions_count_total{otel_scope_name="OpenTelemetry.Instrumentation.Runtime",otel_scope_version="1.8.0"} 20 1721198393274
# EOF
```