### PR TITLE
ci: use setup-qemu-action instead

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -57,6 +57,8 @@ jobs:
             tags: ${{ matrix.docker.repo }}:git-${{ github.sha }}
             file: ${{ matrix.docker.dockerfile }}
             build-args: COMMIT=git-${{ github.sha }}
+        env:
+            BUILDKIT_PROGRESS: 'plain'
 
   tag:
     name: tag (${{ matrix.docker.repo }})

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -43,11 +43,8 @@ jobs:
           docker login \
             --username '${{ secrets.DOCKER_USERNAME }}' \
             --password '${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}'
-      - name: setup-qemu
-        run: |
-          docker run --rm --privileged multiarch/qemu-user-static \
-            --reset \
-            -p yes
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 ARG COMMIT
 ARG TARGETPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ fi
 EOF
 
 # Build runtime image
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 WORKDIR /app
 COPY --from=build-env /app/out .
 

--- a/Dockerfile.ACC
+++ b/Dockerfile.ACC
@@ -32,7 +32,7 @@ fi
 EOF
 
 # Build runtime image
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .

--- a/Dockerfile.ACC
+++ b/Dockerfile.ACC
@@ -1,5 +1,5 @@
 # Use the SDK image to build the app
-FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build-env
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 ARG COMMIT
 ARG TARGETPLATFORM


### PR DESCRIPTION
Since emulating x64 .NET to ARM64 is too hard to cause Segment-fault error, I fixed the `Dockerfile`s to run in `$BUILDPLATFORM` (i.e., `amd64`).