### PR TITLE
Add stateQuery for the validator's delegation

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/ValidatorTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ValidatorTypeTest.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using Libplanet.Types.Tx;
+using Nekoyume.ValidatorDelegation;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NineChronicles.Headless.Tests.GraphTypes
+{
+    public class ValidatorTypeTest : GraphQLTestBase
+    {
+        public ValidatorTypeTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ExecuteQuery()
+        {
+            // Given
+            var block = BlockChain.Tip;
+            var blockHeight = 0L;
+            var tip = new Domain.Model.BlockChain.Block(
+                Hash: block.Hash,
+                PreviousHash: null,
+                Miner: ProposerPrivateKey.Address,
+                Index: blockHeight,
+                Timestamp: block.Timestamp,
+                StateRootHash: block.StateRootHash,
+                Transactions: ImmutableArray<Transaction>.Empty);
+            var worldState = BlockChain.GetNextWorldState();
+            var stateRootHash = block.StateRootHash;
+            var validatorAddress = ProposerPrivateKey.Address.ToHex();
+            var query =
+                $"query {{\n" +
+                $"  stateQuery(index: 0) {{\n" +
+                $"    validator(validatorAddress: \"{validatorAddress}\") {{\n" +
+                $"      power\n" +
+                $"      isActive\n" +
+                $"      totalShares\n" +
+                $"      jailed\n" +
+                $"      jailedUntil\n" +
+                $"      tombstoned\n" +
+                $"      commissionPercentage\n" +
+                $"      totalDelegated {{\n" +
+                $"        currency\n" +
+                $"        quantity\n" +
+                $"      }}\n" +
+                $"    }}\n" +
+                $"  }}\n" +
+                $"}}\n";
+
+            BlockChainRepository.Setup(repository => repository.GetBlock(blockHeight)).Returns(tip);
+            WorldStateRepository.Setup(repository => repository.GetWorldState(stateRootHash)).Returns(worldState);
+
+            // When
+            var result = await ExecuteQueryAsync(query);
+
+            // Then
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
+            var stateQueryResult = (Dictionary<string, object>)data["stateQuery"];
+            var validatorResult = (Dictionary<string, object>)stateQueryResult["validator"];
+
+            Assert.Equal("10,000,000,000,000,000,000", validatorResult["power"]);
+            Assert.Equal(true, validatorResult["isActive"]);
+            Assert.Equal("10,000,000,000,000,000,000", validatorResult["totalShares"]);
+            Assert.Equal(false, validatorResult["jailed"]);
+            Assert.Equal(-1L, validatorResult["jailedUntil"]);
+            Assert.Equal(false, validatorResult["tombstoned"]);
+            Assert.Equal($"{ValidatorDelegatee.DefaultCommissionPercentage}", validatorResult["commissionPercentage"]);
+
+            var totalDelegatedResult = (Dictionary<string, object>)validatorResult["totalDelegated"];
+            Assert.Equal("GUILD_GOLD", totalDelegatedResult["currency"]);
+            Assert.Equal("10.000000000000000000", totalDelegatedResult["quantity"]);
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/StateQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StateQuery.cs
@@ -772,6 +772,25 @@ namespace NineChronicles.Headless.GraphTypes
                     return share.ToString();
                 }
             );
+
+            Field<ValidatorType>(
+                name: "validator",
+                description: "State for validator.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "validatorAddress",
+                        Description = "Address of validator."
+                    }
+                ),
+                resolve: context =>
+                {
+                    var validatorAddress = context.GetArgument<Address>("validatorAddress");
+                    var repository = new ValidatorRepository(new World(context.Source.WorldState), new HallowActionContext { });
+                    var delegatee = repository.GetValidatorDelegatee(validatorAddress);
+                    return ValidatorType.FromDelegatee(delegatee);
+                }
+            );
         }
 
         public static List<RuneOptionSheet.Row.RuneOptionInfo> GetRuneOptions(

--- a/NineChronicles.Headless/GraphTypes/ValidatorType.cs
+++ b/NineChronicles.Headless/GraphTypes/ValidatorType.cs
@@ -1,0 +1,74 @@
+using System.Numerics;
+using GraphQL.Types;
+using Libplanet.Types.Assets;
+using Nekoyume.ValidatorDelegation;
+
+namespace NineChronicles.Headless.GraphTypes;
+
+public class ValidatorType : ObjectGraphType<ValidatorType>
+{
+    public BigInteger Power { get; set; }
+
+    public bool IsActive { get; set; }
+
+    public BigInteger TotalShares { get; set; }
+
+    public bool Jailed { get; set; }
+
+    public long JailedUntil { get; set; }
+
+    public bool Tombstoned { get; set; }
+
+    public FungibleAssetValue TotalDelegated { get; set; }
+
+    public BigInteger CommissionPercentage { get; set; }
+
+    public ValidatorType()
+    {
+        Field<NonNullGraphType<StringGraphType>>(
+            nameof(Power),
+            description: "Power of validator",
+            resolve: context => context.Source.Power.ToString("N0"));
+        Field<NonNullGraphType<BooleanGraphType>>(
+            nameof(IsActive),
+            description: "Specifies whether the validator is active.",
+            resolve: context => context.Source.IsActive);
+        Field<NonNullGraphType<StringGraphType>>(
+            nameof(TotalShares),
+            description: "Total shares of validator",
+            resolve: context => context.Source.TotalShares.ToString("N0"));
+        Field<NonNullGraphType<BooleanGraphType>>(
+            nameof(Jailed),
+            description: "Specifies whether the validator is jailed.",
+            resolve: context => context.Source.Jailed);
+        Field<NonNullGraphType<LongGraphType>>(
+            nameof(JailedUntil),
+            description: "Block height until which the validator is jailed.",
+            resolve: context => context.Source.JailedUntil);
+        Field<NonNullGraphType<BooleanGraphType>>(
+            nameof(Tombstoned),
+            description: "Specifies whether the validator is tombstoned.",
+            resolve: context => context.Source.Tombstoned);
+        Field<NonNullGraphType<FungibleAssetValueType>>(
+            nameof(TotalDelegated),
+            description: "Total delegated amount of the validator.",
+            resolve: context => context.Source.TotalDelegated);
+        Field<NonNullGraphType<StringGraphType>>(
+            nameof(CommissionPercentage),
+            description: "Commission percentage of the validator.",
+            resolve: context => context.Source.CommissionPercentage.ToString("N0"));
+    }
+
+    public static ValidatorType FromDelegatee(ValidatorDelegatee validatorDelegatee) =>
+            new ValidatorType
+            {
+                Power = validatorDelegatee.Power,
+                IsActive = validatorDelegatee.IsActive,
+                TotalShares = validatorDelegatee.TotalShares,
+                Jailed = validatorDelegatee.Jailed,
+                JailedUntil = validatorDelegatee.JailedUntil,
+                Tombstoned = validatorDelegatee.Tombstoned,
+                TotalDelegated = validatorDelegatee.TotalDelegated,
+                CommissionPercentage = validatorDelegatee.CommissionPercentage,
+            };
+}


### PR DESCRIPTION
### Feature

You can use the query below to see the delegation information for a Validator.

query
```GraphQL
query {
  stateQuery {
    validator(validatorAddress: <address>) {
      power
      isActive
      totalShares
      jailed
      jailedUntil
      tombstoned
      commissionPercentage
      totalDelegated {
        currency
        quantity
      }
    }
  }
}
```

result
```json
{
  "data": {
    "stateQuery": {
      "validator": {
        "power": "1,000,000,000,000,000,000,000",
        "isActive": false,
        "totalShares": "1,000,000,000,000,000,000,000",
        "jailed": false,
        "jailedUntil": -1,
        "tombstoned": false,
        "commissionPercentage": "10",
        "totalDelegated": {
          "currency": "GUILD_GOLD",
          "quantity": "1000.000000000000000000"
        }
      }
    }
  }
}
```