### PR TITLE
feat: support template plugin path

### DIFF
--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -649,7 +649,7 @@ namespace Libplanet.Headless.Hosting
                     return Task.Run(() => DownloadPlugin(pluginPath)).GetAwaiter().GetResult();
                 }
 
-                return pluginPath;   
+                return pluginPath;
             }
 
             string RenderPluginPath(string pluginPath)
@@ -687,7 +687,7 @@ namespace Libplanet.Headless.Hosting
 
             if (configuration.Version == 1)
             {
-                return ResolvePluginPathImpl(configuration.PluginPath);                
+                return ResolvePluginPathImpl(configuration.PluginPath);
             }
 
             if (configuration.Version == 2)

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -127,7 +127,7 @@ namespace Libplanet.Headless.Hosting
                 {
                     PluggedActionEvaluatorConfiguration pluginActionEvaluatorConfiguration =>
                         new PluggedActionEvaluator(
-                            ResolvePluginPath(pluginActionEvaluatorConfiguration.PluginPath),
+                            ResolvePluginPath(pluginActionEvaluatorConfiguration),
                             pluginActionEvaluatorConfiguration.TypeName,
                             keyValueStore,
                             actionLoader),
@@ -638,15 +638,23 @@ namespace Libplanet.Headless.Hosting
             Log.Debug("Store disposed.");
         }
 
