### PR TITLE
Add BlockChainService.GetSheetHashes

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -13,6 +13,7 @@ on:
       - release/*
       # This branch is for testing only. Use until the next(v200080) release.
       - test/action-evaluation-publisher-elapse-metric
+      - feat/get-sheet-hashes
     tags:
       - "*"
   workflow_dispatch:

--- a/NineChronicles.Headless.Tests/MemoryCacheExtensionsTest.cs
+++ b/NineChronicles.Headless.Tests/MemoryCacheExtensionsTest.cs
@@ -30,7 +30,7 @@ public class MemoryCacheExtensionsTest
         var csv = sheets[tableName];
         var cacheKey = Addresses.GetSheetAddress(tableName).ToString();
         var value = (Text)csv;
-        var compressed = MessagePackSerializer.Serialize(codec.Encode(value), lz4Options);
+        var compressed = MemoryCacheExtensions.NormalizedBytes(csv);
         cache.SetSheet(cacheKey, value, TimeSpan.FromMilliseconds(100));
         Assert.True(cache.TryGetValue(cacheKey, out byte[] cached));
         Assert.Equal(compressed, cached);

--- a/NineChronicles.Headless.Tests/MemoryCacheExtensionsTest.cs
+++ b/NineChronicles.Headless.Tests/MemoryCacheExtensionsTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Bencodex;
 using Bencodex.Types;
@@ -35,5 +37,18 @@ public class MemoryCacheExtensionsTest
         Assert.Equal(csv, cache.GetSheet(cacheKey));
         await Task.Delay(100);
         Assert.False(cache.TryGetValue(cacheKey, out byte[] _));
+    }
+
+    [Fact]
+    public void NormalizedBytes()
+    {
+        var csv = "a,b,c\n1,2,3\n4,5,6\n";
+        var csv2 = "a,b,c\r\n1,2,3\r\n4,5,6\r\n   ";
+        var expectedString = "a,b,c\n1,2,3\n4,5,6";
+        var expectedBytes = Encoding.UTF8.GetBytes(expectedString);
+        Assert.Equal(expectedString, Encoding.UTF8.GetString(MemoryCacheExtensions.NormalizedBytes(csv)));
+        Assert.Equal(expectedString, Encoding.UTF8.GetString(MemoryCacheExtensions.NormalizedBytes(csv2)));
+        Assert.Equal(expectedBytes, MemoryCacheExtensions.NormalizedBytes(csv));
+        Assert.Equal(expectedBytes, MemoryCacheExtensions.NormalizedBytes(csv2));
     }
 }

--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -626,8 +626,16 @@ namespace NineChronicles.Headless
                 {
                     var address = addresses[i];
                     var value = values[i] ?? Null.Value;
-                    var compressed = _memoryCache.SetSheet(address.ToString(), value, TimeSpan.FromMinutes(1));
-                    result.TryAdd(address.ToByteArray(), compressed);
+                    if (value is Text text)
+                    {
+                        var compressed = _memoryCache.SetSheet(address.ToString(), text.Value, TimeSpan.FromMinutes(1));
+                        result.TryAdd(address.ToByteArray(), compressed);
+                    }
+                    else
+                    {
+                        var compressed = CompressState(_codec, value);
+                        result.TryAdd(address.ToByteArray(), compressed);
+                    }
                 }
             }
             Log.Information("[{FName}]Total: {Elapsed}", fName, DateTime.UtcNow - started);

--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -270,42 +270,26 @@ namespace NineChronicles.Headless
             byte[] stateRootHashBytes,
             IEnumerable<byte[]> addressBytesList)
         {
-            var started = DateTime.UtcNow;
+            return new UnaryResult<Dictionary<byte[], byte[]>>(GetSheetsInternal("GetSheets", stateRootHashBytes, addressBytesList));
+        }
+
+        public UnaryResult<Dictionary<byte[], byte[]>> GetSheetHashes(
+            byte[] stateRootHashBytes,
+            IEnumerable<byte[]> addressBytesList)
+        {
+            var sheets = GetSheetsInternal("GetSheetHashes", stateRootHashBytes, addressBytesList);
+            Log.Information("[GetSheetHashes]Total: Start hashing");
             var sw = new Stopwatch();
             sw.Start();
             var result = new Dictionary<byte[], byte[]>();
-            List<Address> addresses = new List<Address>();
-            foreach (var b in addressBytesList)
+            foreach (var kv in sheets)
             {
-                var address = new Address(b);
-                if (_memoryCache.TryGetSheet(address.ToString(), out byte[] cached))
-                {
-                    result.TryAdd(b, cached);
-                }
-                else
-                {
-                    addresses.Add(address);
-                }
+                using var sha256 = SHA256.Create();
+                var hash = sha256.ComputeHash(kv.Value);
+                result.TryAdd(kv.Key, hash);
             }
             sw.Stop();
-            Log.Information("[GetSheets]Get sheet from cache count: {CachedCount}, not Cached: {CacheMissedCount}, Elapsed: {Elapsed}", result.Count, addresses.Count, sw.Elapsed);
-            sw.Restart();
-            if (addresses.Any())
-            {
-                var stateRootHash = new HashDigest<SHA256>(stateRootHashBytes);
-                IReadOnlyList<IValue> values = _worldStateRepository.GetWorldState(stateRootHash).GetLegacyStates(addresses);
-                sw.Stop();
-                Log.Information("[GetSheets]Get sheet from state: {Count}, Elapsed: {Elapsed}", addresses.Count, sw.Elapsed);
-                sw.Restart();
-                for (int i = 0; i < addresses.Count; i++)
-                {
-                    var address = addresses[i];
-                    var value = values[i] ?? Null.Value;
-                    var compressed = _memoryCache.SetSheet(address.ToString(), value, TimeSpan.FromMinutes(1));
-                    result.TryAdd(address.ToByteArray(), compressed);
-                }
-            }
-            Log.Information("[GetSheets]Total: {Elapsed}", DateTime.UtcNow - started);
+            Log.Information("[GetSheetHashes]Hashing count: {CachedCount}, Elapsed: {Elapsed}", result.Count, sw.Elapsed);
             return new UnaryResult<Dictionary<byte[], byte[]>>(result);
         }
 
@@ -604,6 +588,50 @@ namespace NineChronicles.Headless
                 serializedInventoryRaw!,
                 serializedQuestListRaw!,
                 serializedWorldInformationRaw!);
+        }
+
+        private Dictionary<byte[], byte[]> GetSheetsInternal(
+            string fName,
+            byte[] stateRootHashBytes,
+            IEnumerable<byte[]> addressBytesList)
+        {
+            var started = DateTime.UtcNow;
+            var sw = new Stopwatch();
+            sw.Start();
+            var result = new Dictionary<byte[], byte[]>();
+            List<Address> addresses = new List<Address>();
+            foreach (var b in addressBytesList)
+            {
+                var address = new Address(b);
+                if (_memoryCache.TryGetSheet(address.ToString(), out byte[] cached))
+                {
+                    result.TryAdd(b, cached);
+                }
+                else
+                {
+                    addresses.Add(address);
+                }
+            }
+            sw.Stop();
+            Log.Information("[{FName}]Get sheet from cache count: {CachedCount}, not Cached: {CacheMissedCount}, Elapsed: {Elapsed}", fName, result.Count, addresses.Count, sw.Elapsed);
+            sw.Restart();
+            if (addresses.Any())
+            {
+                var stateRootHash = new HashDigest<SHA256>(stateRootHashBytes);
+                IReadOnlyList<IValue> values = _worldStateRepository.GetWorldState(stateRootHash).GetLegacyStates(addresses);
+                sw.Stop();
+                Log.Information("[{FName}]Get sheet from state: {Count}, Elapsed: {Elapsed}", fName, addresses.Count, sw.Elapsed);
+                sw.Restart();
+                for (int i = 0; i < addresses.Count; i++)
+                {
+                    var address = addresses[i];
+                    var value = values[i] ?? Null.Value;
+                    var compressed = _memoryCache.SetSheet(address.ToString(), value, TimeSpan.FromMinutes(1));
+                    result.TryAdd(address.ToByteArray(), compressed);
+                }
+            }
+            Log.Information("[{FName}]Total: {Elapsed}", fName, DateTime.UtcNow - started);
+            return result;
         }
 
         public static byte[] CompressState(Codec codec, IValue state)

--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -633,7 +633,7 @@ namespace NineChronicles.Headless
                     }
                     else
                     {
-                        var compressed = CompressState(_codec, value);
+                        var compressed = MemoryCacheExtensions.NormalizedBytes(string.Empty);
                         result.TryAdd(address.ToByteArray(), compressed);
                     }
                 }

--- a/NineChronicles.Headless/BlockChainService.cs
+++ b/NineChronicles.Headless/BlockChainService.cs
@@ -273,7 +273,7 @@ namespace NineChronicles.Headless
             return new UnaryResult<Dictionary<byte[], byte[]>>(GetSheetsInternal("GetSheets", stateRootHashBytes, addressBytesList));
         }
 
-        public UnaryResult<Dictionary<byte[], byte[]>> GetSheetHashes(
+        public UnaryResult<Dictionary<byte[], byte[]>> GetSheetsHash(
             byte[] stateRootHashBytes,
             IEnumerable<byte[]> addressBytesList)
         {

--- a/NineChronicles.Headless/MemoryCacheExtensions.cs
+++ b/NineChronicles.Headless/MemoryCacheExtensions.cs
@@ -1,35 +1,50 @@
 using System;
-using Bencodex;
-using Bencodex.Types;
-using MessagePack;
+using System.Text;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace NineChronicles.Headless;
 
 public static class MemoryCacheExtensions
 {
-    private static readonly Codec Codec = new Codec();
-    private static readonly MessagePackSerializerOptions Lz4Options = MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray);
 
-    public static byte[] SetSheet(this MemoryCache cache, string cacheKey, IValue value, TimeSpan ex)
+    public static byte[] SetSheet(this MemoryCache cache, string cacheKey, string value, TimeSpan ex)
     {
-        var compressed = MessagePackSerializer.Serialize(Codec.Encode(value), Lz4Options);
-        cache.Set(cacheKey, compressed, ex);
-        return compressed;
+        var normalized = NormalizedBytes(value);
+        cache.Set(cacheKey, normalized, ex);
+        return normalized;
     }
 
-    public static bool TryGetSheet<T>(this MemoryCache cache, string cacheKey, out T cached)
+    public static bool TryGetSheet<T>(this MemoryCache cache, string cacheKey, out T? result)
     {
-        return cache.TryGetValue(cacheKey, out cached!);
+        if (cache.TryGetValue(cacheKey, out T? cached))
+        {
+            result = cached;
+            return true;
+        }
+
+        result = default!;
+        return false;
     }
 
     public static string? GetSheet(this MemoryCache cache, string cacheKey)
     {
-        if (cache.TryGetSheet(cacheKey, out byte[] cached))
+        if (cache.TryGetSheet(cacheKey, out byte[]? cached))
         {
-            return (Text)Codec.Decode(MessagePackSerializer.Deserialize<byte[]>(cached, Lz4Options));
+            return Encoding.UTF8.GetString(cached!);
         }
 
         return null;
+    }
+
+    public static byte[] NormalizedBytes(string csvText)
+    {
+        // Normalize line endings
+        csvText = csvText.Replace("\r\n", "\n");
+
+        // Remove empty lines at the end
+        csvText = csvText.Trim();
+
+        // Unify encoding (e.g. UTF-8)
+        return Encoding.UTF8.GetBytes(csvText);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/planetarium/NineChronicles.RPC.Shared/issues/39, https://github.com/planetarium/NineChronicles/issues/6901

- RPC interace 업데이트
- 시트캐시에서 해싱값 비교를 위해 Normailze 처리를 추가하고 캐싱하는 값을 해당 데이터로 변경