### PR TITLE
Add txStatusFilter in ncTransactions type

### DIFF
--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -77,7 +77,9 @@ namespace NineChronicles.Headless.GraphTypes
                     new QueryArgument<NonNullGraphType<LongGraphType>>
                     { Name = "limit", Description = "number of block to query." },
                     new QueryArgument<NonNullGraphType<StringGraphType>>
-                    { Name = "actionType", Description = "filter tx by having actions' type. It is regular expression." }
+                    { Name = "actionType", Description = "filter tx by having actions' type. It is regular expression." },
+                    new QueryArgument<ListGraphType<TxStatusType>>
+                    { Name = "txStatusFilter", Description = "filter txStatus." }
                 ),
                 resolve: context =>
                 {
@@ -90,6 +92,7 @@ namespace NineChronicles.Headless.GraphTypes
                     var startingBlockIndex = context.GetArgument<long>("startingBlockIndex");
                     var limit = context.GetArgument<long>("limit");
                     var actionType = context.GetArgument<string>("actionType");
+                    var txStatusFilter = context.GetArgument<List<TxStatus>?>("txStatusFilter");
 
                     var blocks = ListBlocks(blockChain, startingBlockIndex, limit);
                     var transactions = blocks
@@ -99,6 +102,15 @@ namespace NineChronicles.Headless.GraphTypes
                             if (rawAction is not Dictionary action || action["type_id"] is not Text typeId)
                             {
                                 return false;
+                            }
+
+                            if (txStatusFilter is not null)
+                            {
+                                var txResult = TxResult(standaloneContext, tx.Id) as TxResult;
+                                if (txResult is not null && !txStatusFilter.Contains(txResult.TxStatus))
+                                {
+                                    return false;
+                                }
                             }
 
                             return Regex.IsMatch(typeId, actionType);

--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -78,7 +78,7 @@ namespace NineChronicles.Headless.GraphTypes
                     { Name = "limit", Description = "number of block to query." },
                     new QueryArgument<NonNullGraphType<StringGraphType>>
                     { Name = "actionType", Description = "filter tx by having actions' type. It is regular expression." },
-                    new QueryArgument<ListGraphType<TxStatusType>>
+                    new QueryArgument<NonNullGraphType<ListGraphType<TxStatusType>>>
                     { Name = "txStatusFilter", Description = "filter txStatus." }
                 ),
                 resolve: context =>
@@ -92,7 +92,7 @@ namespace NineChronicles.Headless.GraphTypes
                     var startingBlockIndex = context.GetArgument<long>("startingBlockIndex");
                     var limit = context.GetArgument<long>("limit");
                     var actionType = context.GetArgument<string>("actionType");
-                    var txStatusFilter = context.GetArgument<List<TxStatus>?>("txStatusFilter");
+                    var txStatusFilter = context.GetArgument<List<TxStatus>>("txStatusFilter");
 
                     var blocks = ListBlocks(blockChain, startingBlockIndex, limit);
                     var transactions = blocks
@@ -104,13 +104,10 @@ namespace NineChronicles.Headless.GraphTypes
                                 return false;
                             }
 
-                            if (txStatusFilter is not null)
+                            var txResult = TxResult(standaloneContext, tx.Id) as TxResult;
+                            if (txResult is not null && !txStatusFilter.Contains(txResult.TxStatus))
                             {
-                                var txResult = TxResult(standaloneContext, tx.Id) as TxResult;
-                                if (txResult is not null && !txStatusFilter.Contains(txResult.TxStatus))
-                                {
-                                    return false;
-                                }
+                                return false;
                             }
 
                             return Regex.IsMatch(typeId, actionType);

--- a/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/TransactionHeadlessQuery.cs
@@ -78,7 +78,7 @@ namespace NineChronicles.Headless.GraphTypes
                     { Name = "limit", Description = "number of block to query." },
                     new QueryArgument<NonNullGraphType<StringGraphType>>
                     { Name = "actionType", Description = "filter tx by having actions' type. It is regular expression." },
-                    new QueryArgument<NonNullGraphType<ListGraphType<TxStatusType>>>
+                    new QueryArgument<ListGraphType<NonNullGraphType<TxStatusType>>>
                     { Name = "txStatusFilter", Description = "filter txStatus." }
                 ),
                 resolve: context =>
@@ -92,7 +92,7 @@ namespace NineChronicles.Headless.GraphTypes
                     var startingBlockIndex = context.GetArgument<long>("startingBlockIndex");
                     var limit = context.GetArgument<long>("limit");
                     var actionType = context.GetArgument<string>("actionType");
-                    var txStatusFilter = context.GetArgument<List<TxStatus>>("txStatusFilter");
+                    var txStatusFilter = context.GetArgument<List<TxStatus>?>("txStatusFilter");
 
                     var blocks = ListBlocks(blockChain, startingBlockIndex, limit);
                     var transactions = blocks
@@ -104,10 +104,13 @@ namespace NineChronicles.Headless.GraphTypes
                                 return false;
                             }
 
-                            var txResult = TxResult(standaloneContext, tx.Id) as TxResult;
-                            if (txResult is not null && !txStatusFilter.Contains(txResult.TxStatus))
+                            if (txStatusFilter is not null)
                             {
-                                return false;
+                                var txResult = TxResult(standaloneContext, tx.Id) as TxResult;
+                                if (txResult is not null && !txStatusFilter.Contains(txResult.TxStatus))
+                                {
+                                    return false;
+                                }
                             }
 
                             return Regex.IsMatch(typeId, actionType);


### PR DESCRIPTION
Currently, checking the transaction status using the transaction result query consumes unnecessary network resources.
To address this, I propose adding a txStatus filter argument to the ncTransactions type.