### PR TITLE
ci(gh-actions): fix workflow to build docker image

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -59,6 +59,7 @@ jobs:
             platforms: linux/arm64,linux/amd64
             tags: ${{ matrix.docker.repo }}:git-${{ github.sha }}
             file: ${{ matrix.docker.dockerfile }}
+            build-args: COMMIT=git-${{ github.sha }}
 
   tag:
     name: tag (${{ matrix.docker.repo }})


### PR DESCRIPTION
Pass `COMMIT` build-arg when building Docker images in GitHub Actions workflow.