### PR TITLE
Add rate-limit to transactionresults query

### DIFF
--- a/NineChronicles.Headless.Executable/appsettings.json
+++ b/NineChronicles.Headless.Executable/appsettings.json
@@ -109,6 +109,11 @@
                 "Endpoint": "*:/graphql/stagetransaction",
                 "Period": "60s",
                 "Limit": 12
+            },
+            {
+                "Endpoint": "*:/graphql/transactionresults",
+                "Period": "60s",
+                "Limit": 60
             }
         ],
         "QuotaExceededResponse": {
@@ -117,6 +122,7 @@
             "StatusCode": 429
         },
         "IpBanThresholdCount": 5,
+        "TransactionResultsBanThresholdCount": 100,
         "IpBanMinute" : 60,
         "IpBanResponse": {
             "Content": "{ \"message\": \"Your Ip has been banned.\" }",

--- a/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/HttpCaptureMiddleware.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Serilog;
 using ILogger = Serilog.ILogger;
+using Microsoft.Extensions.Configuration;
 
 namespace NineChronicles.Headless.Middleware
 {
@@ -10,20 +11,31 @@ namespace NineChronicles.Headless.Middleware
     {
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
+        private readonly bool _enableIpRateLimiting;
 
-        public HttpCaptureMiddleware(RequestDelegate next)
+        public HttpCaptureMiddleware(RequestDelegate next, Microsoft.Extensions.Configuration.IConfiguration configuration)
         {
             _next = next;
             _logger = Log.Logger.ForContext<HttpCaptureMiddleware>();
+            _enableIpRateLimiting = configuration.GetValue<bool>("IpRateLimiting:EnableEndpointRateLimiting");
         }
 
         public async Task InvokeAsync(HttpContext context)
         {
+            var remoteIp = context.Connection.RemoteIpAddress!.ToString();
+
+            // Conditionally skip IP banning if endpoint rate-limiting is disabled
+            if (_enableIpRateLimiting && IpBanMiddleware.IsIpBanned(remoteIp))
+            {
+                _logger.Information($"[GRAPHQL-REQUEST-CAPTURE] Skipping logging for banned IP: {remoteIp}");
+                await _next(context);
+                return;
+            }
+
             // Prevent to harm HTTP/2 communication.
             if (context.Request.Protocol == "HTTP/1.1")
             {
                 context.Request.EnableBuffering();
-                var remoteIp = context.Connection.RemoteIpAddress;
                 var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
                 context.Items["RequestBody"] = body;
                 _logger.Information("[GRAPHQL-REQUEST-CAPTURE] IP: {IP} Method: {Method} Endpoint: {Path} {Body}",

--- a/NineChronicles.Headless/Middleware/IpBanMiddleware.cs
+++ b/NineChronicles.Headless/Middleware/IpBanMiddleware.cs
@@ -39,6 +39,16 @@ namespace NineChronicles.Headless.Middleware
             }
         }
 
+        public static bool IsIpBanned(string ip)
+        {
+            if (_bannedIps.ContainsKey(ip))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         public Task InvokeAsync(HttpContext context)
         {
             var remoteIp = context.Connection.RemoteIpAddress!.ToString();


### PR DESCRIPTION
This PR addresses an issue where the transactionResults query currently does not limit the number of txids passed down. To mitigate potential abuse, this PR introduces a rate-limit specifically targeting abusive users before implementing a parameter-based limit in the query.