### PR TITLE
Bump OpenTelemetry dependencies

### DIFF
--- a/NineChronicles.Headless/NineChronicles.Headless.csproj
+++ b/NineChronicles.Headless/NineChronicles.Headless.csproj
@@ -50,13 +50,13 @@
     <PackageReference Include="Sentry.DiagnosticSource" Version="3.22.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="GraphQL" Version="4.7.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.49.0.57237">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Currently, Prometheus fails to fetch metrics from headless because its metrics export result isn't compatible for the standard or Prometheus' way. So I had disabled it in #2460 temporarily. And it is enabled again in this version and the error occurs again. But, fortunately, it seems fixed in OpenTelemetry 1.9.0 by https://github.com/open-telemetry/opentelemetry-dotnet/pull/5646. So this pull request bumps them to 1.9.0

```
unit not a suffix of metric "process_runtime_dotnet_gc_allocations_size_bytes_total"
```