-        private string ResolvePluginPath(string path)
+        private string ResolvePluginPath(PluggedActionEvaluatorConfiguration configuration)
         {
-            if (Uri.IsWellFormedUriString(path, UriKind.Absolute))
+            var pluginPath = configuration.PluginPath;
+            if (configuration.Version == 1)
             {
-                // Run the download on a background thread
-                return Task.Run(() => DownloadPlugin(path)).GetAwaiter().GetResult();
+                if (Uri.IsWellFormedUriString(pluginPath, UriKind.Absolute))
+                {
+                    // Run the download on a background thread
+                    return Task.Run(() => DownloadPlugin(pluginPath)).GetAwaiter().GetResult();
+                }
+
+                return pluginPath;   
             }
 
-            return path;
+            throw new ArgumentOutOfRangeException(
+                nameof(configuration),
+                $"Unsupported version: {configuration.Version}");
         }
 
         private async Task<string> DownloadPlugin(string url)

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -656,7 +656,7 @@ namespace Libplanet.Headless.Hosting
             if (configuration.Version == 2)
             {
                 
-                string os = null switch
+                string os = "" switch
                 {
                     _ when RuntimeInformation.IsOSPlatform(OSPlatform.Windows) => "win",
                     _ when RuntimeInformation.IsOSPlatform(OSPlatform.Linux) => "linux",

--- a/Libplanet.Headless/Hosting/LibplanetNodeService.cs
+++ b/Libplanet.Headless/Hosting/LibplanetNodeService.cs
@@ -641,8 +641,7 @@ namespace Libplanet.Headless.Hosting
 
         private string ResolvePluginPath(PluggedActionEvaluatorConfiguration configuration)
         {
-            var pluginPath = configuration.PluginPath;
-            if (configuration.Version == 1)
+            string ResolvePluginPathImpl(string pluginPath)
             {
                 if (Uri.IsWellFormedUriString(pluginPath, UriKind.Absolute))
                 {
@@ -653,9 +652,8 @@ namespace Libplanet.Headless.Hosting
                 return pluginPath;   
             }
 
-            if (configuration.Version == 2)
+            string RenderPluginPath(string pluginPath)
             {
-                
                 string os = "" switch
                 {
                     _ when RuntimeInformation.IsOSPlatform(OSPlatform.Windows) => "win",
@@ -685,6 +683,16 @@ namespace Libplanet.Headless.Hosting
 #else
                     .Replace("<rid>", runtimeIdentifier);
 #endif
+            }
+
+            if (configuration.Version == 1)
+            {
+                return ResolvePluginPathImpl(configuration.PluginPath);                
+            }
+
+            if (configuration.Version == 2)
+            {
+                return ResolvePluginPathImpl(RenderPluginPath(configuration.PluginPath));
             }
 
             throw new ArgumentOutOfRangeException(

--- a/Libplanet.Headless/Hosting/PluggedActionEvaluatorConfiguration.cs
+++ b/Libplanet.Headless/Hosting/PluggedActionEvaluatorConfiguration.cs
@@ -2,7 +2,21 @@ namespace Libplanet.Headless.Hosting;
 
 public class PluggedActionEvaluatorConfiguration : IActionEvaluatorConfiguration
 {
+    /// <summary>
+    /// Default version of the <see cref="PluggedActionEvaluatorConfiguration"/>'s schema.
+    /// It must not be changed for backward-compatibility.
+    /// </summary>
+    public const long DefaultVersion = 1;
+
     public ActionEvaluatorType Type => ActionEvaluatorType.PluggedActionEvaluator;
+
+    /// <summary>
+    /// Gets the version of the <see cref="PluggedActionEvaluatorConfiguration"/>'s schema.
+    /// </summary>
+    /// <remarks>
+    /// For backward compatibility, it uses default version as 1.
+    /// </remarks>
+    public long Version { get; init; } = DefaultVersion;
 
     public string PluginPath { get; init; }
 

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -17,6 +17,8 @@ using Nekoyume.Model.State;
 using NineChronicles.Headless.Executable.IO;
 using CoconaUtils = Libplanet.Extensions.Cocona.Utils;
 using Lib9cUtils = Lib9c.DevExtensions.Utils;
+using NineChronicles.Headless.Executable.Models.Genesis;
+using MeadConfig = NineChronicles.Headless.Executable.Models.Genesis.MeadConfig;
 
 namespace NineChronicles.Headless.Executable.Commands
 {
@@ -332,129 +334,5 @@ namespace NineChronicles.Headless.Executable.Commands
 
             };
         }
-
-#pragma warning disable S3459
-        /// <summary>
-        /// Game data to set into genesis block.
-        /// </summary>
-        /// <seealso cref="GenesisConfig"/>
-        [Serializable]
-        private struct DataConfig
-        {
-            /// <value>A path of game data table directory.</value>
-            public string TablePath { get; set; }
-        }
-
-        /// <summary>
-        /// Currency related configurations.<br/>
-        /// Set initial minter(Tx signer) and/or initial currency depositions.<br/>
-        /// If not provided, default values will set.
-        /// </summary>
-        [Serializable]
-        private struct CurrencyConfig
-        {
-            /// <value>
-            /// Private Key of initial currency minter.<br/>
-            /// If not provided, a new private key will be created and used.<br/>
-            /// </value>
-            public string? InitialMinter { get; set; } // PrivateKey, not Address
-
-            /// <value>
-            /// Initial currency deposition list.<br/>
-            /// If you leave it to empty list or even not provide, the `InitialMinter` will get 10000 currency.<br.>
-            /// You can see newly created deposition info in <c>initial_deposit.csv</c> file.
-            /// </value>
-            public List<GoldDistribution>? InitialCurrencyDeposit { get; set; }
-
-            public bool AllowMint { get; set; }
-        }
-
-        /// <summary>
-        /// Admin related configurations.<br/>
-        /// If not provided, no admin will be set.
-        /// </summary>
-        [Serializable]
-        private struct AdminConfig
-        {
-            /// <value>Whether active admin address or not.</value>
-            public bool Activate { get; set; }
-
-            /// <value>
-            /// Address to give admin privilege.<br/>
-            /// If <c>Activate</c> is <c>true</c> and no <c>Address</c> provided, the <see cref="CurrencyConfig.InitialMinter"/> will get admin privilege.
-            /// </value>
-            public string Address { get; set; }
-
-            /// <value>
-            /// The block count to persist admin privilege.<br/>
-            /// After this block, admin will no longer be admin.
-            /// </value>
-            public long ValidUntil { get; set; }
-        }
-
-        [Serializable]
-        private struct Validator
-        {
-            public string PublicKey { get; set; }
-
-            public long Power { get; set; }
-        }
-
-        [Serializable]
-        private struct MeadConfig
-        {
-            public string Address { get; set; }
-
-            public string Amount { get; set; }
-        }
-
-        [Serializable]
-        private struct PledgeConfig
-        {
-            public string AgentAddress { get; set; }
-
-            public string PatronAddress { get; set; }
-
-            public int Mead { get; set; }
-        }
-
-        /// <summary>
-        /// Config to mine new genesis block.
-        /// </summary>
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Config</term>
-        /// <description>Description</description>
-        /// </listheader>
-        /// <item>
-        /// <term><see cref="DataConfig">Data</see></term>
-        /// <description>Required. Sets game data to genesis block.</description>
-        /// </item>
-        /// <item>
-        /// <term><see cref="CurrencyConfig">Currency</see></term>
-        /// <description>Optional. Sets initial currency mint/deposition data to genesis block.</description>
-        /// </item>
-        /// <item>
-        /// <term><see cref="AdminConfig">Admin</see></term>
-        /// <description>Optional. Sets game admin and lifespan to genesis block.</description>
-        /// </item>
-        /// <item>
-        /// <term><see cref="InitialValidatorSet">Initial validator set</see></term>
-        /// <description>Optional. Sets game admin and lifespan to genesis block.</description>
-        /// </item>
-        /// </list>
-        [Serializable]
-        private struct GenesisConfig
-        {
-            public DataConfig Data { get; set; } // Required
-            public CurrencyConfig? Currency { get; set; }
-            public AdminConfig? Admin { get; set; }
-            public List<Validator>? InitialValidatorSet { get; set; }
-
-            public List<MeadConfig>? InitialMeadConfigs { get; set; }
-
-            public List<PledgeConfig>? InitialPledgeConfigs { get; set; }
-        }
-#pragma warning restore S3459
     }
 }

--- a/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
+++ b/NineChronicles.Headless.Executable/Commands/GenesisCommand.cs
@@ -1,30 +1,17 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
-using System.Numerics;
 using System.Text.Json;
 using Cocona;
-using Lib9c;
 using Libplanet.Common;
-using Libplanet.Crypto;
-using Libplanet.Types.Assets;
-using Libplanet.Types.Blocks;
-using Nekoyume;
-using Nekoyume.Action;
-using Nekoyume.Model.State;
 using NineChronicles.Headless.Executable.IO;
 using CoconaUtils = Libplanet.Extensions.Cocona.Utils;
-using Lib9cUtils = Lib9c.DevExtensions.Utils;
 using NineChronicles.Headless.Executable.Models.Genesis;
-using MeadConfig = NineChronicles.Headless.Executable.Models.Genesis.MeadConfig;
+using Lib9cUtils = Lib9c.DevExtensions.Utils;
 
 namespace NineChronicles.Headless.Executable.Commands
 {
     public class GenesisCommand : CoconaLiteConsoleAppBase
     {
-        private const int DefaultCurrencyValue = 10000;
         private readonly IConsole _console;
 
         public GenesisCommand(IConsole console)
@@ -32,211 +19,6 @@ namespace NineChronicles.Headless.Executable.Commands
             _console = console;
         }
 
-        private void ProcessData(DataConfig config, out Dictionary<string, string> tableSheets)
-        {
-            _console.Out.WriteLine("\nProcessing data for genesis...");
-            if (string.IsNullOrEmpty(config.TablePath))
-            {
-                throw CoconaUtils.Error("TablePath is not set.");
-            }
-
-            tableSheets = Lib9cUtils.ImportSheets(config.TablePath);
-        }
-
-        private void ProcessCurrency(
-            CurrencyConfig? config,
-            out Currency currency,
-            out PrivateKey initialMinter,
-            out List<GoldDistribution> initialDepositList
-        )
-        {
-            _console.Out.WriteLine("\nProcessing currency for genesis...");
-            if (config is null)
-            {
-                _console.Out.WriteLine("CurrencyConfig not provided. Skip setting...");
-                initialMinter = new PrivateKey();
-                initialDepositList = new List<GoldDistribution>
-                {
-                    new()
-                    {
-                        Address = initialMinter.Address,
-                        AmountPerBlock = DefaultCurrencyValue,
-                        StartBlock = 0,
-                        EndBlock = 0,
-                    }
-                };
-
-#pragma warning disable CS0618
-                // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
-                currency = Currency.Legacy("NCG", 2, minters: null);
-#pragma warning restore CS0618
-                return;
-            }
-
-            if (string.IsNullOrEmpty(config.Value.InitialMinter))
-            {
-                _console.Out.WriteLine("Private Key not provided. Create random one...");
-                initialMinter = new PrivateKey();
-            }
-            else
-            {
-                initialMinter = new PrivateKey(config.Value.InitialMinter);
-            }
-
-            initialDepositList = new List<GoldDistribution>();
-            if (config.Value.InitialCurrencyDeposit is null || config.Value.InitialCurrencyDeposit.Count == 0)
-            {
-                _console.Out.WriteLine("Initial currency deposit list not provided. " +
-                                       $"Give initial {DefaultCurrencyValue} currency to InitialMinter");
-                initialDepositList.Add(new GoldDistribution
-                {
-                    Address = initialMinter.Address,
-                    AmountPerBlock = DefaultCurrencyValue,
-                    StartBlock = 0,
-                    EndBlock = 0
-                });
-            }
-            else
-            {
-                initialDepositList = config.Value.InitialCurrencyDeposit;
-            }
-
-#pragma warning disable CS0618
-            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
-            currency = Currency.Legacy("NCG", 2, minters: config.Value.AllowMint ? null : ImmutableHashSet.Create(initialMinter.Address));
-#pragma warning restore CS0618
-        }
-
-        private void ProcessAdmin(
-            AdminConfig? config,
-            PrivateKey initialMinter,
-            out AdminState? adminState,
-            out List<ActionBase> meadActions
-        )
-        {
-            // FIXME: If the `adminState` is not required inside `MineGenesisBlock`,
-            //        this logic will be much lighter.
-            _console.Out.WriteLine("\nProcessing admin for genesis...");
-            adminState = default;
-            meadActions = new List<ActionBase>();
-
-            if (config is null)
-            {
-                _console.Out.WriteLine("AdminConfig not provided. Skip admin setting...");
-                return;
-            }
-
-            if (config.Value.Activate)
-            {
-                Address adminAddress;
-                if (string.IsNullOrEmpty(config.Value.Address))
-                {
-                    _console.Out.WriteLine("Admin address not provided. Give admin privilege to initialMinter");
-                    adminAddress = initialMinter.Address;
-                }
-                else
-                {
-                    adminAddress = new Address(config.Value.Address);
-                }
-
-                adminState = new AdminState(adminAddress, config.Value.ValidUntil);
-                meadActions.Add(new PrepareRewardAssets
-                {
-                    RewardPoolAddress = adminAddress,
-                    Assets = new List<FungibleAssetValue>
-                    {
-                        10000 * Currencies.Mead,
-                    },
-                });
-            }
-            else
-            {
-                _console.Out.WriteLine("Inactivate Admin. Skip admin setting...");
-            }
-
-            _console.Out.WriteLine("Admin config done");
-        }
-
-        private void ProcessValidator(List<Validator>? config, PrivateKey initialValidator,
-            out List<Validator> initialValidatorSet)
-        {
-            _console.Out.WriteLine("\nProcessing initial validator set for genesis...");
-            initialValidatorSet = new List<Validator>();
-            if (config is null || config.Count == 0)
-            {
-                _console.Out.WriteLine(
-                    "InitialValidatorSet not provided. Use initial minter as initial validator."
-                );
-                initialValidatorSet.Add(new Validator
-                {
-                    PublicKey = initialValidator.PublicKey.ToString(),
-                    Power = 1,
-                }
-                );
-            }
-            else
-            {
-                initialValidatorSet = config.ToList();
-            }
-
-            var str = initialValidatorSet.Aggregate(string.Empty,
-                (s, v) => s + "PublicKey: " + v.PublicKey + ", Power: " + v.Power + "\n");
-            _console.Out.WriteLine($"Initial validator set config done: {str}");
-        }
-
-        private void ProcessInitialMeadConfigs(
-            List<MeadConfig>? configs,
-            out List<PrepareRewardAssets> meadActions
-        )
-        {
-            _console.Out.WriteLine("\nProcessing initial mead distribution...");
-
-            meadActions = new List<PrepareRewardAssets>();
-            if (configs is { })
-            {
-                foreach (MeadConfig config in configs)
-                {
-                    _console.Out.WriteLine($"Preparing initial {config.Amount} MEAD for {config.Address}...");
-                    Address target = new(config.Address);
-                    meadActions.Add(
-                        new PrepareRewardAssets(
-                            target,
-                            new List<FungibleAssetValue>
-                            {
-                                FungibleAssetValue.Parse(Currencies.Mead, config.Amount),
-                            }
-                        )
-                    );
-                }
-            }
-        }
-
-        private void ProcessInitialPledgeConfigs(
-            List<PledgeConfig>? configs,
-            out List<CreatePledge> pledgeActions
-        )
-        {
-            _console.Out.WriteLine("\nProcessing initial pledges...");
-
-            pledgeActions = new List<CreatePledge>();
-            if (configs is { })
-            {
-                foreach (PledgeConfig config in configs)
-                {
-                    _console.Out.WriteLine($"Preparing a pledge for {config.AgentAddress}...");
-                    Address agentAddress = new(config.AgentAddress);
-                    Address pledgeAddress = agentAddress.GetPledgeAddress();
-                    pledgeActions.Add(
-                        new CreatePledge()
-                        {
-                            AgentAddresses = new[] { (agentAddress, pledgeAddress) },
-                            PatronAddress = new(config.PatronAddress),
-                            Mead = config.Mead,
-                        }
-                    );
-                }
-            }
-        }
 
         [Command(Description = "Mine a new genesis block")]
         public void Mine(
@@ -253,34 +35,7 @@ namespace NineChronicles.Headless.Executable.Commands
 
             try
             {
-                ProcessData(genesisConfig.Data, out var tableSheets);
-
-                ProcessCurrency(genesisConfig.Currency, out var currency, out var initialMinter, out var initialDepositList);
-
-                ProcessAdmin(genesisConfig.Admin, initialMinter, out var adminState, out var adminMeads);
-
-                ProcessValidator(genesisConfig.InitialValidatorSet, initialMinter, out var initialValidatorSet);
-
-                ProcessInitialMeadConfigs(genesisConfig.InitialMeadConfigs, out var initialMeads);
-
-                ProcessInitialPledgeConfigs(genesisConfig.InitialPledgeConfigs, out var initialPledges);
-
-                // Mine genesis block
-                _console.Out.WriteLine("\nMining genesis block...\n");
-                Block block = BlockHelper.ProposeGenesisBlock(
-                    tableSheets: tableSheets,
-                    goldDistributions: initialDepositList.ToArray(),
-                    pendingActivationStates: Array.Empty<PendingActivationState>(),
-                    // FIXME Should remove default value after fixing parameter type on Lib9c side.
-                    adminState: adminState ?? new AdminState(default, 0L),
-                    privateKey: initialMinter,
-                    initialValidators: initialValidatorSet.ToDictionary(
-                        item => new PublicKey(ByteUtil.ParseHex(item.PublicKey)),
-                        item => new BigInteger(item.Power)),
-                    actionBases: adminMeads.Concat(initialMeads).Concat(initialPledges).Concat(GetAdditionalActionBases()),
-                    goldCurrency: currency
-                );
-
+                var block = genesisConfig.GenerateGenesisBlock(_console, out var initialMinter);
                 Lib9cUtils.ExportBlock(block, "genesis-block");
                 if (genesisConfig.Admin?.Activate == true)
                 {
@@ -305,7 +60,7 @@ namespace NineChronicles.Headless.Executable.Commands
                         File.WriteAllText("initial_deposit.csv",
                             "Address,PrivateKey,AmountPerBlock,StartBlock,EndBlock\n");
                         File.AppendAllText("initial_deposit.csv",
-                            $"{initialMinter.Address},{ByteUtil.Hex(initialMinter.ByteArray)},{DefaultCurrencyValue},0,0");
+                            $"{initialMinter.Address},{ByteUtil.Hex(initialMinter.ByteArray)},{GenesisConfigExtensions.DefaultCurrencyValue},0,0");
                     }
                     else
                     {
@@ -320,19 +75,6 @@ namespace NineChronicles.Headless.Executable.Commands
             {
                 throw CoconaUtils.Error(e.Message);
             }
-        }
-
-        /// <summary>
-        /// Actions to be appended on end of transaction actions.
-        /// You can add actions code to this method before generate genesis block.
-        /// </summary>
-        /// <returns>List of ActionBase.</returns>
-        private static List<ActionBase> GetAdditionalActionBases()
-        {
-            return new List<ActionBase>
-            {
-
-            };
         }
     }
 }

--- a/NineChronicles.Headless.Executable/Models/Genesis/AdminConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/AdminConfig.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace NineChronicles.Headless.Executable.Models.Genesis
+{
+    /// <summary>
+    /// Admin related configurations.<br/>
+    /// If not provided, no admin will be set.
+    /// </summary>
+    [Serializable]
+    public struct AdminConfig
+    {
+        /// <value>Whether active admin address or not.</value>
+        public bool Activate { get; set; }
+
+        /// <value>
+        /// Address to give admin privilege.<br/>
+        /// If <c>Activate</c> is <c>true</c> and no <c>Address</c> provided, the <see cref="CurrencyConfig.InitialMinter"/> will get admin privilege.
+        /// </value>
+        public string Address { get; set; }
+
+        /// <value>
+        /// The block count to persist admin privilege.<br/>
+        /// After this block, admin will no longer be admin.
+        /// </value>
+        public long ValidUntil { get; set; }
+    }
+}

--- a/NineChronicles.Headless.Executable/Models/Genesis/AdminConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/AdminConfig.cs
@@ -3,25 +3,27 @@ using System;
 namespace NineChronicles.Headless.Executable.Models.Genesis
 {
     /// <summary>
-    /// Admin related configurations.<br/>
+    /// Admin related configurations.
     /// If not provided, no admin will be set.
     /// </summary>
     [Serializable]
     public struct AdminConfig
     {
-        /// <value>Whether active admin address or not.</value>
+        /// <summary>
+        /// Gets or sets a value indicating whether active admin address or not.
+        /// </summary>
         public bool Activate { get; set; }
 
-        /// <value>
-        /// Address to give admin privilege.<br/>
-        /// If <c>Activate</c> is <c>true</c> and no <c>Address</c> provided, the <see cref="CurrencyConfig.InitialMinter"/> will get admin privilege.
-        /// </value>
+        /// <summary>
+        /// Gets or sets address to give admin privilege.<br/>
+        /// If <see cref="Activate"/> is <c>true</c> and no <see cref="Address"/> provided, the <see cref="CurrencyConfig.InitialMinter"/> will get admin privilege.
+        /// </summary>
         public string Address { get; set; }
 
-        /// <value>
-        /// The block count to persist admin privilege.<br/>
-        /// After this block, admin will no longer be admin.
-        /// </value>
+        /// <summary>
+        /// Gets or sets the block index to persist admin privilege.
+        /// After <see cref="ValidUntil"/> block index, admin will no longer be admin.
+        /// </summary>
         public long ValidUntil { get; set; }
     }
 }

--- a/NineChronicles.Headless.Executable/Models/Genesis/CurrencyConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/CurrencyConfig.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace NineChronicles.Headless.Executable.Models.Genesis
+{
+    /// <summary>
+    /// Currency related configurations.<br/>
+    /// Set initial minter(Tx signer) and/or initial currency depositions.<br/>
+    /// If not provided, default values will set.
+    /// </summary>
+    [Serializable]
+    public struct CurrencyConfig
+    {
+        /// <value>
+        /// Private Key of initial currency minter.<br/>
+        /// If not provided, a new private key will be created and used.<br/>
+        /// </value>
+        public string? InitialMinter { get; set; } // PrivateKey, not Address
+
+        /// <value>
+        /// Initial currency deposition list.<br/>
+        /// If you leave it to empty list or even not provide, the `InitialMinter` will get 10000 currency.<br.>
+        /// You can see newly created deposition info in <c>initial_deposit.csv</c> file.
+        /// </value>
+        public List<Nekoyume.Action.GoldDistribution>? InitialCurrencyDeposit { get; set; }
+
+        public bool AllowMint { get; set; }
+    }
+}

--- a/NineChronicles.Headless.Executable/Models/Genesis/CurrencyConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/CurrencyConfig.cs
@@ -11,19 +11,23 @@ namespace NineChronicles.Headless.Executable.Models.Genesis
     [Serializable]
     public struct CurrencyConfig
     {
-        /// <value>
-        /// Private Key of initial currency minter.<br/>
-        /// If not provided, a new private key will be created and used.<br/>
-        /// </value>
+        /// <summary>
+        /// Gets or sets the private key of initial currency minter.
+        /// If not provided, a new private key will be created and used.
+        /// </summary>
         public string? InitialMinter { get; set; } // PrivateKey, not Address
 
-        /// <value>
-        /// Initial currency deposition list.<br/>
-        /// If you leave it to empty list or even not provide, the `InitialMinter` will get 10000 currency.<br.>
+        /// <summary>
+        /// Gets or sets initial currency deposition list.
+        /// If you leave it to empty list or even not provide,
+        /// the <see cref="InitialMinter"/> will get 10000 currency.
         /// You can see newly created deposition info in <c>initial_deposit.csv</c> file.
-        /// </value>
+        /// </summary>
         public List<Nekoyume.Action.GoldDistribution>? InitialCurrencyDeposit { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow mint.
+        /// </summary>
         public bool AllowMint { get; set; }
     }
 }

--- a/NineChronicles.Headless.Executable/Models/Genesis/DataConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/DataConfig.cs
@@ -9,7 +9,9 @@ namespace NineChronicles.Headless.Executable.Models.Genesis
     [Serializable]
     public struct DataConfig
     {
-        /// <value>A path of game data table directory.</value>
+        /// <summary>
+        /// Gets or sets a path of game data table directory.
+        /// </summary>
         public string TablePath { get; set; }
     }
 }

--- a/NineChronicles.Headless.Executable/Models/Genesis/DataConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/DataConfig.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace NineChronicles.Headless.Executable.Models.Genesis
+{
+    /// <summary>
+    /// Game data to set into genesis block.
+    /// </summary>
+    /// <seealso cref="GenesisConfig"/>
+    [Serializable]
+    public struct DataConfig
+    {
+        /// <value>A path of game data table directory.</value>
+        public string TablePath { get; set; }
+    }
+}

--- a/NineChronicles.Headless.Executable/Models/Genesis/GenesisConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/GenesisConfig.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace NineChronicles.Headless.Executable.Models.Genesis
+{
+    /// <summary>
+    /// Config to mine new genesis block.
+    /// </summary>
+    /// <list type="table">
+    /// <listheader>
+    /// <term>Config</term>
+    /// <description>Description</description>
+    /// </listheader>
+    /// <item>
+    /// <term><see cref="DataConfig">Data</see></term>
+    /// <description>Required. Sets game data to genesis block.</description>
+    /// </item>
+    /// <item>
+    /// <term><see cref="CurrencyConfig">Currency</see></term>
+    /// <description>Optional. Sets initial currency mint/deposition data to genesis block.</description>
+    /// </item>
+    /// <item>
+    /// <term><see cref="AdminConfig">Admin</see></term>
+    /// <description>Optional. Sets game admin and lifespan to genesis block.</description>
+    /// </item>
+    /// <item>
+    /// <term><see cref="InitialValidatorSet">Initial validator set</see></term>
+    /// <description>Optional. Sets game admin and lifespan to genesis block.</description>
+    /// </item>
+    /// </list>
+    [Serializable]
+    public struct GenesisConfig
+    {
+        public DataConfig Data { get; set; } // Required
+        public CurrencyConfig? Currency { get; set; }
+        public AdminConfig? Admin { get; set; }
+        public List<Validator>? InitialValidatorSet { get; set; }
+
+        public List<MeadConfig>? InitialMeadConfigs { get; set; }
+
+        public List<PledgeConfig>? InitialPledgeConfigs { get; set; }
+    }
+}

--- a/NineChronicles.Headless.Executable/Models/Genesis/GenesisConfigExtensions.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/GenesisConfigExtensions.cs
@@ -89,10 +89,10 @@ namespace NineChronicles.Headless.Executable.Models.Genesis
                     }
                 };
 
-    #pragma warning disable CS0618
+#pragma warning disable CS0618
                 // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
                 currency = Currency.Legacy("NCG", 2, minters: null);
-    #pragma warning restore CS0618
+#pragma warning restore CS0618
                 return;
             }
 
