### PR TITLE
ci(gh-actions): fix tagging docker image

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -76,14 +76,13 @@ jobs:
             --password '${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}'
       - name: push git tagged version
         run: |
-          docker pull ${{ matrix.docker.repo }}:git-${{ github.sha }}
           if [[ -z "${{ github.event.inputs.imageTag }}" ]]; then
             export IMAGE_TAG=${{ github.ref_name }}
           else
             export IMAGE_TAG=${{ github.event.inputs.imageTag }}
           fi
 
-          docker tag \
-            ${{ matrix.docker.repo }}:git-${{ github.sha }} \
-            ${{ matrix.docker.repo }}:$IMAGE_TAG
-          docker push ${{ matrix.docker.repo }}:$IMAGE_TAG
+          docker buildx imagetools create \
+            --progress=plain \
+            --tag ${{ matrix.docker.repo }}:$IMAGE_TAG \
+            ${{ matrix.docker.repo }}:git-${{ github.sha }}


### PR DESCRIPTION
## Context

Previously, the `push_docker_image` workflow tagged image incorrectly, tag for only one platform (not both linux/amd64 and linux/arm64). It was because of misunderstanding for `docker pull` and `docker tag` command.

## Solution

So I researched the way and I found `docker buildx imagetools create` command. It can create a new manifest list from manifest list with a tag. (`docker manifest` cannot handle manifest list 😢)

The following lines are my shell output when testing locally. Because their digests are same with the original manifest, I believe that its behavior is just retagging.

```
% docker buildx imagetools create --progress=plain --tag=moreal/9c-headless:333 planetariumhq/ninechronicles-headless:git-08308b1134eaaa7a593350ebe59f12021b33fae7
#1 [internal] pushing docker.io/moreal/9c-headless:333
#1 0.000 copying sha256:37972d8de505d56f856e702479e83e6e16d5141f5bc2fbaaf1cc78749555a1b3 from docker.io/planetariumhq/ninechronicles-headless:git-08308b1134eaaa7a593350ebe59f12021b33fae7 to docker.io/moreal/9c-headless:333
#1 6.780 pushing sha256:37972d8de505d56f856e702479e83e6e16d5141f5bc2fbaaf1cc78749555a1b3 to docker.io/moreal/9c-headless:333
#1 DONE 7.0s
% docker manifest inspect moreal/9c-headless:333
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 2011,
         "digest": "sha256:7f4aafb09979d926bc3188e83aea43217987d9ab3bbe34378d9f7e53b2571e46",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 2011,
         "digest": "sha256:674547a00e0574a03ec91aae913a5020f80081ee3bf170f15eab426bb01b257a",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 567,
         "digest": "sha256:fab32ecde32f5e80d6fe83d65c8e72b26008ebd2cbfad852f76b5c4df84a7f82",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 567,
         "digest": "sha256:a13ca1fd21051c3eb221d998cb795849f7a71063e42e7974d9ab33f33338a805",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
% docker manifest inspect planetariumhq/ninechronicles-headless:git-08308b1134eaaa7a593350ebe59f12021b33fae7        
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 2011,
         "digest": "sha256:7f4aafb09979d926bc3188e83aea43217987d9ab3bbe34378d9f7e53b2571e46",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 2011,
         "digest": "sha256:674547a00e0574a03ec91aae913a5020f80081ee3bf170f15eab426bb01b257a",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 567,
         "digest": "sha256:fab32ecde32f5e80d6fe83d65c8e72b26008ebd2cbfad852f76b5c4df84a7f82",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 567,
         "digest": "sha256:a13ca1fd21051c3eb221d998cb795849f7a71063e42e7974d9ab33f33338a805",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
```

You can see the `moreal/9c-headless:333` in Docker Hub

https://hub.docker.com/layers/moreal/9c-headless/333/images/sha256-7f4aafb09979d926bc3188e83aea43217987d9ab3bbe34378d9f7e53b2571e46?context=repo

## References

- https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/