### PR TITLE
Remove moreal from auto_assign reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -4,4 +4,3 @@ addAssignees: author
 reviewers:
     - ipdae
     - area363
-    - moreal


### PR DESCRIPTION
I stepped down from maintainer by leaving the company so I remove myself from auto_assign reviewers list.