### PR TITLE
ci(gh-actions): specify project to build

### DIFF
--- a/.github/workflows/deploy_gh_pages.yaml
+++ b/.github/workflows/deploy_gh_pages.yaml
@@ -33,10 +33,12 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: yarn global add graphql @graphql-inspector/cli
+      - name: Install .NET dependencies
+        run: dotnet restore
+      - name: Build GraphQL Node
+        run: dotnet build --no-restore --project NineChronicles.Headless.Executable
       - name: Build GraphQL Schema
         run: |
-          dotnet restore
-          dotnet build
           dotnet run --project NineChronicles.Headless.Executable -- \
             --graphql-server \
             --graphql-port 30000 \


### PR DESCRIPTION
This pull request may fix an issue where the `Deploy gh pages` workflow failed.