### PR TITLE
Add state and action queries for guild system and delegation

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/DelegatorTypeTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/DelegatorTypeTest.cs
@@ -1,14 +1,10 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Numerics;
 using System.Threading.Tasks;
 using GraphQL.Execution;
 using Lib9c;
-using Libplanet.Types.Tx;
-using Nekoyume.ValidatorDelegation;
 using NineChronicles.Headless.GraphTypes;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NineChronicles.Headless.Tests.GraphTypes
 {

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -13,6 +13,8 @@ using Nekoyume.TableData;
 using Nekoyume.Action.ValidatorDelegation;
 using Nekoyume.Action.Guild.Migration;
 using Lib9c;
+using Nekoyume.Action.Guild;
+using Nekoyume.TypedAddress;
 
 namespace NineChronicles.Headless.GraphTypes
 {
@@ -573,6 +575,100 @@ namespace NineChronicles.Headless.GraphTypes
                 resolve: context => Encode(
                     context,
                     new MigrateDelegationHeight(context.GetArgument<long>("amount"))));
+
+            Field<ByteStringType>(
+                name: "makeGuild",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "validatorAddress",
+                        Description = "The validator address to create a guild."
+                    }),
+                resolve: context =>
+                {
+                    var validatorAddress = context.GetArgument<Address>("validatorAddress");
+                    return Encode(context, new MakeGuild(validatorAddress));
+                });
+
+            Field<ByteStringType>(
+                name: "removeGuild",
+                resolve: context => Encode(context, new RemoveGuild()));
+
+            Field<ByteStringType>(
+                name: "joinGuild",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "guildAddress",
+                        Description = "The guild address to join."
+                    }),
+                resolve: context =>
+                {
+                    var address = context.GetArgument<Address>("guildAddress");
+                    var guildAddress = new GuildAddress(address);
+                    return Encode(context, new JoinGuild(guildAddress));
+                });
+
+            Field<ByteStringType>(
+                name: "quitGuild",
+                resolve: context => Encode(context, new QuitGuild()));
+
+            Field<ByteStringType>(
+                name: "moveGuild",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "guildAddress",
+                        Description = "The guild address to move."
+                    }),
+                resolve: context =>
+                {
+                    var address = context.GetArgument<Address>("guildAddress");
+                    var guildAddress = new GuildAddress(address);
+                    return Encode(context, new MoveGuild(guildAddress));
+                });
+
+            Field<ByteStringType>(
+                name: "banGuildMember",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "agentAddress",
+                        Description = "The agent address to ban."
+                    }),
+                resolve: context =>
+                {
+                    var address = context.GetArgument<Address>("agentAddress");
+                    var agentAddress = new AgentAddress(address);
+                    return Encode(context, new BanGuildMember(agentAddress));
+                });
+
+            Field<ByteStringType>(
+                name: "unbanGuildMember",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "agentAddress",
+                        Description = "The agent address to unban."
+                    }),
+                resolve: context =>
+                {
+                    var address = context.GetArgument<Address>("agentAddress");
+                    var agentAddress = new AgentAddress(address);
+                    return Encode(context, new UnbanGuildMember(agentAddress));
+                });
+
+            Field<ByteStringType>(
+                name: "claimReward",
+                resolve: context => Encode(context, new ClaimReward()));
+
+            Field<ByteStringType>(
+                name: "claimGuildReward",
+                resolve: context => Encode(context, new ClaimGuildReward()));
+
+            Field<ByteStringType>(
+                name: "claimUnbonded",
+                resolve: context => Encode(context, new ClaimUnbonded()));
 
             RegisterHackAndSlash();
             RegisterHackAndSlashSweep();

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -15,6 +15,7 @@ using Nekoyume.Action.Guild.Migration;
 using Lib9c;
 using Nekoyume.Action.Guild;
 using Nekoyume.TypedAddress;
+using System.Globalization;
 
 namespace NineChronicles.Headless.GraphTypes
 {
@@ -569,6 +570,42 @@ namespace NineChronicles.Headless.GraphTypes
                         new PromoteValidator(
                             publicKey,
                             currency));
