### PR TITLE
ci(gh-actions): remove invalid option

### DIFF
--- a/.github/workflows/deploy_gh_pages.yaml
+++ b/.github/workflows/deploy_gh_pages.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install .NET dependencies
         run: dotnet restore
       - name: Build GraphQL Node
-        run: dotnet build --no-restore --project NineChronicles.Headless.Executable
+        run: dotnet build --no-restore NineChronicles.Headless.Executable
       - name: Build GraphQL Schema
         run: |
           dotnet run --project NineChronicles.Headless.Executable -- \


### PR DESCRIPTION
`dotnet build` command doesn't accept `--project` option. Project path is just an argument.