### PR TITLE
Bump lib9c to development

### DIFF
--- a/NineChronicles.Headless.Tests/ArenaParticipantsWorkerTest.cs
+++ b/NineChronicles.Headless.Tests/ArenaParticipantsWorkerTest.cs
@@ -110,7 +110,7 @@ public class ArenaParticipantsWorkerTest
         var tableSheets = new TableSheets(_sheets);
         var agentAddress = new PrivateKey().Address;
         var avatarAddress = Addresses.GetAvatarAddress(agentAddress, 0);
-        var avatarState = new AvatarState(
+        var avatarState = AvatarState.Create(
             avatarAddress,
             agentAddress,
             0,
@@ -119,7 +119,7 @@ public class ArenaParticipantsWorkerTest
             "avatar_state"
         );
         var avatar2Address = Addresses.GetAvatarAddress(agentAddress, 1);
-        var avatarState2 = new AvatarState(
+        var avatarState2 = AvatarState.Create(
             avatar2Address,
             agentAddress,
             0,

--- a/NineChronicles.Headless.Tests/Common/Fixtures.cs
+++ b/NineChronicles.Headless.Tests/Common/Fixtures.cs
@@ -26,7 +26,7 @@ namespace NineChronicles.Headless.Tests
 
         public static readonly TableSheets TableSheetsFX = new(TableSheetsImporter.ImportSheets());
 
-        public static readonly AvatarState AvatarStateFX = new(
+        public static readonly AvatarState AvatarStateFX = AvatarState.Create(
             AvatarAddress,
             UserAddress,
             0,


### PR DESCRIPTION
It bumps `Lib9c` submodule to the latest commit of its `development` branch. It only includes commits related with https://github.com/planetarium/lib9c/pull/2780