+                });
+
+            Field<ByteStringType>(
+                name: "unjailValidator",
+                resolve: context => Encode(context, new UnjailValidator()));
+
+            Field<ByteStringType>(
+                name: "delegateValidator",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Description = "A string value of guild gold to delegate.",
+                        Name = "amount",
+                    }),
+                resolve: context =>
+                {
+                    var fav = FungibleAssetValue.Parse(
+                        currency: Currencies.GuildGold,
+                        value: context.GetArgument<string>("amount"));
+                    return Encode(context, new DelegateValidator(fav));
+                });
+
+            Field<ByteStringType>(
+                name: "undelegateValidator",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Description = "A string value of share to undelegate.",
+                        Name = "share",
+                    }),
+                resolve: context =>
+                {
+                    var share = BigInteger.Parse(
+                        value: context.GetArgument<string>("share"),
+                        style: NumberStyles.Number);
+                    return Encode(context, new UndelegateValidator(share));
                 });
 
             Field<ByteStringType>(

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -35,14 +35,20 @@ namespace NineChronicles.Headless.GraphTypes
                         Name = "amount",
                         Description = "An amount to stake.",
                     },
-                    new QueryArgument<NonNullGraphType<AddressType>>
+                    new QueryArgument<AddressType>
                     {
                         Name = "avatarAddress",
                         Description = "Address of avatar.",
                     }),
