### PR TITLE
fix: use private codec instead of static Codec

### DIFF
--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -34,7 +34,6 @@ namespace NineChronicles.Headless
 {
     public class BlockChainService : ServiceBase<IBlockChainService>, IBlockChainService
     {
-        private static readonly Codec Codec = new Codec();
         private BlockChain _blockChain;
         private Swarm _swarm;
         private RpcContext _context;
@@ -346,7 +345,7 @@ namespace NineChronicles.Headless
         public UnaryResult<byte[]> GetTip()
         {
             Bencodex.Types.Dictionary headerDict = _blockChain.Tip.MarshalBlock();
-            byte[] headerBytes = Codec.Encode(headerDict);
+            byte[] headerBytes = _codec.Encode(headerDict);
             return new UnaryResult<byte[]>(headerBytes);
         }
 


### PR DESCRIPTION
# Context
![image](https://github.com/user-attachments/assets/ffc5c0bb-f2b6-4bdb-a5b2-b54d52088806)

We observed that when the network quota ran out, the response speed of `GetTip` became significantly slower. 
The difference between `GetTip` and other `IBlockChainService` methods seems to be that it uses `private static Codec` instead of `private _codec`. First, I want to change it to use `_codec` instead of `Codec` and then check if there is a performance improvement.

# Rationale
Use `_codec` instead of `Codec` on the `GetTip`.