### PR TITLE
Fixed exception thrown when executing with URL or other name config

### DIFF
--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -331,6 +331,7 @@ namespace NineChronicles.Headless.Executable
             try
             {
                 IHostBuilder hostBuilder = Host.CreateDefaultBuilder();
+                hostBuilder.ConfigureAppConfiguration(builder => builder.AddConfiguration(configuration));
 
                 var standaloneContext = new StandaloneContext
                 {


### PR DESCRIPTION
### Issue

Apparently, on Mac, specifying the config path as a `url` or using a different name like `appsettings123.json` will cause the program to crash on launch.
This is presumably because the configuration generated by IHostBuilder does not read the settings from the specified path.

This PR contains changes to resolve the issue