-                resolve: context => Encode(
-                    context,
-                    new Stake(context.GetArgument<BigInteger>("amount"), context.GetArgument<Address>("avatarAddress"))));
+                resolve: context =>
+                {
+                    var amount = context.GetArgument<BigInteger>("amount");
+                    var avatarAddress = context.GetArgument<Address?>("avatarAddress");
+                    var stake = avatarAddress is not null
+                        ? new Stake(amount, avatarAddress.Value)
+                        : new Stake(amount);
+                    return Encode(context, stake);
+                });
 
             Field<ByteStringType>(
                 name: "claimStakeReward",

--- a/NineChronicles.Headless/GraphTypes/DelegateeRepositoryType.cs
+++ b/NineChronicles.Headless/GraphTypes/DelegateeRepositoryType.cs
@@ -1,0 +1,22 @@
+using GraphQL.Types;
+
+namespace NineChronicles.Headless.GraphTypes;
+
+public class DelegateeRepositoryType : ObjectGraphType<DelegateeRepositoryType>
+{
+    public DelegateeType? GuildDelegatee { get; set; }
+
+    public DelegateeType? ValidatorDelegatee { get; set; }
+
+    public DelegateeRepositoryType()
+    {
+        Field<NonNullGraphType<DelegateeType>>(
+            nameof(GuildDelegatee),
+            description: "Delegatee of the guild repository",
+            resolve: context => context.Source.GuildDelegatee);
+        Field<NonNullGraphType<DelegateeType>>(
+            nameof(ValidatorDelegatee),
+            description: "Delegatee of the validator repository",
+            resolve: context => context.Source.ValidatorDelegatee);
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/DelegateeType.cs
+++ b/NineChronicles.Headless/GraphTypes/DelegateeType.cs
@@ -1,0 +1,75 @@
+using System.Numerics;
+using GraphQL.Types;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using Nekoyume.Model.Guild;
+using Nekoyume.ValidatorDelegation;
+
+namespace NineChronicles.Headless.GraphTypes;
+
+public class DelegateeType : ObjectGraphType<DelegateeType>
+{
+    public BigInteger TotalShares { get; set; }
+
+    public bool Jailed { get; set; }
+
+    public long JailedUntil { get; set; }
+
+    public bool Tombstoned { get; set; }
+
+    public FungibleAssetValue TotalDelegated { get; set; }
+
+    public BigInteger CommissionPercentage { get; set; }
+
+    public DelegateeType()
+    {
+        Field<NonNullGraphType<StringGraphType>>(
+            nameof(TotalShares),
+            description: "Total shares of delegatee",
+            resolve: context => context.Source.TotalShares.ToString("N0"));
+        Field<NonNullGraphType<BooleanGraphType>>(
+            nameof(Jailed),
+            description: "Specifies whether the delegatee is jailed.",
+            resolve: context => context.Source.Jailed);
+        Field<NonNullGraphType<LongGraphType>>(
+            nameof(JailedUntil),
+            description: "Block height until which the delegatee is jailed.",
+            resolve: context => context.Source.JailedUntil);
+        Field<NonNullGraphType<BooleanGraphType>>(
+            nameof(Tombstoned),
+            description: "Specifies whether the delegatee is tombstoned.",
+            resolve: context => context.Source.Tombstoned);
+        Field<NonNullGraphType<FungibleAssetValueType>>(
+            nameof(TotalDelegated),
+            description: "Total delegated amount of the delegatee.",
+            resolve: context => context.Source.TotalDelegated);
+    }
+
+    public static DelegateeType From(GuildRepository guildRepository, Address validatorAddress)
+    {
+        var delegatee = guildRepository.GetDelegatee(validatorAddress);
+
+        return new DelegateeType
+        {
+            TotalShares = delegatee.TotalShares,
+            Jailed = delegatee.Jailed,
+            JailedUntil = delegatee.JailedUntil,
+            Tombstoned = delegatee.Tombstoned,
+            TotalDelegated = delegatee.TotalDelegated,
+        };
+    }
+
+    public static DelegateeType From(ValidatorRepository validatorRepository, Address validatorAddress)
+    {
+        var delegatee = validatorRepository.GetDelegatee(validatorAddress);
+
+        return new DelegateeType
+        {
+            TotalShares = delegatee.TotalShares,
+            Jailed = delegatee.Jailed,
+            JailedUntil = delegatee.JailedUntil,
+            Tombstoned = delegatee.Tombstoned,
+            TotalDelegated = delegatee.TotalDelegated,
+        };
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/DelegatorRepositoryType.cs
+++ b/NineChronicles.Headless/GraphTypes/DelegatorRepositoryType.cs
@@ -1,0 +1,50 @@
+using GraphQL.Types;
+using Libplanet.Crypto;
+using Nekoyume.Model.Guild;
+using Nekoyume.ValidatorDelegation;
+
+namespace NineChronicles.Headless.GraphTypes;
+
+public class DelegatorRepositoryType : ObjectGraphType<DelegatorRepositoryType>
+{
+    public DelegatorType? GuildDelegator { get; set; }
+
+    public DelegatorType? ValidatorDelegator { get; set; }
+
+    public DelegatorRepositoryType()
+    {
+        Field<DelegatorType>(
+            nameof(GuildDelegator),
+            description: "Delegator of the guild repository",
+            resolve: context => context.Source.GuildDelegator);
+        Field<DelegatorType>(
+            nameof(ValidatorDelegator),
+            description: "Delegator of the validator repository",
+            resolve: context => context.Source.ValidatorDelegator);
+    }
+
+    public static DelegatorRepositoryType From(GuildRepository guildRepository, GuildParticipant guildParticipant)
+    {
+        var validatorRepository = new ValidatorRepository(
+            guildRepository.World, guildRepository.ActionContext);
+        var guild = guildRepository.GetGuild(guildParticipant.GuildAddress);
+
+        return new DelegatorRepositoryType
+        {
+            GuildDelegator = DelegatorType.From(guildRepository, guildParticipant),
+            ValidatorDelegator = DelegatorType.From(validatorRepository, guild),
+        };
+    }
+
+    public static DelegatorRepositoryType From(ValidatorRepository validatorRepository, Address validatorAddress)
+    {
+        var guildRepository = new GuildRepository(
+            validatorRepository.World, validatorRepository.ActionContext);
+
+        return new DelegatorRepositoryType
+        {
+            GuildDelegator = DelegatorType.From(guildRepository, validatorAddress),
+            ValidatorDelegator = DelegatorType.From(validatorRepository, validatorAddress),
+        };
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/DelegatorType.cs
+++ b/NineChronicles.Headless/GraphTypes/DelegatorType.cs
@@ -1,6 +1,9 @@
 using System.Numerics;
 using GraphQL.Types;
+using Libplanet.Crypto;
 using Libplanet.Types.Assets;
+using Nekoyume.Model.Guild;
+using Nekoyume.ValidatorDelegation;
 
 namespace NineChronicles.Headless.GraphTypes;
 
@@ -26,5 +29,78 @@ public class DelegatorType : ObjectGraphType<DelegatorType>
             nameof(Fav),
             description: "Delegated FAV calculated based on Share value",
             resolve: context => context.Source.Fav);
+    }
+
+    public static DelegatorType From(GuildRepository guildRepository, GuildParticipant guildParticipant)
+    {
+        var guild = guildRepository.GetGuild(guildParticipant.GuildAddress);
+        var delegatee = guildRepository.GetDelegatee(guild.ValidatorAddress);
+        var bond = guildRepository.GetBond(delegatee, guildParticipant.Address);
+        var totalFAV = delegatee.Metadata.TotalDelegatedFAV;
+        var totalShare = delegatee.Metadata.TotalShares;
+        var lastDistributeHeight = bond.LastDistributeHeight ?? -1;
+        var share = bond.Share;
+        var fav = (share * totalFAV).DivRem(totalShare).Quotient;
+
+        return new DelegatorType
+        {
+            LastDistributeHeight = lastDistributeHeight,
+            Share = share,
+            Fav = fav,
+        };
+    }
+
+    public static DelegatorType From(ValidatorRepository validatorRepository, Guild guild)
+    {
+        var delegatee = validatorRepository.GetDelegatee(guild.ValidatorAddress);
+        var bond = validatorRepository.GetBond(delegatee, guild.Address);
+        var totalFAV = delegatee.Metadata.TotalDelegatedFAV;
+        var totalShare = delegatee.Metadata.TotalShares;
+        var lastDistributeHeight = bond.LastDistributeHeight ?? -1;
+        var share = bond.Share;
+        var fav = (share * totalFAV).DivRem(totalShare).Quotient;
+
+        return new DelegatorType
+        {
+            LastDistributeHeight = lastDistributeHeight,
+            Share = share,
+            Fav = fav,
+        };
+    }
+
+    public static DelegatorType From(GuildRepository guildRepository, Address validatorAddress)
+    {
+        var delegatee = guildRepository.GetDelegatee(validatorAddress);
+        var bond = guildRepository.GetBond(delegatee, validatorAddress);
+        var totalFAV = delegatee.Metadata.TotalDelegatedFAV;
+        var totalShare = delegatee.Metadata.TotalShares;
+        var lastDistributeHeight = bond.LastDistributeHeight ?? -1;
+        var share = bond.Share;
+        var fav = (share * totalFAV).DivRem(totalShare).Quotient;
+
+        return new DelegatorType
+        {
+            LastDistributeHeight = lastDistributeHeight,
+            Share = share,
+            Fav = fav,
+        };
+    }
+
+    public static DelegatorType From(ValidatorRepository validatorRepository, Address validatorAddress)
+    {
+        var delegatee = validatorRepository.GetDelegatee(validatorAddress);
+        var bond = validatorRepository.GetBond(delegatee, validatorAddress);
+        var totalFAV = delegatee.Metadata.TotalDelegatedFAV;
+        var totalShare = delegatee.Metadata.TotalShares;
+        var lastDistributeHeight = bond.LastDistributeHeight ?? -1;
+        var share = bond.Share;
+        var fav = (share * totalFAV).DivRem(totalShare).Quotient;
+
+        return new DelegatorType
+        {
+            LastDistributeHeight = lastDistributeHeight,
+            Share = share,
+            Fav = fav,
+        };
     }
 }


### PR DESCRIPTION
### 개요

1. 길드 시스템에 대한 action query 를 추가하였습니다.
2. Delegatee 와 Delegator 상태를 확인할 수 있는 state query 를 추가하였습니다.
3. 밸리데이터는 아바타가 없기 때문에 stake 액션 쿼리를 실행할 수 없는 문제점을 수정하였습니다.
4. 밸리데이터 관련 action query 를 추가하였습니다.

### 길드 관련 액션 쿼리

makeGuild
removeGuild
joinGuild
quitGuild
moveGuild
banGuildMember
unbanGuildMember

### 클레임 관련 액션 쿼리

claimReward
claimGuildReward
claimUnbonded

### 밸리데이터 관련 액션 쿼리

unjailValidator
delegateValidator
undelegateValidator

### 위임정보 확인 스테이트 쿼리

delegatee
delegator