### PR TITLE
Release 241

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/ActionQueryTest.cs
@@ -18,6 +18,7 @@ using Libplanet.Types.Tx;
 using Nekoyume;
 using Nekoyume.Action;
 using Nekoyume.Action.Garages;
+using Nekoyume.Action.Guild.Migration;
 using Nekoyume.Helper;
 using Nekoyume.Model;
 using Nekoyume.Model.EnumType;
@@ -1583,6 +1584,22 @@ actionPoint: {actionPoint},
                     Assert.Equal(i == 0, tradable);
                 }
             }
+        }
+
+        [Fact]
+        public async Task MigrateStakeAndJoinGuild()
+        {
+            var targetAddress = new PrivateKey().Address;
+            var query = $"{{migrateStakeAndJoinGuild(targetAddress: \"{targetAddress}\")}}";
+            var queryResult = await ExecuteQueryAsync<ActionQuery>(query, standaloneContext: _standaloneContext);
+            Assert.Null(queryResult.Errors);
+
+            var data = (Dictionary<string, object>)((ExecutionNode)queryResult.Data!).ToValue()!;
+            var plainValue = _codec.Decode(ByteUtil.ParseHex((string)data["migrateStakeAndJoinGuild"]));
+            Assert.IsType<Dictionary>(plainValue);
+            var polymorphicAction = DeserializeNCAction(plainValue);
+            var action = Assert.IsType<MigrateStakeAndJoinGuild>(polymorphicAction);
+            Assert.Equal(targetAddress, action.Target);
         }
     }
 }

--- a/NineChronicles.Headless/GraphTypes/ActionQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/ActionQuery.cs
@@ -713,6 +713,21 @@ namespace NineChronicles.Headless.GraphTypes
                 name: "claimUnbonded",
                 resolve: context => Encode(context, new ClaimUnbonded()));
 
+            Field<ByteStringType>(
+                name: "migrateStakeAndJoinGuild",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "targetAddress",
+                        Description = "The agent address to migrate."
+                    }),
+                resolve: context =>
+                {
+                    var targetAddress = context.GetArgument<Address>("targetAddress");
+                    var agentAddress = new AgentAddress(targetAddress);
+                    return Encode(context, new MigrateStakeAndJoinGuild(agentAddress));
+                });
+
             RegisterHackAndSlash();
             RegisterHackAndSlashSweep();
             RegisterDailyReward();


### PR DESCRIPTION
Hotfix
- Lib9c 1.22.0 -> 1.22.1
- 제거되었던 길드 / 위임 관련 마이그레이션 액션을 다시 되돌림
- 마이그레이션되지 않은 유저가 확인되었기 때문