@@ -124,10 +124,10 @@ namespace NineChronicles.Headless.Executable.Models.Genesis
                 initialDepositList = config.Value.InitialCurrencyDeposit;
             }
 
-    #pragma warning disable CS0618
+#pragma warning disable CS0618
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             currency = Currency.Legacy("NCG", 2, minters: config.Value.AllowMint ? null : ImmutableHashSet.Create(initialMinter.Address));
-    #pragma warning restore CS0618
+#pragma warning restore CS0618
         }
 
         private static void ProcessAdmin(
@@ -266,7 +266,7 @@ namespace NineChronicles.Headless.Executable.Models.Genesis
                 }
             }
         }
-        
+
         /// <summary>
         /// Actions to be appended on end of transaction actions.
         /// You can add actions code to this method before generate genesis block.

--- a/NineChronicles.Headless.Executable/Models/Genesis/GenesisConfigExtensions.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/GenesisConfigExtensions.cs
@@ -1,0 +1,282 @@
+using Libplanet.Types.Blocks;
+
+namespace NineChronicles.Headless.Executable.Models.Genesis
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Numerics;
+    using NineChronicles.Headless.Executable.IO;
+    using Lib9c;
+    using Libplanet.Common;
+    using Libplanet.Crypto;
+    using Libplanet.Types.Assets;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Model.State;
+    using Lib9cUtils = Lib9c.DevExtensions.Utils;
+    using CoconaUtils = Libplanet.Extensions.Cocona.Utils;
+
+    public static class GenesisConfigExtensions
+    {
+        public const int DefaultCurrencyValue = 10000;
+
+        // FIXME: Remove initialMinter.
+        public static Block GenerateGenesisBlock(this GenesisConfig genesisConfig, IConsole console, out PrivateKey initialMinter)
+        {
+            ProcessData(console, genesisConfig.Data, out var tableSheets);
+
+            ProcessCurrency(console, genesisConfig.Currency, out var currency, out initialMinter, out var initialDepositList);
+
+            ProcessAdmin(console, genesisConfig.Admin, initialMinter, out var adminState, out var adminMeads);
+
+            ProcessValidator(console, genesisConfig.InitialValidatorSet, initialMinter, out var initialValidatorSet);
+
+            ProcessInitialMeadConfigs(console, genesisConfig.InitialMeadConfigs, out var initialMeads);
+
+            ProcessInitialPledgeConfigs(console, genesisConfig.InitialPledgeConfigs, out var initialPledges);
+
+            // Mine genesis block
+            console.Out.WriteLine("\nMining genesis block...\n");
+            return BlockHelper.ProposeGenesisBlock(
+                tableSheets: tableSheets,
+                goldDistributions: initialDepositList.ToArray(),
+                pendingActivationStates: Array.Empty<PendingActivationState>(),
+                // FIXME Should remove default value after fixing parameter type on Lib9c side.
+                adminState: adminState ?? new AdminState(default, 0L),
+                privateKey: initialMinter,
+                initialValidators: initialValidatorSet.ToDictionary(
+                    item => new PublicKey(ByteUtil.ParseHex(item.PublicKey)),
+                    item => new BigInteger(item.Power)),
+                actionBases: adminMeads.Concat(initialMeads).Concat(initialPledges).Concat(GetAdditionalActionBases()),
+                goldCurrency: currency
+            );
+        }
+
+        private static void ProcessData(IConsole console, DataConfig config, out Dictionary<string, string> tableSheets)
+        {
+            console.Out.WriteLine("\nProcessing data for genesis...");
+            if (string.IsNullOrEmpty(config.TablePath))
+            {
+                throw CoconaUtils.Error("TablePath is not set.");
+            }
+
+            tableSheets = Lib9cUtils.ImportSheets(config.TablePath);
+        }
+
+        private static void ProcessCurrency(
+            IConsole console,
+            CurrencyConfig? config,
+            out Currency currency,
+            out PrivateKey initialMinter,
+            out List<GoldDistribution> initialDepositList
+        )
+        {
+            console.Out.WriteLine("\nProcessing currency for genesis...");
+            if (config is null)
+            {
+                console.Out.WriteLine("CurrencyConfig not provided. Skip setting...");
+                initialMinter = new PrivateKey();
+                initialDepositList = new List<GoldDistribution>
+                {
+                    new()
+                    {
+                        Address = initialMinter.Address,
+                        AmountPerBlock = DefaultCurrencyValue,
+                        StartBlock = 0,
+                        EndBlock = 0,
+                    }
+                };
+
+    #pragma warning disable CS0618
+                // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                currency = Currency.Legacy("NCG", 2, minters: null);
+    #pragma warning restore CS0618
+                return;
+            }
+
+            if (string.IsNullOrEmpty(config.Value.InitialMinter))
+            {
+                console.Out.WriteLine("Private Key not provided. Create random one...");
+                initialMinter = new PrivateKey();
+            }
+            else
+            {
+                initialMinter = new PrivateKey(config.Value.InitialMinter);
+            }
+
+            initialDepositList = new List<GoldDistribution>();
+            if (config.Value.InitialCurrencyDeposit is null || config.Value.InitialCurrencyDeposit.Count == 0)
+            {
+                console.Out.WriteLine("Initial currency deposit list not provided. " +
+                                       $"Give initial {DefaultCurrencyValue} currency to InitialMinter");
+                initialDepositList.Add(new GoldDistribution
+                {
+                    Address = initialMinter.Address,
+                    AmountPerBlock = DefaultCurrencyValue,
+                    StartBlock = 0,
+                    EndBlock = 0
+                });
+            }
+            else
+            {
+                initialDepositList = config.Value.InitialCurrencyDeposit;
+            }
+
+    #pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            currency = Currency.Legacy("NCG", 2, minters: config.Value.AllowMint ? null : ImmutableHashSet.Create(initialMinter.Address));
+    #pragma warning restore CS0618
+        }
+
+        private static void ProcessAdmin(
+            IConsole console,
+            AdminConfig? config,
+            PrivateKey initialMinter,
+            out AdminState? adminState,
+            out List<ActionBase> meadActions
+        )
+        {
+            // FIXME: If the `adminState` is not required inside `MineGenesisBlock`,
+            //        this logic will be much lighter.
+            console.Out.WriteLine("\nProcessing admin for genesis...");
+            adminState = default;
+            meadActions = new List<ActionBase>();
+
+            if (config is null)
+            {
+                console.Out.WriteLine("AdminConfig not provided. Skip admin setting...");
+                return;
+            }
+
+            if (config.Value.Activate)
+            {
+                Address adminAddress;
+                if (string.IsNullOrEmpty(config.Value.Address))
+                {
+                    console.Out.WriteLine("Admin address not provided. Give admin privilege to initialMinter");
+                    adminAddress = initialMinter.Address;
+                }
+                else
+                {
+                    adminAddress = new Address(config.Value.Address);
+                }
+
+                adminState = new AdminState(adminAddress, config.Value.ValidUntil);
+                meadActions.Add(new PrepareRewardAssets
+                {
+                    RewardPoolAddress = adminAddress,
+                    Assets = new List<FungibleAssetValue>
+                    {
+                        10000 * Currencies.Mead,
+                    },
+                });
+            }
+            else
+            {
+                console.Out.WriteLine("Inactivate Admin. Skip admin setting...");
+            }
+
+            console.Out.WriteLine("Admin config done");
+        }
+
+        private static void ProcessValidator(
+            IConsole console,
+            List<Validator>? config,
+            PrivateKey initialValidator,
+            out List<Validator> initialValidatorSet)
+        {
+            console.Out.WriteLine("\nProcessing initial validator set for genesis...");
+            initialValidatorSet = new List<Validator>();
+            if (config is null || config.Count == 0)
+            {
+                console.Out.WriteLine(
+                    "InitialValidatorSet not provided. Use initial minter as initial validator."
+                );
+                initialValidatorSet.Add(new Validator
+                {
+                    PublicKey = initialValidator.PublicKey.ToString(),
+                    Power = 1,
+                }
+                );
+            }
+            else
+            {
+                initialValidatorSet = config.ToList();
+            }
+
+            var str = initialValidatorSet.Aggregate(string.Empty,
+                (s, v) => s + "PublicKey: " + v.PublicKey + ", Power: " + v.Power + "\n");
+            console.Out.WriteLine($"Initial validator set config done: {str}");
+        }
+
+        private static void ProcessInitialMeadConfigs(
+            IConsole console,
+            List<MeadConfig>? configs,
+            out List<PrepareRewardAssets> meadActions
+        )
+        {
+            console.Out.WriteLine("\nProcessing initial mead distribution...");
+
+            meadActions = new List<PrepareRewardAssets>();
+            if (configs is { })
+            {
+                foreach (MeadConfig config in configs)
+                {
+                    console.Out.WriteLine($"Preparing initial {config.Amount} MEAD for {config.Address}...");
+                    Address target = new(config.Address);
+                    meadActions.Add(
+                        new PrepareRewardAssets(
+                            target,
+                            new List<FungibleAssetValue>
+                            {
+                                FungibleAssetValue.Parse(Currencies.Mead, config.Amount),
+                            }
+                        )
+                    );
+                }
+            }
+        }
+
+        private static void ProcessInitialPledgeConfigs(
+            IConsole console,
+            List<PledgeConfig>? configs,
+            out List<CreatePledge> pledgeActions
+        )
+        {
+            console.Out.WriteLine("\nProcessing initial pledges...");
+
+            pledgeActions = new List<CreatePledge>();
+            if (configs is { })
+            {
+                foreach (PledgeConfig config in configs)
+                {
+                    console.Out.WriteLine($"Preparing a pledge for {config.AgentAddress}...");
+                    Address agentAddress = new(config.AgentAddress);
+                    Address pledgeAddress = agentAddress.GetPledgeAddress();
+                    pledgeActions.Add(
+                        new CreatePledge()
+                        {
+                            AgentAddresses = new[] { (agentAddress, pledgeAddress) },
+                            PatronAddress = new(config.PatronAddress),
+                            Mead = config.Mead,
+                        }
+                    );
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Actions to be appended on end of transaction actions.
+        /// You can add actions code to this method before generate genesis block.
+        /// </summary>
+        /// <returns>List of ActionBase.</returns>
+        private static List<ActionBase> GetAdditionalActionBases()
+        {
+            return new List<ActionBase>
+            {
+            };
+        }
+    }
+}

--- a/NineChronicles.Headless.Executable/Models/Genesis/MeadConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/MeadConfig.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NineChronicles.Headless.Executable.Models.Genesis
+{
+    [Serializable]
+    public struct MeadConfig
+    {
+        public string Address { get; set; }
+
+        public string Amount { get; set; }
+    }
+}

--- a/NineChronicles.Headless.Executable/Models/Genesis/PledgeConfig.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/PledgeConfig.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace NineChronicles.Headless.Executable.Models.Genesis
+{
+    [Serializable]
+    public struct PledgeConfig
+    {
+        public string AgentAddress { get; set; }
+
+        public string PatronAddress { get; set; }
+
+        public int Mead { get; set; }
+    }
+}

--- a/NineChronicles.Headless.Executable/Models/Genesis/Validator.cs
+++ b/NineChronicles.Headless.Executable/Models/Genesis/Validator.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NineChronicles.Headless.Executable.Models.Genesis
+{
+    [Serializable]
+    public struct Validator
+    {
+        public string PublicKey { get; set; }
+
+        public long Power { get; set; }
+    }
+}

--- a/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
+++ b/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable.csproj
@@ -70,6 +70,12 @@
     <None Update="appsettings.local.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings.odin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.heimdall.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -279,7 +279,7 @@ namespace NineChronicles.Headless.Executable
                     ActionEvaluatorType.ForkableActionEvaluator => new ForkableActionEvaluatorConfiguration
                     {
                         Pairs = (configuration.GetSection("Pairs") ??
-                                 throw new KeyNotFoundException()).GetChildren().Select(pair =>
+                            throw new KeyNotFoundException()).GetChildren().Select(pair =>
                         {
                             var range = new ForkableActionEvaluatorRange();
                             pair.Bind("Range", range);
@@ -291,6 +291,7 @@ namespace NineChronicles.Headless.Executable
                     },
                     ActionEvaluatorType.PluggedActionEvaluator => new PluggedActionEvaluatorConfiguration
                     {
+                        Version = configuration.GetValue<long>("Version", PluggedActionEvaluatorConfiguration.DefaultVersion),
                         PluginPath = configuration.GetValue<string>("PluginPath"),
                     },
                     _ => throw new InvalidOperationException("Unexpected type."),

--- a/NineChronicles.Headless.Executable/Program.cs
+++ b/NineChronicles.Headless.Executable/Program.cs
@@ -215,6 +215,8 @@ namespace NineChronicles.Headless.Executable
             [Option("config", new[] { 'C' },
                 Description = "Absolute path of \"appsettings.json\" file to provide headless configurations.")]
             string? configPath = "appsettings.json",
+            bool odin = false,
+            bool heimdall = false,
             [Option(Description = "[DANGER] Turn on RemoteKeyValueService to debug.")]
             bool remoteKeyValueService = false,
             [Ignore] CancellationToken? cancellationToken = null
@@ -232,7 +234,16 @@ namespace NineChronicles.Headless.Executable
             }
             else
             {
-                configurationBuilder.AddJsonFile(configPath!)
+                var finalConfigPath = (odin, heimdall) switch
+                {
+                    (true, false) => "appsettings.odin.json",
+                    (false, true) => "appsettings.heimdall.json",
+                    (true, true) =>
+                        throw new ArgumentException("You must provide only one of the --odin and --heimdall options."),
+                    _ => configPath
+                };
+
+                configurationBuilder.AddJsonFile(finalConfigPath!)
                     .AddEnvironmentVariables();
             }
 

--- a/NineChronicles.Headless.Executable/appsettings-schema.json
+++ b/NineChronicles.Headless.Executable/appsettings-schema.json
@@ -229,12 +229,32 @@
                         "type": {
                             "const": "PluggedActionEvaluator"
                         },
+                        "version": {
+                            "const": 1
+                        },
                         "pluginPath": {
-                            "$comment": "Local path or URI. If it is URI, download it under ./plugin",
+                            "$comment": "Local path or URI. If there are template keywords (e.g., <rid>, <os>, <arch>), they are replaced in runtime. If it is URI, download it under ./plugin",
                             "type": "string"
                         }
                     },
                     "required": [ "pluginPath" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "PluggedActionEvaluator"
+                        },
+                        "version": {
+                            "const": 2
+                        },
+                        "pluginPath": {
+                            "$comment": "Local path or URI. If there are template keywords (e.g., <rid>, <os>, <arch>), they are replaced in runtime. If it is URI, download it under ./plugin",
+                            "type": "string"
+                        }
+                    },
+                    "required": [ "pluginPath", "version" ],
                     "additionalProperties": false
                 },
                 {

--- a/NineChronicles.Headless.Executable/appsettings.heimdall.json
+++ b/NineChronicles.Headless.Executable/appsettings.heimdall.json
@@ -1,0 +1,391 @@
+{
+    "$schema": "https://raw.githubusercontent.com/planetarium/NineChronicles.Headless/main/NineChronicles.Headless.Executable/appsettings-schema.json",
+    "Serilog": {
+        "Using": [
+            "Serilog.Expressions",
+            "Serilog.Sinks.Console",
+            "Serilog.Sinks.RollingFile"
+        ],
+        "MinimumLevel": "Debug",
+        "WriteTo": [
+            {
+                "Name": "Logger",
+                "Args": {
+                    "configureLogger": {
+                        "WriteTo": [
+                            {
+                                "Name": "Console",
+                                "Args": {
+                                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] [{Source}] {Message:lj}{NewLine}{Exception}"
+                                }
+                            }
+                        ],
+                        "Filter": [
+                            {
+                                "Name": "ByIncludingOnly",
+                                "Args": {
+                                    "expression": "Source is not null"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "Name": "Logger",
+                "Args": {
+                    "configureLogger": {
+                        "WriteTo": [
+                            {
+                                "Name": "Console",
+                                "Args": {
+                                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+                                }
+                            }
+                        ],
+                        "Filter": [
+                            {
+                                "Name": "ByExcluding",
+                                "Args": {
+                                    "expression": "Source is not null"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "Filter": [
+            {
+                "Name": "ByExcluding",
+                "Args": {
+                    "expression": "SourceContext = 'Libplanet.Stun.TurnClient'"
+                }
+            },
+            {
+                "Name": "ByExcluding",
+                "Args": {
+                    "expression": "Source = 'VolatileStagePolicy'"
+                }
+            },
+            {
+                "Name": "ByExcluding",
+                "Args": {
+                    "expression": "SourceContext = 'Libplanet.Net.Protocols.RoutingTable'"
+                }
+            },
+            {
+                "Name": "ByExcluding",
+                "Args": {
+                    "expression": "Source = 'LoggedRenderer'"
+                }
+            }
+        ]
+    },
+    "Headless": {
+        "AppProtocolVersionString": "",
+        "GenesisBlockPath": "",
+        "StoreType": "rocksdb",
+        "StorePath": "",
+        "Port": 31234,
+        "IceServerStrings": [],
+        "PeerStrings": [],
+        "TrustedAppProtocolVersionSignerStrings": [],
+        "NoMiner": true,
+        "RpcServer": true,
+        "RpcListenHost": "127.0.0.1",
+        "RpcListenPort": 31238,
+        "RpcRemoteServer": true,
+        "GraphQLServer": true,
+        "GraphQLHost": "127.0.0.1",
+        "GraphQLPort": 31280,
+        "NoCors": true,
+        "Confirmations": 0,
+        "ChainTipStaleBehaviorType": "reboot",
+        "ActionEvaluator": {
+            "type": "ForkableActionEvaluator",
+            "pairs": [
+                {
+                    "range": {
+                        "start": 0,
+                        "end": 265299
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/8df91845e16ab5e445a35125588007c10814150c/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 265300,
+                        "end": 335183
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/06ccead46d51b2868942a0996e10e21b99c1726f/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 335184,
+                        "end": 520160
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/eb4e8827dd6fd2e8b88812fdfed725e2c3beb334/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 520161,
+                        "end": 812970
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/a9cca56c1c62214dd29d70bdcb40b16d1e8ca090/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 812971,
+                        "end": 1026580
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/e482c5988c75782d55525a91110d79e8c3353821/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 1026581,
+                        "end": 1030975
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/0c6d74ebdc3a73cb73fc559e3857d9e688997053/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 1030976,
+                        "end": 1126970
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/f744ce3b165eea3115b2da4866de232fd4367fb3/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 1126971,
+                        "end": 1128902
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/96c88ed0d254350957a63f629c16175d86206f6d/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 1128903,
+                        "end": 1138560
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/ff2c8ae6cfd030ffd20020e1a5bbc4e0caadfe97/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 1138561,
+                        "end": 1438969
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/baac89c749fd2cc491f0df5a52011bd8357eafb6/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 1438970,
+                        "end": 1825923
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c6a17ceb8856f4c7c6bdc7a7288be58479d9d006/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 1825924,
+                        "end": 2241046
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c5644aff871034a92042833edca03b85c2a24a1c/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 2241047,
+                        "end": 2506145
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/01f38299ed963db47634aab341984a76dc722f9b/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 2506146,
+                        "end": 2593176
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/315e97a66317f69ab946db68b2c7739317bc7ccd/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 2593177,
+                        "end": 2817714
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a5dd5bdf928d819b063a0c193fb9608e9f84f6e9/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 2817715,
+                        "end": 2916772
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/3a535117c642e2aca43ef57fa58416e328b6a051/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 2916773,
+                        "end": 3126487
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a0dcd8028ea3c1cf9b44244a1fc2b74044aa8399/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 3126488,
+                        "end": 3139160
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/2767d125b43ebebb7f2434c81a7eced463be93fd/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 3139161,
+                        "end": 3479774
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/95968dfc2482cdaf21ad5fc71cf40b5f191b6d39/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 3479775,
+                        "end": 3788647
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/810b1d86a3f11f9780c270671b845bfa7c8bd0a1/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 3788648,
+                        "end": 3971980
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/9f1661102a74ef38c4715061c7e8a36d8c544366/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 3971981,
+                        "end": 4005778
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/cd378f26a8d187c08ea928a15ec988d394fc14a3/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 4005779,
+                        "end": 9223372036854775807
+                    },
+                    "actionEvaluator": {
+                        "type": "Default"
+                    }
+                }
+            ]
+        }
+    },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "Debug"
+        }
+    },
+    "IpRateLimiting": {
+        "EnableEndpointRateLimiting": false,
+        "StackBlockedRequests": true,
+        "RealIpHeader": "X-Real-IP",
+        "HttpStatusCode": 429,
+        "IpWhitelist": [
+            "127.0.0.1"
+        ],
+        "GeneralRules": [
+            {
+                "Endpoint": "*:/IBlockChainService/PutTransaction",
+                "Period": "60s",
+                "Limit": 12
+            },
+            {
+                "Endpoint": "*:/graphql/stagetransaction",
+                "Period": "60s",
+                "Limit": 12
+            }
+        ],
+        "QuotaExceededResponse": {
+            "Content": "{ \"message\": \"Whoa! Calm down, cowboy!\", \"details\": \"Quota exceeded. Maximum allowed: {0} per {1}. Please try again in {2} second(s).\" }",
+            "ContentType": "application/json",
+            "StatusCode": 429
+        },
+        "IpBanThresholdCount": 10,
+        "IpBanMinute": 60,
+        "IpBanResponse": {
+            "Content": "{ \"message\": \"Your Ip has been banned.\" }",
+            "ContentType": "application/json",
+            "StatusCode": 403
+        }
+    },
+    "MultiAccountManaging": {
+        "EnableManaging": false,
+        "ManagementTimeMinutes": 10,
+        "TxIntervalMinutes": 10,
+        "ThresholdCount": 29
+    },
+    "Jwt": {
+        "EnableJwtAuthentication": false,
+        "Key": "secretKey",
+        "Issuer": "planetariumhq.com"
+    }
+}

--- a/NineChronicles.Headless.Executable/appsettings.heimdall.json
+++ b/NineChronicles.Headless.Executable/appsettings.heimdall.json
@@ -361,7 +361,9 @@
                         "end": 9223372036854775807
                     },
                     "actionEvaluator": {
-                        "type": "Default"
+                        "version": 2,
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/51c8b73fb5df5cb1e3e3db2d5a8b094dbe5e7ae1/<os>-<arch>.zip"
                     }
                 }
             ]

--- a/NineChronicles.Headless.Executable/appsettings.heimdall.json
+++ b/NineChronicles.Headless.Executable/appsettings.heimdall.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/planetarium/NineChronicles.Headless/main/NineChronicles.Headless.Executable/appsettings-schema.json",
+    "$schema": "./appsettings-schema.json",
     "Serilog": {
         "Using": [
             "Serilog.Expressions",
@@ -113,8 +113,9 @@
                         "end": 265299
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/8df91845e16ab5e445a35125588007c10814150c/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/8df91845e16ab5e445a35125588007c10814150c/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -123,8 +124,9 @@
                         "end": 335183
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/06ccead46d51b2868942a0996e10e21b99c1726f/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/06ccead46d51b2868942a0996e10e21b99c1726f/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -133,8 +135,9 @@
                         "end": 520160
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/eb4e8827dd6fd2e8b88812fdfed725e2c3beb334/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/eb4e8827dd6fd2e8b88812fdfed725e2c3beb334/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -143,8 +146,9 @@
                         "end": 812970
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/a9cca56c1c62214dd29d70bdcb40b16d1e8ca090/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/a9cca56c1c62214dd29d70bdcb40b16d1e8ca090/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -153,8 +157,9 @@
                         "end": 1026580
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/e482c5988c75782d55525a91110d79e8c3353821/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/e482c5988c75782d55525a91110d79e8c3353821/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -163,8 +168,9 @@
                         "end": 1030975
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/0c6d74ebdc3a73cb73fc559e3857d9e688997053/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/0c6d74ebdc3a73cb73fc559e3857d9e688997053/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -173,8 +179,9 @@
                         "end": 1126970
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/f744ce3b165eea3115b2da4866de232fd4367fb3/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/f744ce3b165eea3115b2da4866de232fd4367fb3/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -183,8 +190,9 @@
                         "end": 1128902
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/96c88ed0d254350957a63f629c16175d86206f6d/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/96c88ed0d254350957a63f629c16175d86206f6d/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -193,8 +201,9 @@
                         "end": 1138560
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/ff2c8ae6cfd030ffd20020e1a5bbc4e0caadfe97/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/ff2c8ae6cfd030ffd20020e1a5bbc4e0caadfe97/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -203,8 +212,9 @@
                         "end": 1438969
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/baac89c749fd2cc491f0df5a52011bd8357eafb6/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/baac89c749fd2cc491f0df5a52011bd8357eafb6/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -213,8 +223,9 @@
                         "end": 1825923
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c6a17ceb8856f4c7c6bdc7a7288be58479d9d006/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c6a17ceb8856f4c7c6bdc7a7288be58479d9d006/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -223,8 +234,9 @@
                         "end": 2241046
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c5644aff871034a92042833edca03b85c2a24a1c/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c5644aff871034a92042833edca03b85c2a24a1c/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -233,8 +245,9 @@
                         "end": 2506145
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/01f38299ed963db47634aab341984a76dc722f9b/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/01f38299ed963db47634aab341984a76dc722f9b/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -243,8 +256,9 @@
                         "end": 2593176
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/315e97a66317f69ab946db68b2c7739317bc7ccd/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/315e97a66317f69ab946db68b2c7739317bc7ccd/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -253,8 +267,9 @@
                         "end": 2817714
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a5dd5bdf928d819b063a0c193fb9608e9f84f6e9/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a5dd5bdf928d819b063a0c193fb9608e9f84f6e9/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -263,8 +278,9 @@
                         "end": 2916772
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/3a535117c642e2aca43ef57fa58416e328b6a051/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/3a535117c642e2aca43ef57fa58416e328b6a051/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -273,8 +289,9 @@
                         "end": 3126487
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a0dcd8028ea3c1cf9b44244a1fc2b74044aa8399/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a0dcd8028ea3c1cf9b44244a1fc2b74044aa8399/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -283,8 +300,9 @@
                         "end": 3139160
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/2767d125b43ebebb7f2434c81a7eced463be93fd/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/2767d125b43ebebb7f2434c81a7eced463be93fd/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -293,8 +311,9 @@
                         "end": 3479774
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/95968dfc2482cdaf21ad5fc71cf40b5f191b6d39/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/95968dfc2482cdaf21ad5fc71cf40b5f191b6d39/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -303,8 +322,9 @@
                         "end": 3788647
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/810b1d86a3f11f9780c270671b845bfa7c8bd0a1/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/810b1d86a3f11f9780c270671b845bfa7c8bd0a1/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -313,8 +333,9 @@
                         "end": 3971980
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/9f1661102a74ef38c4715061c7e8a36d8c544366/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/9f1661102a74ef38c4715061c7e8a36d8c544366/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -323,8 +344,9 @@
                         "end": 4005778
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/cd378f26a8d187c08ea928a15ec988d394fc14a3/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/cd378f26a8d187c08ea928a15ec988d394fc14a3/<os>-<arch>.zip"
                     }
                 },
                 {

--- a/NineChronicles.Headless.Executable/appsettings.heimdall.json
+++ b/NineChronicles.Headless.Executable/appsettings.heimdall.json
@@ -85,12 +85,18 @@
         ]
     },
     "Headless": {
-        "AppProtocolVersionString": "",
-        "GenesisBlockPath": "",
+        "AppProtocolVersionString": "200240/eE394bb942fa7c2d807C170C7Db7F26cb3EA037F/MEUCIQCOAt0QJngeHcaIypabSru0Gw2c4dzVdfI6CpCfv4RYRAIgCKx6jtZJuQejFml6c7EnJJIH07iIZdmQniD5ff9paLE=/ZHU5OnRpbWVzdGFtcHUxMDoyMDI0LTEwLTI5ZQ==",
+        "GenesisBlockPath": "https://planets.nine-chronicles.com/planets/0x000000000001/genesis",
         "StoreType": "rocksdb",
         "StorePath": "",
         "Port": 31234,
-        "IceServerStrings": [],
+        "IceServerStrings": [
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.nine-chronicles.com:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us2.nine-chronicles.com:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us3.nine-chronicles.com:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us4.nine-chronicles.com:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us5.nine-chronicles.com:3478"
+        ],
         "PeerStrings": [],
         "TrustedAppProtocolVersionSignerStrings": [],
         "NoMiner": true,

--- a/NineChronicles.Headless.Executable/appsettings.odin.json
+++ b/NineChronicles.Headless.Executable/appsettings.odin.json
@@ -1,0 +1,391 @@
+{
+    "$schema": "https://raw.githubusercontent.com/planetarium/NineChronicles.Headless/main/NineChronicles.Headless.Executable/appsettings-schema.json",
+    "Serilog": {
+        "Using": [
+            "Serilog.Expressions",
+            "Serilog.Sinks.Console",
+            "Serilog.Sinks.RollingFile"
+        ],
+        "MinimumLevel": "Debug",
+        "WriteTo": [
+            {
+                "Name": "Logger",
+                "Args": {
+                    "configureLogger": {
+                        "WriteTo": [
+                            {
+                                "Name": "Console",
+                                "Args": {
+                                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] [{Source}] {Message:lj}{NewLine}{Exception}"
+                                }
+                            }
+                        ],
+                        "Filter": [
+                            {
+                                "Name": "ByIncludingOnly",
+                                "Args": {
+                                    "expression": "Source is not null"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "Name": "Logger",
+                "Args": {
+                    "configureLogger": {
+                        "WriteTo": [
+                            {
+                                "Name": "Console",
+                                "Args": {
+                                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+                                }
+                            }
+                        ],
+                        "Filter": [
+                            {
+                                "Name": "ByExcluding",
+                                "Args": {
+                                    "expression": "Source is not null"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "Filter": [
+            {
+                "Name": "ByExcluding",
+                "Args": {
+                    "expression": "SourceContext = 'Libplanet.Stun.TurnClient'"
+                }
+            },
+            {
+                "Name": "ByExcluding",
+                "Args": {
+                    "expression": "Source = 'VolatileStagePolicy'"
+                }
+            },
+            {
+                "Name": "ByExcluding",
+                "Args": {
+                    "expression": "SourceContext = 'Libplanet.Net.Protocols.RoutingTable'"
+                }
+            },
+            {
+                "Name": "ByExcluding",
+                "Args": {
+                    "expression": "Source = 'LoggedRenderer'"
+                }
+            }
+        ]
+    },
+    "Headless": {
+        "AppProtocolVersionString": "",
+        "GenesisBlockPath": "",
+        "StoreType": "rocksdb",
+        "StorePath": "",
+        "Port": 31234,
+        "IceServerStrings": [],
+        "PeerStrings": [],
+        "TrustedAppProtocolVersionSignerStrings": [],
+        "NoMiner": true,
+        "RpcServer": true,
+        "RpcListenHost": "127.0.0.1",
+        "RpcListenPort": 31238,
+        "RpcRemoteServer": true,
+        "GraphQLServer": true,
+        "GraphQLHost": "127.0.0.1",
+        "GraphQLPort": 31280,
+        "NoCors": true,
+        "Confirmations": 0,
+        "ChainTipStaleBehaviorType": "reboot",
+        "ActionEvaluator": {
+            "type": "ForkableActionEvaluator",
+            "pairs": [
+                {
+                    "range": {
+                        "start": 0,
+                        "end": 8649535
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/8df91845e16ab5e445a35125588007c10814150c/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 8649536,
+                        "end": 8717452
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/06ccead46d51b2868942a0996e10e21b99c1726f/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 8717453,
+                        "end": 8900572
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/eb4e8827dd6fd2e8b88812fdfed725e2c3beb334/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 8900573,
+                        "end": 9195812
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/a9cca56c1c62214dd29d70bdcb40b16d1e8ca090/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 9195813,
+                        "end": 9410737
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/e482c5988c75782d55525a91110d79e8c3353821/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 9410738,
+                        "end": 9414199
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/0c6d74ebdc3a73cb73fc559e3857d9e688997053/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 9414200,
+                        "end": 9415427
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/5fd5e579406eb0a34de56d8ca6a2be30474a6d5f/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 9415428,
+                        "end": 9511234
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/f744ce3b165eea3115b2da4866de232fd4367fb3/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 9511235,
+                        "end": 9513363
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/96c88ed0d254350957a63f629c16175d86206f6d/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 9513364,
+                        "end": 9523326
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/ff2c8ae6cfd030ffd20020e1a5bbc4e0caadfe97/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 9523327,
+                        "end": 9842921
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/baac89c749fd2cc491f0df5a52011bd8357eafb6/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 9842922,
+                        "end": 10264034
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c6a17ceb8856f4c7c6bdc7a7288be58479d9d006/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 10264035,
+                        "end": 10713816
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c5644aff871034a92042833edca03b85c2a24a1c/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 10713817,
+                        "end": 11010423
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/01f38299ed963db47634aab341984a76dc722f9b/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 11010424,
+                        "end": 11100831
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/315e97a66317f69ab946db68b2c7739317bc7ccd/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 11100832,
+                        "end": 11328655
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a5dd5bdf928d819b063a0c193fb9608e9f84f6e9/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 11328656,
+                        "end": 11427518
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/3a535117c642e2aca43ef57fa58416e328b6a051/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 11427519,
+                        "end": 11622905
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a0dcd8028ea3c1cf9b44244a1fc2b74044aa8399/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 11622906,
+                        "end": 11970016
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/95968dfc2482cdaf21ad5fc71cf40b5f191b6d39/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 11970017,
+                        "end": 12262530
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/810b1d86a3f11f9780c270671b845bfa7c8bd0a1/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 12262531,
+                        "end": 12441703
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/9f1661102a74ef38c4715061c7e8a36d8c544366/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 12441704,
+                        "end": 12474765
+                    },
+                    "actionEvaluator": {
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/cd378f26a8d187c08ea928a15ec988d394fc14a3/linux-arm64.zip"
+                    }
+                },
+                {
+                    "range": {
+                        "start": 12474766,
+                        "end": 9223372036854775807
+                    },
+                    "actionEvaluator": {
+                        "type": "Default"
+                    }
+                }
+            ]
+        }
+    },
+    "Logging": {
+        "LogLevel": {
+            "Microsoft": "Debug"
+        }
+    },
+    "IpRateLimiting": {
+        "EnableEndpointRateLimiting": false,
+        "StackBlockedRequests": true,
+        "RealIpHeader": "X-Real-IP",
+        "HttpStatusCode": 429,
+        "IpWhitelist": [
+            "127.0.0.1"
+        ],
+        "GeneralRules": [
+            {
+                "Endpoint": "*:/IBlockChainService/PutTransaction",
+                "Period": "60s",
+                "Limit": 12
+            },
+            {
+                "Endpoint": "*:/graphql/stagetransaction",
+                "Period": "60s",
+                "Limit": 12
+            }
+        ],
+        "QuotaExceededResponse": {
+            "Content": "{ \"message\": \"Whoa! Calm down, cowboy!\", \"details\": \"Quota exceeded. Maximum allowed: {0} per {1}. Please try again in {2} second(s).\" }",
+            "ContentType": "application/json",
+            "StatusCode": 429
+        },
+        "IpBanThresholdCount": 10,
+        "IpBanMinute": 60,
+        "IpBanResponse": {
+            "Content": "{ \"message\": \"Your Ip has been banned.\" }",
+            "ContentType": "application/json",
+            "StatusCode": 403
+        }
+    },
+    "MultiAccountManaging": {
+        "EnableManaging": false,
+        "ManagementTimeMinutes": 10,
+        "TxIntervalMinutes": 10,
+        "ThresholdCount": 29
+    },
+    "Jwt": {
+        "EnableJwtAuthentication": false,
+        "Key": "secretKey",
+        "Issuer": "planetariumhq.com"
+    }
+}

--- a/NineChronicles.Headless.Executable/appsettings.odin.json
+++ b/NineChronicles.Headless.Executable/appsettings.odin.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/planetarium/NineChronicles.Headless/main/NineChronicles.Headless.Executable/appsettings-schema.json",
+    "$schema": "./appsettings-schema.json",
     "Serilog": {
         "Using": [
             "Serilog.Expressions",
@@ -113,8 +113,9 @@
                         "end": 8649535
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/8df91845e16ab5e445a35125588007c10814150c/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/8df91845e16ab5e445a35125588007c10814150c/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -123,8 +124,9 @@
                         "end": 8717452
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/06ccead46d51b2868942a0996e10e21b99c1726f/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/06ccead46d51b2868942a0996e10e21b99c1726f/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -133,8 +135,9 @@
                         "end": 8900572
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/eb4e8827dd6fd2e8b88812fdfed725e2c3beb334/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/eb4e8827dd6fd2e8b88812fdfed725e2c3beb334/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -144,7 +147,7 @@
                     },
                     "actionEvaluator": {
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/a9cca56c1c62214dd29d70bdcb40b16d1e8ca090/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/a9cca56c1c62214dd29d70bdcb40b16d1e8ca090/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -153,8 +156,9 @@
                         "end": 9410737
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/e482c5988c75782d55525a91110d79e8c3353821/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/e482c5988c75782d55525a91110d79e8c3353821/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -163,8 +167,9 @@
                         "end": 9414199
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/0c6d74ebdc3a73cb73fc559e3857d9e688997053/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/0c6d74ebdc3a73cb73fc559e3857d9e688997053/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -173,8 +178,9 @@
                         "end": 9415427
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/5fd5e579406eb0a34de56d8ca6a2be30474a6d5f/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/5fd5e579406eb0a34de56d8ca6a2be30474a6d5f/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -183,8 +189,9 @@
                         "end": 9511234
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/f744ce3b165eea3115b2da4866de232fd4367fb3/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/f744ce3b165eea3115b2da4866de232fd4367fb3/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -193,8 +200,9 @@
                         "end": 9513363
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/96c88ed0d254350957a63f629c16175d86206f6d/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/96c88ed0d254350957a63f629c16175d86206f6d/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -203,8 +211,9 @@
                         "end": 9523326
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/ff2c8ae6cfd030ffd20020e1a5bbc4e0caadfe97/linux-arm64.zip"
+                        "pluginPath": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/ff2c8ae6cfd030ffd20020e1a5bbc4e0caadfe97/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -213,8 +222,9 @@
                         "end": 9842921
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/baac89c749fd2cc491f0df5a52011bd8357eafb6/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/baac89c749fd2cc491f0df5a52011bd8357eafb6/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -223,8 +233,9 @@
                         "end": 10264034
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c6a17ceb8856f4c7c6bdc7a7288be58479d9d006/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c6a17ceb8856f4c7c6bdc7a7288be58479d9d006/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -233,8 +244,9 @@
                         "end": 10713816
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c5644aff871034a92042833edca03b85c2a24a1c/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/c5644aff871034a92042833edca03b85c2a24a1c/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -243,8 +255,9 @@
                         "end": 11010423
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/01f38299ed963db47634aab341984a76dc722f9b/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/01f38299ed963db47634aab341984a76dc722f9b/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -253,8 +266,9 @@
                         "end": 11100831
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/315e97a66317f69ab946db68b2c7739317bc7ccd/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/315e97a66317f69ab946db68b2c7739317bc7ccd/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -263,8 +277,9 @@
                         "end": 11328655
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a5dd5bdf928d819b063a0c193fb9608e9f84f6e9/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a5dd5bdf928d819b063a0c193fb9608e9f84f6e9/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -273,8 +288,9 @@
                         "end": 11427518
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/3a535117c642e2aca43ef57fa58416e328b6a051/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/3a535117c642e2aca43ef57fa58416e328b6a051/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -283,8 +299,9 @@
                         "end": 11622905
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a0dcd8028ea3c1cf9b44244a1fc2b74044aa8399/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/a0dcd8028ea3c1cf9b44244a1fc2b74044aa8399/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -293,8 +310,9 @@
                         "end": 11970016
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/95968dfc2482cdaf21ad5fc71cf40b5f191b6d39/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/95968dfc2482cdaf21ad5fc71cf40b5f191b6d39/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -303,8 +321,9 @@
                         "end": 12262530
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/810b1d86a3f11f9780c270671b845bfa7c8bd0a1/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/810b1d86a3f11f9780c270671b845bfa7c8bd0a1/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -313,8 +332,9 @@
                         "end": 12441703
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/9f1661102a74ef38c4715061c7e8a36d8c544366/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/9f1661102a74ef38c4715061c7e8a36d8c544366/<os>-<arch>.zip"
                     }
                 },
                 {
@@ -323,8 +343,9 @@
                         "end": 12474765
                     },
                     "actionEvaluator": {
+                        "version": 2,
                         "type": "PluggedActionEvaluator",
-                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/cd378f26a8d187c08ea928a15ec988d394fc14a3/linux-arm64.zip"
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/cd378f26a8d187c08ea928a15ec988d394fc14a3/<os>-<arch>.zip"
                     }
                 },
                 {

--- a/NineChronicles.Headless.Executable/appsettings.odin.json
+++ b/NineChronicles.Headless.Executable/appsettings.odin.json
@@ -360,7 +360,9 @@
                         "end": 9223372036854775807
                     },
                     "actionEvaluator": {
-                        "type": "Default"
+                        "version": 2,
+                        "type": "PluggedActionEvaluator",
+                        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/51c8b73fb5df5cb1e3e3db2d5a8b094dbe5e7ae1/<os>-<arch>.zip"
                     }
                 }
             ]

--- a/NineChronicles.Headless.Executable/appsettings.odin.json
+++ b/NineChronicles.Headless.Executable/appsettings.odin.json
@@ -85,12 +85,18 @@
         ]
     },
     "Headless": {
-        "AppProtocolVersionString": "",
-        "GenesisBlockPath": "",
+        "AppProtocolVersionString": "200240/AB2da648b9154F2cCcAFBD85e0Bc3d51f97330Fc/MEUCIQDt4y8p9LjOTKoopQXzY..GaoJOqJVuX5LuGKMPvdeA8gIgVBj8xPatJ.8tA3AtbhzFipntkzmjv859KwZogniUE2I=/ZHU5OnRpbWVzdGFtcHUxMDoyMDI0LTEwLTI5ZQ==",
+        "GenesisBlockPath": "https://planets.nine-chronicles.com/planets/0x000000000000/genesis",
         "StoreType": "rocksdb",
         "StorePath": "",
         "Port": 31234,
-        "IceServerStrings": [],
+        "IceServerStrings": [
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us2.planetarium.dev:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us3.planetarium.dev:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us4.planetarium.dev:3478",
+            "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us5.planetarium.dev:3478"
+        ],
         "PeerStrings": [],
         "TrustedAppProtocolVersionSignerStrings": [],
         "NoMiner": true,


### PR DESCRIPTION
Previously, we need to manage several configuration files for each os and architecture. (e.g., `linux-amd64`, `linux-arm64`, etc) because `pluginPath` field is a constant string.

This pull request introduces a new feature for `pluginPath` field in `appsettings.json`-like configuration files.

To use this feature, you must specify `version` field to `2` first.

```json
{
	"actionEvaluator": {
        "version": 2,
        "type": "PluggedActionEvaluator",
        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/51c8b73fb5df5cb1e3e3db2d5a8b094dbe5e7ae1/linux-arm64.zip"
    }
}
```

The `actionEvaluator` with `version: 2` and `type: PluggedActionEvaluator`, uses `pluginPath` as template.

The decoder of `actionEvaluator` replaces the following keywords in `pluginPath`, with corresponding values.

- `<os>`: Operating Systems. (`macOS` → `osx`, `Windows` → `win`, `Linux` → `linux`, not supported else) (It is determined by .NET `RuntimeInformation.IsOSPlatform(...)`).
- `<arch>`: OS Architecture. (`x64` → `x64`, `x86` → `x86`, `Arm64` → `arm64`, `Arm` → `arm`, not supported else) (It is determined by .NET `RuntimeInformation.OSArchitecture`).
- `<rid>`: Same with `<os>-<arch>` (e.g., `linux-arm64`) (https://learn.microsoft.com/en-us/dotnet/core/rid-catalog#known-rids)

```json
{
	"actionEvaluator": {
        "version": 2,
        "type": "PluggedActionEvaluator",
        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/51c8b73fb5df5cb1e3e3db2d5a8b094dbe5e7ae1/<os>-<arch>.zip"
    }
}
```

Or

```json
{
	"actionEvaluator": {
        "version": 2,
        "type": "PluggedActionEvaluator",
        "pluginPath": "https://lib9c-plugin.s3.us-east-2.amazonaws.com/51c8b73fb5df5cb1e3e3db2d5a8b094dbe5e7ae1/<rid>.zip"
    }
}
```