### PR TITLE
fix code style for namespace

### DIFF
--- a/NineChronicles.Headless.Executable.sln.DotSettings
+++ b/NineChronicles.Headless.Executable.sln.DotSettings
@@ -41,8 +41,12 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_NEW_PARENTHESES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BETWEEN_ATTRIBUTE_SECTIONS/@EntryValue">False</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">300</s:Int64>
-	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/PreferQualifiedReference/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AllowAlias/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/CanUseGlobalAlias/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/PreferQualifiedReference/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/QualifiedUsingAtNestedScope/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/SortUsingsWithSystemFirst/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AI/@EntryIndexedValue">AI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CRYSTAL/@EntryIndexedValue">CRYSTAL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GARAGE/@EntryIndexedValue">GARAGE</s:String>


### PR DESCRIPTION
- lib9c/headless등에 적용된 StyleCop 코드 규칙에 맞게 코드 변경을 진행 후 추가적으로 수정되는 스타일입니다.
- StyleCop 규칙에서 using문에 namespace를 작성할 때 무조건 namespace의 풀 네임을 적용해야 하는 규칙이 있습니다
- 이를 대비하기 위해 라이더에서 'PreferQualifiedReference' 옵션을 True로 설정해두었는데 이로 인해 필드의 클래스를 지정할때에도 자동적으로 full namespace가 들어가는 케이스가 있고 이게 신경쓰이는 상황이 반복되어 False로 옵션을 변경해두었습니다

```
SA1210: Using directives should be ordered alphabetically by the namespaces.
SA1135: Using directive for namespace 'Lib9c.Tests.Action' should be qualified
```

현재 development를 머지 타겟으로 설정해두었는데, 현재 작업중인 250(클라기준) 패치와 관련된 작업 브랜치에 머지해야겠다 싶으시면 코멘트 남겨주세요!