### PR TITLE
chore: update dependabot conf to bump GitHub Actions automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
We usually missed to bump GitHub Actions and cannot realizing if there is a new release to bump. Since Dependabot supports GitHub Actions, I updated its configuration to check if there is something to bump automatically 🤖 