### PR TITLE
logging remote replay tx execute arguments

### DIFF
--- a/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/ReplayCommand.cs
@@ -433,10 +433,16 @@ namespace NineChronicles.Headless.Executable.Commands
                 .Select(ToAction)
                 .Cast<IAction>()
                 .ToImmutableList();
+            var blockIndex = transactionResult.BlockIndex ?? 0;
+            var blockProtocolVersion = (int)protocolVersion;
+            var preEvaluationHash = HashDigest<SHA256>.FromString(preEvaluationHashValue);
+            byte[] preEvaluationHashBytes = preEvaluationHash.ToByteArray();
+            int seed = ActionEvaluator.GenerateRandomSeed(preEvaluationHashBytes, transaction.Signature, 0);
+            _console.Out.WriteLine($"BlockIndex: {blockIndex}, BlockProtocolVersion: {blockProtocolVersion}, Miner: {miner}, PreviousState: {previousStateRootHash}, RandomSeed: {seed}, Signer: {transaction.Signer}, TxId: {transactionId}");
             var actionEvaluations = EvaluateActions(
-                preEvaluationHash: HashDigest<SHA256>.FromString(preEvaluationHashValue),
-                blockIndex: transactionResult.BlockIndex ?? 0,
-                blockProtocolVersion: (int)protocolVersion,
+                preEvaluationHash: preEvaluationHash,
+                blockIndex: blockIndex,
+                blockProtocolVersion: blockProtocolVersion,
                 txid: transaction.Id,
                 previousStates: previousStates,
                 miner: miner,

--- a/README.md
+++ b/README.md
@@ -224,3 +224,16 @@ Actions in 0 transactions for block #1 pre-evaluation hash: 10d93de7... evaluate
 [NetMQTransport] Broadcasting message Libplanet.Net.Messages.BlockHeaderMessage as 0x7862DD9b....Unspecified/localhost:43210. to 0 peers
 [Swarm] Block broadcasting complete.
 ```
+
+---
+
+## How to replay tx with remote headless
+
+
+When using the replay remote-tx command, you can replay the results of a specific transaction on a remote node to verify the execution result.
+
+The remote headless node needs to enable the `--remote-key-value-service` option and enable the grpc options to retrieve chain information.
+
+```shell
+replay remote-tx --tx {txId(hex)} --endpoint {gqlUrl(fullState gql url)} --grpc-endpoint {grpcEndpoint(remote tx grpc url)}
+```


### PR DESCRIPTION
replay remote tx 커맨드 실행시 유니티 등 다른 클라이언트에서 사용할 인자를 참조할 수 있도록 사용된 인자를 표시합니다.

```
/Users/yang/projects/headless/NineChronicles.Headless.Executable/bin/Release/net6/NineChronicles.Headless.Executable replay remote-tx --tx {txId} --endpoint {graphqlEndPoint} --grpc-endpoint {grpcEndPoint}

BlockIndex: 2657433, BlockProtocolVersion: 8, Miner: 0x088d96AF8e90b8B2040AeF7B3BF7d375C9E421f7, PreviousState: 5eee8394545c4eb2c91ef3051ecb3f18507f398fa6e623f826418e35886591a9, RandomSeed: 400765736, Signer: 0x3146FE0E47A1998e14cd8a33640e3648A5A90276, TxId: 23a69ad8ac380e0dfd9b3427f11b1fe505011a1d8ebd1d002c3c3ba073f4afac
```