### PR TITLE
Introduce `blockStartingTxNoncesQuery`

### DIFF
--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -823,7 +823,7 @@ namespace NineChronicles.Headless.Tests.GraphTypes
                 new Dictionary<string, object>
                 {
                     ["signer"] = sender.ToString(),
-                    ["nonce"] = 4L  // 5 - 1
+                    ["nonce"] = 5L
                 }
             };
 

--- a/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
+++ b/NineChronicles.Headless.Tests/GraphTypes/StandaloneQueryTest.cs
@@ -776,6 +776,60 @@ namespace NineChronicles.Headless.Tests.GraphTypes
             Assert.Equal(0 * CrystalCalculator.CRYSTAL, 0 * currency);
         }
 
+        [Fact]
+        public async Task BlockStartingTxNonces()
+        {
+            PrivateKey senderKey = new PrivateKey(), recipientKey = new PrivateKey();
+            Address sender = senderKey.Address, recipient = recipientKey.Address;
+
+            var blockHash = BlockHash.FromString("613dfa26e104465790625ae7bc03fc27a64947c02a9377565ec190405ef7154b");
+            Transaction MakeTx(long nonce, ActionBase action)
+            {
+                return Transaction.Create(nonce, senderKey, blockHash, new[] { action.PlainValue });
+            }
+
+            var currency = Currency.Uncapped("NCG", 2, null);
+            var txs = new[]
+            {
+                MakeTx(5, new TransferAsset(sender, recipient, new FungibleAssetValue(currency, 1, 0))),
+                MakeTx(6, new TransferAsset(sender, recipient, new FungibleAssetValue(currency, 1, 0))),
+                MakeTx(7, new TransferAsset(sender, recipient, new FungibleAssetValue(currency, 1, 0))),
+            };
+            var block = new Domain.Model.BlockChain.Block(
+                blockHash,
+                BlockHash.FromString("36456be15af9a5b9b13a02c7ce1e849ae9cba8781ec309010499cdb93e29237d"),
+                default(Address),
+                0,
+                Timestamp: DateTimeOffset.UtcNow,
+                StateRootHash: MerkleTrie.EmptyRootHash,
+                Transactions: txs.ToImmutableArray()
+            );
+
+            BlockChainRepository.Setup(repo => repo.GetBlock(blockHash))
+                .Returns(block);
+
+            var blockHashHex = ByteUtil.Hex(block.Hash.ToByteArray());
+            var result = await ExecuteQueryAsync(
+                $"{{ blockStartingTxNoncesQuery(hash: \"{blockHashHex}\") {{ signer nonce }} }}");
+
+            Assert.Null(result.Errors);
+            var data = (Dictionary<string, object>)((ExecutionNode)result.Data!).ToValue()!;
+            var actual = ((IList)data["blockStartingTxNoncesQuery"])
+                .Cast<Dictionary<string, object>>()
+                .ToList();
+
+            var expected = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object>
+                {
+                    ["signer"] = sender.ToString(),
+                    ["nonce"] = 4L  // 5 - 1
+                }
+            };
+
+            Assert.Equal(expected, actual);
+        }
+
         private NineChroniclesNodeService MakeNineChroniclesNodeService(PrivateKey privateKey)
         {
 #pragma warning disable CS0618

--- a/NineChronicles.Headless/GraphTypes/BlockStartingTxNoncesType.cs
+++ b/NineChronicles.Headless/GraphTypes/BlockStartingTxNoncesType.cs
@@ -16,7 +16,7 @@ namespace NineChronicles.Headless.GraphTypes
 
             Field<NonNullGraphType<LongGraphType>>(
                 name: "nonce",
-                description: "The nonce of the transaction.",
+                description: "The starting nonce before the block executes.",
                 resolve: context => context.Source.Nonce
             );
         }

--- a/NineChronicles.Headless/GraphTypes/BlockStartingTxNoncesType.cs
+++ b/NineChronicles.Headless/GraphTypes/BlockStartingTxNoncesType.cs
@@ -1,0 +1,24 @@
+using GraphQL.Types;
+using Libplanet.Crypto;
+using Libplanet.Explorer.GraphTypes;
+
+namespace NineChronicles.Headless.GraphTypes
+{
+    public class BlockStartingTxNoncesType : ObjectGraphType<(Address Signer, long Nonce)>
+    {
+        public BlockStartingTxNoncesType()
+        {
+            Field<NonNullGraphType<AddressType>>(
+                name: "signer",
+                description: "The address of the transaction signer.",
+                resolve: context => context.Source.Signer
+            );
+
+            Field<NonNullGraphType<LongGraphType>>(
+                name: "nonce",
+                description: "The nonce of the transaction.",
+                resolve: context => context.Source.Nonce
+            );
+        }
+    }
+}

--- a/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
+++ b/NineChronicles.Headless/GraphTypes/StandaloneQuery.cs
@@ -611,7 +611,8 @@ namespace NineChronicles.Headless.GraphTypes
                         .GroupBy(tx => tx.Signer)
                         .Select(group => (
                             Signer: group.Key,
-                            Nonce: group.Min(tx => tx.Nonce) - 1))
+                            Nonce: group.Min(tx => tx.Nonce)))
+                        .OrderBy(x => x.Signer)
                         .ToArray();
                 });
         }


### PR DESCRIPTION
특정 블록 실행 전의 논스값들을 가져올 수 있는 쿼리를 추가합니다.
- Arguments로서는 블록의 hash 혹은 index 둘 중의 하나를 받아,
  - 해당 블록이 실행되기 이전의 해당 블록에 포함된 트랜잭션 서명자들에 대한 논스값을 리턴하며,
  - 만약 hash와 index 양 쪽 모두 기입하지 않을 경우, tip에 대하여 위의 논스값들을 리턴합니다.